### PR TITLE
Localize a few more texts

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -244,7 +244,7 @@ class App extends React.Component {
       device.urls.map(({ name, url }) => {
         return (
           <MenuItem key={name} onClick={this.openURL(url)}>
-            {name}
+            {i18n.app.deviceMenu[name] || name}
           </MenuItem>
         );
       });

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -40,6 +40,11 @@ const English = {
       chat: "Real-time chat",
       feedback: "Send feedback",
       exit: "Exit Chrysalis"
+    },
+    deviceMenu: {
+      Homepage: "Homepage",
+      Forum: "Forum",
+      Chat: "Chat"
     }
   },
   layoutEditor: {

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -72,7 +72,7 @@ const English = {
     updatingTitle: "Updating the firmware",
     selected: "Selected firmware",
     custom: "Custom firmware",
-    description: `Updating the firmware is a safe process, it's very hard to brick your keyboard even with bad firmware, as most keyboards provide a way to go stay in bootloader mode, where new firmware can be flashed. Nevertheless, updating the firmware will overwrite the previous one. If you customised your firmware, make sure you're flashing one that you are comfortable with.`,
+    description: `Updating the firmware is a safe process, it's very hard to brick your keyboard even with bad firmware, as most keyboards provide a way to go stay in bootloader mode, where new firmware can be flashed. Nevertheless, updating the firmware will overwrite the previous one. If you customised your firmware, make sure you're flashing one that you are comfortable with. If you wish to proceed, please consult the documentation of your keyboard to see how to enable uploading new firmware, and then press the {0} button to continue.`,
     postUpload: `Once the upload is finished - either successfully or with errors -, you will be taken back to the initial keyboard selection screen. This is normal.`
   },
   welcome: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -40,6 +40,11 @@ const Hungarian = {
       chat: "Csevegőszoba",
       feedback: "Visszajelzés küldése",
       exit: "Kilépés"
+    },
+    deviceMenu: {
+      Homepage: "Honlap",
+      Forum: "Fórum",
+      Chat: "Csevegőszoba"
     }
   },
   layoutEditor: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -72,7 +72,7 @@ const Hungarian = {
     updatingTitle: "Vezérlő frissítés",
     selected: "Kiválasztott vezérlő",
     custom: "Egyedi vezérlő",
-    description: `A vezérlő frissítés egy biztonságos folyamat, nagyon nehéz téglásítani a billentyűzetet, még akkor is, ha hibás vezérlőt töltünk rá. A legtöbb billentyűzettel megoldható, hogy programozható módban maradjon csatlakozáskor, függetlenül attól, milyen vezérlő van rajta. A vezérlő frissítése azzal jár, hogy a meglévő program felülíródik. Ha testre szabta a programját, kérjük győződjön meg róla, hogy amire frissíteni akar, megfelelő.`,
+    description: `A vezérlő frissítés egy biztonságos folyamat, nagyon nehéz téglásítani a billentyűzetet, még akkor is, ha hibás vezérlőt töltünk rá. A legtöbb billentyűzettel megoldható, hogy programozható módban maradjon csatlakozáskor, függetlenül attól, milyen vezérlő van rajta. A vezérlő frissítése azzal jár, hogy a meglévő program felülíródik. Ha testre szabta a programját, kérjük győződjön meg róla, hogy amire frissíteni akar, megfelelő. Amennyiben folytatni kívánja, kérjük olvassa el a billentyűzete dokumentációjának vezérlő frissítésről szóló részét, majd nyomja meg a {0} gombot.`,
     postUpload: `Amint a feltöltés befejeződött - sikeresen, vagy sikertelenül -, visszatérünk a kezdeti billentyűzet választó oldalra. Ez az elvárt működés.`
   },
   welcome: {

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -192,8 +192,10 @@ class FirmwareUpdate extends React.Component {
               {i18n.firmwareUpdate.updatingTitle}
             </Typography>
             <Typography component="p" gutterBottom>
-              {i18n.firmwareUpdate.description}{" "}
-              {this.state.device.messages.preFlash}
+              {i18n.formatString(
+                i18n.firmwareUpdate.description,
+                i18n.firmwareUpdate.flashing.button
+              )}
             </Typography>
             <Typography component="p">
               {i18n.firmwareUpdate.postUpload}


### PR DESCRIPTION
This replaces the hardware-specific text we pulled from the hardware libraries on the FirmwareUpdate screen with a generic one that suggests looking atthe keyboard docs to figure outhow to put it into bootloader mode. It also runs the entries in the device menu through the i18n stuff, so we can translate those too.

![screenshot from 2019-01-08 17-43-22](https://user-images.githubusercontent.com/17243/50845355-ee7bd780-136c-11e9-9dab-0387a4494b34.png)
![screenshot from 2019-01-08 17-43-32](https://user-images.githubusercontent.com/17243/50845364-f176c800-136c-11e9-8470-a68e605dab60.png)
