### PR TITLE
LayoutEditor: Initialize to the default layer (if set)

### DIFF
--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -92,6 +92,7 @@ class LayoutEditor extends React.Component {
       this.setState({
         roLayers: roLayers,
         defaultLayer: defLayer,
+        currentLayer: defLayer < keymap.length ? defLayer : 0,
         keymap: keymap
       });
     } catch (e) {


### PR DESCRIPTION
When initially displaying the LayoutEditor screen, start with the default layer's tab selected.

Fixes #186.
