### PR TITLE
LayoutEditor: Only switch to the default layer on mount

### DIFF
--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -92,7 +92,6 @@ class LayoutEditor extends React.Component {
       this.setState({
         roLayers: roLayers,
         defaultLayer: defLayer,
-        currentLayer: defLayer < keymap.length ? defLayer : 0,
         keymap: keymap
       });
     } catch (e) {
@@ -173,7 +172,12 @@ class LayoutEditor extends React.Component {
   };
 
   componentDidMount() {
-    this.scanKeyboard();
+    this.scanKeyboard().then(() => {
+      this.setState(state => ({
+        currentLayer:
+          state.defaultLayer < state.keymap.length ? state.defaultLayer : 0
+      }));
+    });
   }
 
   UNSAFE_componentWillReceiveProps = nextProps => {


### PR DESCRIPTION
We only want to switch to the default layer when the component is mounted, not when properties update or when we rescan the keyboard for some other reason. Thus, move the `currentLayer` setting to `componentDidMount()`.

Fixes #195.
