### PR TITLE
Bundle the fonts we use

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "react-dom": "^16.5.2",
     "react-localization": "^1.0.13",
     "source-map-support": "^0.5.5",
+    "typeface-roboto": "^0.0.54",
+    "typeface-source-code-pro": "^0.0.71",
     "usb": "^1.5.0"
   },
   "devDependencies": {

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -22,6 +22,8 @@ import { spawn } from "child_process";
 import Focus from "@chrysalis-api/focus";
 import "@chrysalis-api/keymap";
 import "@chrysalis-api/colormap";
+import "typeface-roboto/index.css";
+import "typeface-source-code-pro/index.css";
 
 import AppBar from "@material-ui/core/AppBar";
 import Button from "@material-ui/core/Button";

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -45,7 +45,7 @@ const styles = theme => ({
     width: 225
   },
   key: {
-    fontFamily: "Input Mono, monospace",
+    fontFamily: '"Source Code Pro", monospace',
     margin: theme.spacing.unit / 2,
     padding: "4px 8px",
     minWidth: "auto",

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -20,7 +20,7 @@ button {
 }
 
 .layer {
-  font-family: "Input Mono", "monospace";
+  font-family: "Source Code Pro", "monospace";
   font-size: 10px;
   font-weight: 700;
   min-width: 550px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11103,6 +11103,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typeface-roboto@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.54.tgz#8f02c9a18d1cfa7f49381a6ff0d21ff061f38ad2"
+  integrity sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ==
+
+typeface-source-code-pro@^0.0.71:
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/typeface-source-code-pro/-/typeface-source-code-pro-0.0.71.tgz#30994f73aed203feb7d616937349bccf656c45a5"
+  integrity sha512-lBpRNuC/wLFVjeFpH1qAby5iTG1jggQFBGteB+kDlMDAlpfguGPj8X0ObXK8xKiAl98+WkGbkumc14AckHr0mQ==
+
 ua-parser-js@^0.7.18:
   version "0.7.19"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"


### PR DESCRIPTION
Bundle the "Roboto" and "Source Code Pro" fonts we use in the application (the latter replaces "Input Mono", which I didn't find a package for).

Fixes #159.
