### PR TITLE
FirmwareUpdate: Mention the firmware bundle repo

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -113,6 +113,7 @@ const English = {
       button: "Update",
       buttonSuccess: "Updated!"
     },
+    repo: `To see what is included in the default firmware, please see the {0} repository.`,
     defaultFirmware: "Default firmware",
     updatingTitle: "Updating the firmware",
     selected: "Selected firmware",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -113,6 +113,7 @@ const Hungarian = {
       button: "Frissítés",
       buttonSuccess: "Frissítve!"
     },
+    repo: `Látogasson el a {0} gyűjtemény oldalára, ha kiváncsi pontosan mit tartalmaz az alapértelmezett vezérlő.`,
     defaultFirmware: "Alapértelmezett vezérlő",
     updatingTitle: "Vezérlő frissítés",
     selected: "Kiválasztott vezérlő",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -206,8 +206,16 @@ class FirmwareUpdate extends React.Component {
               )}
             </Typography>
             {tooling}
-            <Typography component="p">
+            <Typography component="p" gutterBottom>
               {i18n.firmwareUpdate.postUpload}
+            </Typography>
+            <Typography component="p">
+              {i18n.formatString(
+                i18n.firmwareUpdate.repo,
+                <a href="https://github.com/keyboardio/Chrysalis-Firmware-Bundle#readme">
+                  Chrysalis-Firmware-Bundle
+                </a>
+              )}
             </Typography>
           </CardContent>
           <Divider variant="middle" />


### PR DESCRIPTION
We should let users know where to find the sources of the bundled default firmware files, and where to find them.
