### PR TITLE
Welcome: Implement a "Reconnect" button

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -85,7 +85,9 @@ const English = {
   welcome: {
     title: "Welcome to Chrysalis",
     contents: `Your keyboard is supported by Chrysalis, but the firmware it is using appears to be missing essential features. You can flash a firmware with reasonable defaults - including features essential for Chrysalis - by visiting the "{0}" page.`,
-    gotoUpdate: "Go to the {0} page"
+    gotoUpdate: "Go to the {0} page",
+    reconnect: "Reconnect",
+    reconnectDescription: `There's a possibility that we misdetected the capabilities of the keyboard, or that the keyboard was starting up while we connected. In this case, you can try clicking the "{0}" button to attempt a reconnect, and look for the necessary features again.`
   }
 };
 

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -85,7 +85,9 @@ const Hungarian = {
   welcome: {
     title: "Üdvözöljük!",
     contents: `A billentyűzetét támogatja ugyan a Chrysalis, de a rajta lévő vezérlőből a jelek szerint hiányzik néhány elengedhetetlen funkcionalitás. Van lehetőség azonban egy ésszerű alapértelmezett, Chrysalis használatát lehetővé tevő funkciókkal ellátott vezérlőre frissíteni. Ehhez látogasson el a "{0}" oldalra.`,
-    gotoUpdate: "Irány a {0} oldal"
+    gotoUpdate: "Irány a {0} oldal",
+    reconnect: "Újracsatlakozás",
+    reconnectDescription: `Elképzelhető, hogy hibásan ismertük fel a billentyűzet által kínált funkcionalitást, vagy az is, hogy a billentyűzet még nem állt teljesen rendelkezésre mikor csatlakozni próbáltunk. Ebben az esetben az "{0}" gombra kattintva újra megpróbálunk csatlakozni.`
   }
 };
 

--- a/src/renderer/screens/Welcome.js
+++ b/src/renderer/screens/Welcome.js
@@ -30,6 +30,8 @@ import Portal from "@material-ui/core/Portal";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 
+import { withSnackbar } from "notistack";
+
 import FirmwareUpdate from "./FirmwareUpdate";
 import i18n from "../i18n";
 
@@ -42,8 +44,8 @@ const styles = theme => ({
     margin: theme.spacing.unit * 4,
     maxWidth: "50%"
   },
-  actions: {
-    justifyContent: "center"
+  grow: {
+    flexGrow: 1
   }
 });
 
@@ -59,11 +61,39 @@ class Welcome extends React.Component {
     this.setState({ factoryResetStarted: false });
   };
 
+  reconnect = async () => {
+    let focus = new Focus();
+    const device = {
+      comName: focus._port.path,
+      device: focus.device
+    };
+
+    try {
+      await this.props.onConnect(device);
+    } catch (err) {
+      this.props.enqueueSnackbar(err.toString(), { variant: "error" });
+    }
+  };
+
   render() {
     let focus = new Focus();
     const { classes } = this.props;
 
     const device = this.props.device || focus.device;
+
+    const reconnectButton = focus._port && (
+      <Button color="secondary" onClick={this.reconnect}>
+        {i18n.welcome.reconnect}
+      </Button>
+    );
+    const reconnectText = focus._port && (
+      <Typography component="p" gutterBottom>
+        {i18n.formatString(
+          i18n.welcome.reconnectDescription,
+          i18n.welcome.reconnect
+        )}
+      </Typography>
+    );
 
     return (
       <div className={classes.root}>
@@ -87,8 +117,11 @@ class Welcome extends React.Component {
                 i18n.app.menu.firmwareUpdate
               )}
             </Typography>
+            {reconnectText}
           </CardContent>
-          <CardActions className={classes.actions}>
+          <CardActions>
+            {reconnectButton}
+            <div className={classes.grow} />
             <Button
               color="primary"
               variant="outlined"
@@ -108,4 +141,4 @@ class Welcome extends React.Component {
   }
 }
 
-export default withStyles(styles)(Welcome);
+export default withSnackbar(withStyles(styles)(Welcome));


### PR DESCRIPTION
If we're connected to a keyboard with a serial port, but did not find Chrysalis, there's a small chance that we connected while the keyboard was booting up, or while something else was reading from the port too. In this case, offer an easy way to reconnect.

If we're connected to a board without a serial port, we do not offer the reconnect.

Fixes #157.

## A device with a serial port

![screenshot from 2019-01-10 09-43-57](https://user-images.githubusercontent.com/17243/50956601-63a9f280-14bc-11e9-82ee-3a61a63d8deb.png)

## A device without

![screenshot from 2019-01-10 09-44-18](https://user-images.githubusercontent.com/17243/50956613-699fd380-14bc-11e9-8083-fb5d57956273.png)
