### PR TITLE
A few SaveChangesButton updates

### DIFF
--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -70,7 +70,7 @@ const styles = theme => ({
     position: "fixed",
     justifyContent: "flex-end",
     bottom: 0,
-    right: 0
+    right: theme.spacing.unit * 4
   }
 });
 
@@ -109,6 +109,22 @@ class SaveChangesButton extends React.Component {
       [classes.buttonSuccess]: success
     });
 
+    const textPart = !this.props.floating && (
+      <div className={classes.wrapper}>
+        <Button
+          variant="contained"
+          color="secondary"
+          className={buttonClassname}
+          disabled={inProgress || (this.props.disabled && !success)}
+          onClick={this.handleButtonClick}
+        >
+          {success
+            ? successMessage || i18n.components.save.success
+            : this.props.children}
+        </Button>
+      </div>
+    );
+
     return (
       <div
         className={classNames(
@@ -131,19 +147,7 @@ class SaveChangesButton extends React.Component {
             <CircularProgress size={68} className={classes.fabProgress} />
           )}
         </div>
-        <div className={classes.wrapper}>
-          <Button
-            variant="contained"
-            color="secondary"
-            className={buttonClassname}
-            disabled={inProgress || (this.props.disabled && !success)}
-            onClick={this.handleButtonClick}
-          >
-            {success
-              ? successMessage || i18n.components.save.success
-              : this.props.children}
-          </Button>
-        </div>
+        {textPart}
       </div>
     );
   }

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -125,6 +125,8 @@ class SaveChangesButton extends React.Component {
       </div>
     );
 
+    const icon = this.props.icon || <SaveIcon />;
+
     return (
       <div
         className={classNames(
@@ -141,7 +143,7 @@ class SaveChangesButton extends React.Component {
             classes={{ disabled: classes.disabled }}
             onClick={this.handleButtonClick}
           >
-            {success ? <CheckIcon /> : <SaveIcon />}
+            {success ? <CheckIcon /> : icon}
           </Fab>
           {inProgress && (
             <CircularProgress size={68} className={classes.fabProgress} />

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -24,7 +24,7 @@ import green from "@material-ui/core/colors/green";
 import Button from "@material-ui/core/Button";
 import Fab from "@material-ui/core/Fab";
 import CheckIcon from "@material-ui/icons/Check";
-import SaveIcon from "@material-ui/icons/SaveAlt";
+import SyncIcon from "@material-ui/icons/Sync";
 import { withStyles } from "@material-ui/core/styles";
 
 import i18n from "../i18n";
@@ -125,7 +125,7 @@ class SaveChangesButton extends React.Component {
       </div>
     );
 
-    const icon = this.props.icon || <SaveIcon />;
+    const icon = this.props.icon || <SyncIcon />;
 
     return (
       <div

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -26,6 +26,7 @@ import BuildIcon from "@material-ui/icons/Build";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
+import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import Divider from "@material-ui/core/Divider";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
@@ -237,6 +238,7 @@ class FirmwareUpdate extends React.Component {
             </Menu>
             <div className={classes.grow} />
             <SaveChangesButton
+              icon={<CloudUploadIcon />}
               onClick={this.upload}
               successMessage={i18n.firmwareUpdate.flashing.buttonSuccess}
             >


### PR DESCRIPTION
This makes the icon settable by the caller, so we can use different ones for different purposes (such as one for the firmware upgrade button, and another for the layout/colormap save). It also makes the default icon `Sync` instead of `SaveAlt`, because the latter was too easy to interpret as downloading, which isn't what it does.

Furthermore, when in floating mode, display the FAB part only.

## When floating, display the FAB part only

![screenshot from 2019-01-12 10-05-08](https://user-images.githubusercontent.com/17243/51071472-ad781180-1651-11e9-8a94-3d77ce54c2ee.png)

## Inline, display the text part too

![screenshot from 2019-01-12 10-05-13](https://user-images.githubusercontent.com/17243/51071488-efa15300-1651-11e9-8971-6eccc3631a54.png)
