### PR TITLE
Use transitions for components that appear/disappear

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -18,6 +18,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import Fade from "@material-ui/core/Fade";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Portal from "@material-ui/core/Portal";
 import Tab from "@material-ui/core/Tab";
@@ -140,12 +141,16 @@ class ColormapEditor extends React.Component {
     });
 
     let colormap = (
-      <Layer
-        index={this.state.currentLayer}
-        palette={this.state.palette}
-        colormap={this.state.colorMap[this.state.currentLayer]}
-        onKeySelect={this.onKeySelect}
-      />
+      <Fade in appear key={this.state.currentLayer}>
+        <div className={classes.editor}>
+          <Layer
+            index={this.state.currentLayer}
+            palette={this.state.palette}
+            colormap={this.state.colorMap[this.state.currentLayer]}
+            onKeySelect={this.onKeySelect}
+          />
+        </div>
+      </Fade>
     );
 
     return (
@@ -167,7 +172,7 @@ class ColormapEditor extends React.Component {
           </Toolbar>
         </Portal>
         {this.state.colorMap.length == 0 && <LinearProgress variant="query" />}
-        <div className={classes.editor}>{colormap}</div>
+        {colormap}
         <Palette
           palette={this.state.palette}
           onColorSelect={this.onColorSelect}

--- a/src/renderer/screens/ColormapEditor/Palette.js
+++ b/src/renderer/screens/ColormapEditor/Palette.js
@@ -18,6 +18,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import Fade from "@material-ui/core/Fade";
 import Paper from "@material-ui/core/Paper";
 import { withStyles } from "@material-ui/core/styles";
 
@@ -80,14 +81,15 @@ class Palette extends React.Component {
     });
 
     const color = this.props.palette[this.props.selected];
-    const picker = this.props.selected != -1 && (
-      <MaterialPicker color={color} onChangeComplete={this.onColorPick} />
-    );
 
     return (
       <Paper className={classes.root} square>
         {lowWidget}
-        <div className={classes.picker}>{picker}</div>
+        <Fade in={this.props.selected != -1} unMountOnExit>
+          <div className={classes.picker}>
+            <MaterialPicker color={color} onChangeComplete={this.onColorPick} />
+          </div>
+        </Fade>
         {highWidget}
       </Paper>
     );

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -18,9 +18,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import Fade from "@material-ui/core/Fade";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Portal from "@material-ui/core/Portal";
+import Slide from "@material-ui/core/Slide";
 import Switch from "@material-ui/core/Switch";
 import Tab from "@material-ui/core/Tab";
 import Tabs from "@material-ui/core/Tabs";
@@ -167,13 +169,17 @@ class LayoutEditor extends React.Component {
       isReadOnly = layerIndex < this.state.roLayers,
       layerData = this.state.keymap[layerIndex],
       layer = (
-        <Layer
-          readOnly={isReadOnly}
-          index={layerIndex}
-          keymap={layerData}
-          onKeySelect={this.onKeySelect}
-          selectedKey={this.state.currentKeyIndex}
-        />
+        <Fade in appear key={layerIndex}>
+          <div className={classes.editor}>
+            <Layer
+              readOnly={isReadOnly}
+              index={layerIndex}
+              keymap={layerData}
+              onKeySelect={this.onKeySelect}
+              selectedKey={this.state.currentKeyIndex}
+            />
+          </div>
+        </Fade>
       );
 
     let tabs = this.state.keymap.map((_, index) => {
@@ -221,12 +227,14 @@ class LayoutEditor extends React.Component {
           </Toolbar>
         </Portal>
         {this.state.keymap.length == 0 && <LinearProgress variant="query" />}
-        <div className={classes.editor}>{layer}</div>
-        <KeySelector
-          disabled={isReadOnly}
-          onKeySelect={this.onKeyChange}
-          currentKeyCode={this.getCurrentKey()}
-        />
+        {layer}
+        <Slide in={this.getCurrentKey() != -1} direction="up" unMountOnExit>
+          <KeySelector
+            disabled={isReadOnly}
+            onKeySelect={this.onKeyChange}
+            currentKeyCode={this.getCurrentKey()}
+          />
+        </Slide>
         <SaveChangesButton
           floating
           onClick={this.onApply}

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -340,8 +340,6 @@ class KeySelector extends React.Component {
     const { classes, currentKeyCode, disabled } = this.props;
     const { anchorEl, selectedGroup, actualKeycode } = this.state;
 
-    if (currentKeyCode == -1) return null;
-
     let groupIndex = selectedGroup,
       keyCode = currentKeyCode;
 


### PR DESCRIPTION
Layers fade in, the key selector slides up, and the color picker fades in too.

Fixes #168.