### PR TITLE
LayoutEditor: Fix layer clearing

### DIFF
--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -214,7 +214,7 @@ class LayoutEditor extends React.Component {
       let newKeymap = state.keymap.slice();
       newKeymap[state.currentLayer] = Array(newKeymap[0].length)
         .fill()
-        .map(() => 0);
+        .map(() => ({ keyCode: 0 }));
       return {
         keymap: newKeymap,
         modified: true,


### PR DESCRIPTION
When clearing the layer, don't fill the array with zeros, but with objects with their `keyCode` property set to zero - this is the structure the layout editor expects.
