### PR TITLE
When clearing or copying a layer, start the context state

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -165,6 +165,7 @@ class ColormapEditor extends React.Component {
     this.setState(state => {
       let newMap = state.colorMap.slice();
       newMap[layer] = state.colorMap[state.currentLayer].slice();
+      this.props.startContext();
       return {
         colorMap: newMap,
         copyMenuExpanded: false,
@@ -181,6 +182,7 @@ class ColormapEditor extends React.Component {
       newMap[state.currentLayer] = Array(newMap[0].length)
         .fill()
         .map(() => 0);
+      this.props.startContext();
       return {
         colorMap: newMap,
         modified: true,

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -204,6 +204,7 @@ class LayoutEditor extends React.Component {
     this.setState(state => {
       let newKeymap = state.keymap.slice();
       newKeymap[layer] = state.keymap[state.currentLayer].slice();
+      this.props.startContext();
       return {
         keymap: newKeymap,
         copyMenuExpanded: false,
@@ -220,6 +221,7 @@ class LayoutEditor extends React.Component {
       newKeymap[state.currentLayer] = Array(newKeymap[0].length)
         .fill()
         .map(() => ({ keyCode: 0 }));
+      this.props.startContext();
       return {
         keymap: newKeymap,
         modified: true,


### PR DESCRIPTION
Without this, the main menu will not turn into a contextual alternate, and we won't be able to easily cancel the clear or the copy.
