### PR TITLE
LayoutEditor: Use a contextual AppBar for selecting the default layer

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -26,6 +26,7 @@ import "@chrysalis-api/colormap";
 import AppBar from "@material-ui/core/AppBar";
 import Button from "@material-ui/core/Button";
 import ChatIcon from "@material-ui/icons/Chat";
+import CloseIcon from "@material-ui/icons/Close";
 import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import Divider from "@material-ui/core/Divider";
@@ -102,6 +103,7 @@ class App extends React.Component {
       connected: false,
       device: null,
       pages: {},
+      contextual: false,
       Page: KeyboardSelect
     };
   }
@@ -226,9 +228,15 @@ class App extends React.Component {
     this.setState({ Page: page });
   };
 
+  toggleContextual = () => {
+    this.setState(state => ({
+      contextual: !state.contextual
+    }));
+  };
+
   render() {
     const { classes } = this.props;
-    const { connected, pages, Page } = this.state;
+    const { connected, pages, Page, contextual } = this.state;
 
     let focus = new Focus(),
       device =
@@ -400,14 +408,18 @@ class App extends React.Component {
     return (
       <div className={classes.root}>
         <CssBaseline />
-        <AppBar position="static" color="inherit" id="appbar">
+        <AppBar
+          position="static"
+          color={contextual ? "primary" : "inherit"}
+          id="appbar"
+        >
           <Toolbar variant="dense">
             <Button
               className={classes.menuButton}
               color="inherit"
-              onClick={this.pageMenu}
+              onClick={contextual ? this.toggleContextual : this.pageMenu}
             >
-              <MenuIcon />
+              {contextual ? <CloseIcon /> : <MenuIcon />}
               <Typography
                 variant="h6"
                 color="inherit"
@@ -429,6 +441,8 @@ class App extends React.Component {
             onDisconnect={this.onKeyboardDisconnect}
             openPage={this.openPage}
             toggleFlashing={this.toggleFlashing}
+            toggleContextual={this.toggleContextual}
+            contextual={contextual}
           />
         </main>
         <Drawer open={this.state.pageMenu} onClose={this.closePageMenu}>


### PR DESCRIPTION
Instead of a dropdown on the right side of the toolbar, offer an Edit button in the same position, which switches the AppBar into a contextual mode. In this mode, the page menu becomes a Close/Cancel button, the Edit becomes Save, and selecting a layer will select it as the new default (not saved until Save is pressed).

Fixes #108.

![screenshot from 2019-01-07 00-35-10](https://user-images.githubusercontent.com/17243/50743179-f88ac280-1214-11e9-8243-c3d5eb5b9073.png)
![screenshot from 2019-01-07 00-35-34](https://user-images.githubusercontent.com/17243/50743181-ffb1d080-1214-11e9-950c-871849a3a220.png)
