### PR TITLE
KeySelector: Implement support for DualUse keys

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -50,7 +50,9 @@ const English = {
   layoutEditor: {
     defaultLayer: "Default layer",
     clearLayer: "Clear layer...",
-    copyTo: "Copy to layer..."
+    copyTo: "Copy to layer...",
+    dualUse: "Modifier when held, normal key otherwise",
+    dualUseLayer: "Layer shift when held, normal key otherwise"
   },
   colormapEditor: {
     clearLayer: "Clear layer...",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -50,7 +50,9 @@ const Hungarian = {
   layoutEditor: {
     defaultLayer: "Alapértelmezett réteg",
     clearLayer: "Réteg ürítése...",
-    copyTo: "Réteg másolás..."
+    copyTo: "Réteg másolás...",
+    dualUse: "Nyomvatartáskor módosító, normál gomb egyébként",
+    dualUseLayer: "Nyomvatartáskor réteg váltó, normál gomb egyébként"
   },
   colormapEditor: {
     clearLayer: "Réteg ürítése...",


### PR DESCRIPTION
Adds support for DualUse keys to the Key Selector component.

Fixes #76.

## DualUse modifier key

![screenshot from 2019-01-12 13-18-03](https://user-images.githubusercontent.com/17243/51073111-82e78200-166c-11e9-9ad6-362d42d9b7be.png)

When looking at a DualUse modifier key, one can toggle DualUse off, DualUse Layers are disabled. Selecting a different modifier selects that one only. `AltGr` is disabled, because that's not supported by DualUse at t he moment.

## DualUse layer select key

![screenshot from 2019-01-12 13-18-20](https://user-images.githubusercontent.com/17243/51073117-8b3fbd00-166c-11e9-801a-980ed088e744.png)

When looking at a DualUse layer key, modifiers are not shown, and dual-use can toggle off.

## Modded key

![screenshot from 2019-01-12 13-18-38](https://user-images.githubusercontent.com/17243/51073127-9692e880-166c-11e9-8e3c-ce6c6d4682de.png)

Looking at a modded key, dual-use can be turned on (unless the modifier is `AltGr`).

## Multiple mods on the same key

![screenshot from 2019-01-12 13-18-58](https://user-images.githubusercontent.com/17243/51073131-a1e61400-166c-11e9-8470-282821af2fe7.png)

Multiple modifiers selected? DualUse is not an option then.

## Normal key

![screenshot from 2019-01-12 13-19-12](https://user-images.githubusercontent.com/17243/51073135-aad6e580-166c-11e9-813f-f4b36e4d866d.png)

For a normal key, we offer a modifier bar with dual-use disabled until a modifier is selected. We also offer a dual-use layer option, which defaults to switching to layer 0 first.