### PR TITLE
Fix layer copying

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -164,7 +164,7 @@ class ColormapEditor extends React.Component {
   copyToLayer = layer => {
     this.setState(state => {
       let newMap = state.colorMap.slice();
-      newMap[layer] = state.colorMap[state.currentLayer];
+      newMap[layer] = state.colorMap[state.currentLayer].slice();
       return {
         colorMap: newMap,
         copyMenuExpanded: false,

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -198,7 +198,7 @@ class LayoutEditor extends React.Component {
   copyToLayer = layer => {
     this.setState(state => {
       let newKeymap = state.keymap.slice();
-      newKeymap[layer] = state.keymap[state.currentLayer];
+      newKeymap[layer] = state.keymap[state.currentLayer].slice();
       return {
         keymap: newKeymap,
         copyMenuExpanded: false,


### PR DESCRIPTION
When copying a layer, do a deep copy instead of simple assignment. With a simple assignment, when we edit the copied layer, the source would change too, as they are the same array object under the hood. With a deep copy, they're separate, as they should be.
