### PR TITLE
Implement a way to cancel pending changes

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -28,6 +28,7 @@ import "typeface-source-code-pro/index.css";
 import AppBar from "@material-ui/core/AppBar";
 import Button from "@material-ui/core/Button";
 import ChatIcon from "@material-ui/icons/Chat";
+import CloseIcon from "@material-ui/icons/Close";
 import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import Divider from "@material-ui/core/Divider";
@@ -105,6 +106,7 @@ class App extends React.Component {
       connected: false,
       device: null,
       pages: {},
+      contextBar: false,
       Page: KeyboardSelect
     };
   }
@@ -229,9 +231,16 @@ class App extends React.Component {
     this.setState({ Page: page });
   };
 
+  cancelContext = () => {
+    this.setState({ contextBar: false });
+  };
+  startContext = () => {
+    this.setState({ contextBar: true });
+  };
+
   render() {
     const { classes } = this.props;
-    const { connected, pages, Page } = this.state;
+    const { connected, pages, Page, contextBar } = this.state;
 
     let focus = new Focus(),
       device =
@@ -401,14 +410,18 @@ class App extends React.Component {
     return (
       <div className={classes.root}>
         <CssBaseline />
-        <AppBar position="static" color="inherit" id="appbar">
+        <AppBar
+          position="static"
+          color={contextBar ? "primary" : "inherit"}
+          id="appbar"
+        >
           <Toolbar variant="dense">
             <Button
               className={classes.menuButton}
               color="inherit"
-              onClick={this.pageMenu}
+              onClick={contextBar ? this.cancelContext : this.pageMenu}
             >
-              <MenuIcon />
+              {contextBar ? <CloseIcon /> : <MenuIcon />}
               <Typography
                 variant="h6"
                 color="inherit"
@@ -430,6 +443,9 @@ class App extends React.Component {
             onDisconnect={this.onKeyboardDisconnect}
             openPage={this.openPage}
             toggleFlashing={this.toggleFlashing}
+            inContext={this.state.contextBar}
+            startContext={this.startContext}
+            cancelContext={this.cancelContext}
           />
         </main>
         <Drawer open={this.state.pageMenu} onClose={this.closePageMenu}>

--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -94,6 +94,7 @@ class ColormapEditor extends React.Component {
       palette: newPalette,
       modified: true
     });
+    this.props.startContext();
   };
 
   onKeySelect = event => {
@@ -107,6 +108,7 @@ class ColormapEditor extends React.Component {
         return colormap;
       });
       this.setState({ modified: true });
+      this.props.startContext();
     } else {
       this.setState({
         selectedPaletteColor: this.state.colorMap[layer][ledIndex]
@@ -123,11 +125,19 @@ class ColormapEditor extends React.Component {
       saving: false
     });
     console.log("colormap updated");
+    this.props.cancelContext();
   };
 
   componentDidMount() {
     this.scanKeyboard();
   }
+
+  UNSAFE_componentWillReceiveProps = nextProps => {
+    if (this.props.inContext && !nextProps.inContext) {
+      this.scanKeyboard();
+      this.setState({ modified: false });
+    }
+  };
 
   render() {
     const { classes } = this.props;

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -109,6 +109,7 @@ class LayoutEditor extends React.Component {
       return keymap;
     });
     this.setState({ modified: true });
+    this.props.startContext();
   };
 
   onKeySelect = event => {
@@ -142,6 +143,7 @@ class LayoutEditor extends React.Component {
       saving: false
     });
     console.log("keymap updated");
+    this.props.cancelContext();
   };
 
   onDefaultLayerChange = async event => {
@@ -157,6 +159,13 @@ class LayoutEditor extends React.Component {
   componentDidMount() {
     this.scanKeyboard();
   }
+
+  UNSAFE_componentWillReceiveProps = nextProps => {
+    if (this.props.inContext && !nextProps.inContext) {
+      this.scanKeyboard();
+      this.setState({ modified: false });
+    }
+  };
 
   render() {
     const { classes } = this.props;


### PR DESCRIPTION
When there are pending changes in the Colormap or Layout editors, switch the appbar to a context bar, with the main menu replaced with a cancel button. When that icon is clicked, reload the data from the keyboard, effectively canceling any pending changes.

Fixes #143.

![screenshot from 2019-01-11 17-07-07](https://user-images.githubusercontent.com/17243/51045216-588dba00-15c3-11e9-8c92-6151162799f3.png)
