### PR TITLE
KeyboardSelector UI improvements

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -18,7 +18,7 @@
 const English = {
   language: "English",
   errors: {
-    deviceDisconnected: "Device disconnected"
+    deviceDisconnected: "Keyboard disconnected"
   },
   components: {
     layer: "Layer #{0}",
@@ -28,7 +28,7 @@ const English = {
     }
   },
   app: {
-    device: "Device",
+    device: "Keyboard",
     menu: {
       welcome: "Welcome",
       layoutEditor: "Layout Editor",
@@ -97,10 +97,10 @@ const English = {
   keyboardSelect: {
     unknown: "Unknown",
     selectPrompt: "Please select a keyboard:",
-    noDevices: "No devices found!",
+    noDevices: "No keyboards found!",
     connect: "Connect",
     disconnect: "Disconnect",
-    scan: "Scan devices"
+    scan: "Scan keyboards"
   },
   firmwareUpdate: {
     dialog: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -18,7 +18,7 @@
 const Hungarian = {
   language: "Magyar",
   errors: {
-    deviceDisconnected: "Az eszköz lecsatlakozott"
+    deviceDisconnected: "Az billentyűzet lecsatlakozott"
   },
   components: {
     layer: "#{0}. réteg",
@@ -28,7 +28,7 @@ const Hungarian = {
     }
   },
   app: {
-    device: "Eszköz",
+    device: "Billentyűzet",
     menu: {
       welcome: "Üdvözlet",
       layoutEditor: "Kiosztás szerkesztő",
@@ -97,10 +97,10 @@ const Hungarian = {
   keyboardSelect: {
     unknown: "Ismeretlen",
     selectPrompt: "Kérem válasszon billentyűzetet:",
-    noDevices: "Nincs ismert eszköz csatlakoztatva!",
+    noDevices: "Nincs ismert billentyűzet csatlakoztatva!",
     connect: "Kapcsolódás",
     disconnect: "Lecsatlakozás",
-    scan: "Eszköz keresés"
+    scan: "Billentyűzet keresés"
   },
   firmwareUpdate: {
     dialog: {

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -23,18 +23,17 @@ import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
-import CardHeader from "@material-ui/core/CardHeader";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Divider from "@material-ui/core/Divider";
+import FormControl from "@material-ui/core/FormControl";
 import green from "@material-ui/core/colors/green";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
 import LinearProgress from "@material-ui/core/LinearProgress";
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
 import MenuItem from "@material-ui/core/MenuItem";
-import Menu from "@material-ui/core/Menu";
 import Portal from "@material-ui/core/Portal";
+import Select from "@material-ui/core/Select";
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
@@ -76,13 +75,20 @@ const styles = theme => ({
  ${theme.spacing.unit * 3}px`
   },
   content: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    paddingTop: 0,
-    paddingBottom: 0
+    display: "inline-block",
+    width: "100%"
   },
-  avatar: {
+  selectControl: {
+    display: "flex"
+  },
+  connect: {
+    verticalAlign: "bottom",
+    marginLeft: 65
+  },
+  cardActions: {
+    justifyContent: "center"
+  },
+  supported: {
     backgroundColor: theme.palette.secondary.main
   },
   grow: {
@@ -100,7 +106,6 @@ const styles = theme => ({
 
 class KeyboardSelect extends React.Component {
   state = {
-    anchorEl: null,
     selectedPortIndex: 0,
     opening: false,
     devices: null,
@@ -195,16 +200,8 @@ class KeyboardSelect extends React.Component {
     usb.off("detach", this.finder);
   }
 
-  handleClickListItem = event => {
-    this.setState({ anchorEl: event.currentTarget });
-  };
-
-  handleMenuItemClick = (event, index) => {
-    this.setState({ selectedPortIndex: index, anchorEl: null });
-  };
-
-  handleClose = () => {
-    this.setState({ anchorEl: null });
+  selectPort = event => {
+    this.setState({ selectedPortIndex: event.target.value });
   };
 
   onKeyboardConnect = async () => {
@@ -224,7 +221,7 @@ class KeyboardSelect extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const { anchorEl, scanFoundDevices, devices } = this.state;
+    const { scanFoundDevices, devices } = this.state;
 
     let loader = null;
     if (this.state.loading) {
@@ -246,39 +243,37 @@ class KeyboardSelect extends React.Component {
         } else if (option.info) {
           label = <ListItemText primary={option.info.displayName} />;
         }
+
+        const icon = (
+          <ListItemIcon>
+            <Avatar className={option.comName && classes.supported}>
+              <KeyboardIcon />
+            </Avatar>
+          </ListItemIcon>
+        );
+
         return (
           <MenuItem
             key={`device-${index}`}
+            value={index}
             selected={index === this.state.selectedPortIndex}
-            onClick={event => this.handleMenuItemClick(event, index)}
           >
+            {icon}
             {label}
           </MenuItem>
         );
       });
 
-      let portDesc = devices[this.state.selectedPortIndex],
-        portInfo = portDesc.device ? portDesc.device.info : portDesc.info;
-
       port = (
-        <React.Fragment>
-          <List component="nav">
-            <ListItem button onClick={this.handleClickListItem}>
-              <ListItemText
-                primary={portInfo.displayName}
-                secondary={portDesc.comName || i18n.keyboardSelect.unknown}
-              />
-            </ListItem>
-          </List>
-          <Menu
-            anchorEl={anchorEl}
-            open={Boolean(anchorEl)}
-            onClose={this.handleClose}
+        <FormControl className={classes.selectControl}>
+          <Select
+            value={this.state.selectedPortIndex}
+            classes={{ select: classes.selectControl }}
+            onChange={this.selectPort}
           >
-            <MenuItem disabled>{i18n.keyboardSelect.selectPrompt}</MenuItem>
             {deviceItems}
-          </Menu>
-        </React.Fragment>
+          </Select>
+        </FormControl>
       );
     }
 
@@ -294,12 +289,6 @@ class KeyboardSelect extends React.Component {
     if (this.state.opening) {
       connectContent = <CircularProgress color="secondary" size={16} />;
     }
-
-    const avatar = (
-      <Avatar className={classes.avatar}>
-        <KeyboardIcon />
-      </Avatar>
-    );
 
     const scanDevicesButton = (
       <Button
@@ -344,6 +333,7 @@ class KeyboardSelect extends React.Component {
           variant="contained"
           color="primary"
           onClick={this.onKeyboardConnect}
+          className={classes.connect}
         >
           {connectContent}
         </Button>
@@ -357,7 +347,6 @@ class KeyboardSelect extends React.Component {
         </Portal>
         {loader}
         <Card className={classes.card}>
-          <CardHeader className={classes.content} avatar={avatar} />
           <CardContent className={classes.content}>{port}</CardContent>
           <Divider variant="middle" />
           <CardActions className={classes.cardActions}>

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -35,7 +35,7 @@ import ListItemText from "@material-ui/core/ListItemText";
 import MenuItem from "@material-ui/core/MenuItem";
 import Menu from "@material-ui/core/Menu";
 import Portal from "@material-ui/core/Portal";
-import red from "@material-ui/core/colors/red";
+import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
 import { withSnackbar } from "notistack";
@@ -89,13 +89,12 @@ const styles = theme => ({
     flexGrow: 1
   },
   error: {
-    color: theme.palette.error.dark
+    marginTop: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit * 2,
+    textAlign: "center"
   },
   found: {
     color: green[500]
-  },
-  notFound: {
-    color: red[500]
   }
 });
 
@@ -284,7 +283,11 @@ class KeyboardSelect extends React.Component {
     }
 
     if (devices && devices.length == 0) {
-      port = <p className={classes.error}>{i18n.keyboardSelect.noDevices}</p>;
+      port = (
+        <Typography variant="body1" color="error" className={classes.error}>
+          {i18n.keyboardSelect.noDevices}
+        </Typography>
+      );
     }
 
     let connectContent = i18n.keyboardSelect.connect;

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -298,18 +298,16 @@ class KeyboardSelect extends React.Component {
       </Avatar>
     );
 
-    let scanDevicesButton;
-    if (scanFoundDevices == undefined) {
-      scanDevicesButton = (
-        <Button onClick={this.scanDevices}>{i18n.keyboardSelect.scan}</Button>
-      );
-    } else {
-      scanDevicesButton = (
-        <Button className={scanFoundDevices ? classes.found : classes.notFound}>
-          {i18n.keyboardSelect.scan}
-        </Button>
-      );
-    }
+    const scanDevicesButton = (
+      <Button
+        variant={devices && devices.length ? "outlined" : "contained"}
+        color={devices && devices.length ? "default" : "primary"}
+        className={scanFoundDevices && classes.found}
+        onClick={scanFoundDevices ? null : this.scanDevices}
+      >
+        {i18n.keyboardSelect.scan}
+      </Button>
+    );
 
     let connectionButton;
     let focus = new Focus();


### PR DESCRIPTION
## Overview

![screenshot from 2019-01-18 09-38-14](https://user-images.githubusercontent.com/17243/51375111-481a9980-1b05-11e9-9f78-561a76a01928.png)

- "Scan devices" became "Scan keyboards" (#212)
- "Scan devices" is outlined by default (#211)
- The selector became a real dropdown (#214)
- The icon has been integrated into the dropdown

## Menu

![screenshot from 2019-01-18 09-38-20](https://user-images.githubusercontent.com/17243/51375322-d5f68480-1b05-11e9-9fac-592004d9463f.png)

Keyboards that have a serial port are in the secondary color, keyboards that do not, are grey.

## Error

![screenshot from 2019-01-18 09-44-16](https://user-images.githubusercontent.com/17243/51375376-fcb4bb00-1b05-11e9-9d87-160a29d53bca.png)

- The error message uses the same typeface as everything else (#213)