### PR TITLE
ColormapEditor: When clicking on a key, select the palette color

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -77,6 +77,7 @@ class ColormapEditor extends React.Component {
   };
 
   onColorSelect = colorIndex => {
+    if (colorIndex == this.state.selectedPaletteColor) colorIndex = -1;
     this.setState({ selectedPaletteColor: colorIndex });
   };
 
@@ -105,6 +106,10 @@ class ColormapEditor extends React.Component {
         return colormap;
       });
       this.setState({ modified: true });
+    } else {
+      this.setState({
+        selectedPaletteColor: this.state.colorMap[layer][ledIndex]
+      });
     }
   };
 
@@ -167,6 +172,7 @@ class ColormapEditor extends React.Component {
           palette={this.state.palette}
           onColorSelect={this.onColorSelect}
           onColorPick={this.onColorPick}
+          selected={this.state.selectedPaletteColor}
         />
         <SaveChangesButton
           floating

--- a/src/renderer/screens/ColormapEditor/Palette.js
+++ b/src/renderer/screens/ColormapEditor/Palette.js
@@ -44,18 +44,8 @@ const styles = theme => ({
 });
 
 class Palette extends React.Component {
-  state = {
-    selectedColor: -1
-  };
-
-  onColorSelect = colorIndex => {
-    if (colorIndex == this.state.selectedColor) colorIndex = -1;
-    this.setState({ selectedColor: colorIndex });
-    this.props.onColorSelect(colorIndex);
-  };
-
   onColorPick = ({ rgb: { r, g, b } }) => {
-    this.props.onColorPick(this.state.selectedColor, r, g, b);
+    this.props.onColorPick(this.props.selected, r, g, b);
   };
 
   render() {
@@ -68,11 +58,11 @@ class Palette extends React.Component {
       const itemKey = "palette-index-" + index.toString();
       return (
         <ColorBox
-          selected={index == this.state.selectedColor}
+          selected={index == this.props.selected}
           key={itemKey}
           color={color}
           colorIndex={index}
-          onColorSelect={this.onColorSelect}
+          onColorSelect={this.props.onColorSelect}
         />
       );
     });
@@ -80,17 +70,17 @@ class Palette extends React.Component {
       const itemKey = "palette-index-" + (index + 8).toString();
       return (
         <ColorBox
-          selected={index + 8 == this.state.selectedColor}
+          selected={index + 8 == this.props.selected}
           key={itemKey}
           color={color}
           colorIndex={index + 8}
-          onColorSelect={this.onColorSelect}
+          onColorSelect={this.props.onColorSelect}
         />
       );
     });
 
-    const color = this.props.palette[this.state.selectedColor];
-    const picker = this.state.selectedColor != -1 && (
+    const color = this.props.palette[this.props.selected];
+    const picker = this.props.selected != -1 && (
       <MaterialPicker color={color} onChangeComplete={this.onColorPick} />
     );
 


### PR DESCRIPTION
When clicking on a key with no palette color selected, select the color of said key.

Fixes #161.
