### PR TITLE
Provide a way to disconnect from the keyboard

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -99,6 +99,7 @@ const English = {
     selectPrompt: "Please select a keyboard:",
     noDevices: "No devices found!",
     connect: "Connect",
+    disconnect: "Disconnect",
     scan: "Scan devices"
   },
   firmwareUpdate: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -99,6 +99,7 @@ const Hungarian = {
     selectPrompt: "Kérem válasszon billentyűzetet:",
     noDevices: "Nincs ismert eszköz csatlakoztatva!",
     connect: "Kapcsolódás",
+    disconnect: "Lecsatlakozás",
     scan: "Eszköz keresés"
   },
   firmwareUpdate: {

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -311,6 +311,44 @@ class KeyboardSelect extends React.Component {
       );
     }
 
+    let connectionButton;
+    let focus = new Focus();
+    const selectedDevice = devices && devices[this.state.selectedPortIndex];
+
+    if (
+      focus._port &&
+      selectedDevice &&
+      selectedDevice.comName == focus._port.path
+    ) {
+      connectionButton = (
+        <Button
+          disabled={
+            this.state.opening ||
+            (this.state.devices && this.state.devices.length == 0)
+          }
+          variant="outlined"
+          color="secondary"
+          onClick={this.props.onDisconnect}
+        >
+          {i18n.keyboardSelect.disconnect}
+        </Button>
+      );
+    } else {
+      connectionButton = (
+        <Button
+          disabled={
+            this.state.opening ||
+            (this.state.devices && this.state.devices.length == 0)
+          }
+          variant="contained"
+          color="primary"
+          onClick={this.onKeyboardConnect}
+        >
+          {connectContent}
+        </Button>
+      );
+    }
+
     return (
       <div className={classes.main}>
         <Portal container={this.props.titleElement}>
@@ -324,17 +362,7 @@ class KeyboardSelect extends React.Component {
           <CardActions className={classes.cardActions}>
             {scanDevicesButton}
             <div className={classes.grow} />
-            <Button
-              disabled={
-                this.state.opening ||
-                (this.state.devices && this.state.devices.length == 0)
-              }
-              variant="contained"
-              color="primary"
-              onClick={this.onKeyboardConnect}
-            >
-              {connectContent}
-            </Button>
+            {connectionButton}
           </CardActions>
         </Card>
       </div>

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -171,9 +171,24 @@ class KeyboardSelect extends React.Component {
     this.finder = () => {
       this.findKeyboards();
     };
-    this.finder();
     usb.on("attach", this.finder);
     usb.on("detach", this.finder);
+
+    this.findKeyboards().then(() => {
+      let focus = new Focus();
+      if (!focus._port) return;
+
+      for (let device of this.state.devices) {
+        if (!device.comName) continue;
+
+        if (device.comName == focus._port.path) {
+          this.setState(state => ({
+            selectedPortIndex: state.devices.indexOf(device)
+          }));
+          break;
+        }
+      }
+    });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
There are cases where one wants to disconnect from the keyboard without exiting Chrysalis and without changing to another keyboard. For this reason, the `Connect` button on the `KeyboardSelector` screen will turn into `Disconnect` when the selected device is the one we're connected to (assuming we have Serial open). To make this easier, the `KeyboardSelector` screen now defaults to showing the opened device on mount instead of the first one found.

![screenshot from 2019-01-14 13-48-28](https://user-images.githubusercontent.com/17243/51113677-194dac00-1803-11e9-9a4b-4976870c0607.png)
