### PR TITLE
Welcome screen: UI improvements

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -125,7 +125,7 @@ const English = {
   },
   welcome: {
     title: "Welcome to Chrysalis",
-    contents: `Your keyboard is supported by Chrysalis, but the firmware it is using appears to be missing essential features. You can flash a firmware with reasonable defaults - including features essential for Chrysalis - by visiting the "{0}" page.`,
+    contents: `Chrysalis recognizes your keyboard, but needs to update its firmware before you can continue.`,
     gotoUpdate: "Update Firmware",
     reconnect: "Reconnect",
     reconnectDescription: `There's a possibility that we misdetected the capabilities of the keyboard, or that the keyboard was starting up while we connected. In this case, you can try clicking the "{0}" button to attempt a reconnect, and look for the necessary features again.`

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -126,7 +126,7 @@ const English = {
   welcome: {
     title: "Welcome to Chrysalis",
     contents: `Your keyboard is supported by Chrysalis, but the firmware it is using appears to be missing essential features. You can flash a firmware with reasonable defaults - including features essential for Chrysalis - by visiting the "{0}" page.`,
-    gotoUpdate: "Go to the {0} page",
+    gotoUpdate: "Update Firmware",
     reconnect: "Reconnect",
     reconnectDescription: `There's a possibility that we misdetected the capabilities of the keyboard, or that the keyboard was starting up while we connected. In this case, you can try clicking the "{0}" button to attempt a reconnect, and look for the necessary features again.`
   }

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -125,7 +125,7 @@ const Hungarian = {
   },
   welcome: {
     title: "Üdvözöljük!",
-    contents: `A billentyűzetét támogatja ugyan a Chrysalis, de a rajta lévő vezérlőből a jelek szerint hiányzik néhány elengedhetetlen funkcionalitás. Van lehetőség azonban egy ésszerű alapértelmezett, Chrysalis használatát lehetővé tevő funkciókkal ellátott vezérlőre frissíteni. Ehhez látogasson el a "{0}" oldalra.`,
+    contents: `A Chrysalis felismerte a billentyűzetét, de a folytatáshoz frissíteni kell a vezérlőjét.`,
     gotoUpdate: "Vezérlő frissítés",
     reconnect: "Újracsatlakozás",
     reconnectDescription: `Elképzelhető, hogy hibásan ismertük fel a billentyűzet által kínált funkcionalitást, vagy az is, hogy a billentyűzet még nem állt teljesen rendelkezésre mikor csatlakozni próbáltunk. Ebben az esetben az "{0}" gombra kattintva újra megpróbálunk csatlakozni.`

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -126,7 +126,7 @@ const Hungarian = {
   welcome: {
     title: "Üdvözöljük!",
     contents: `A billentyűzetét támogatja ugyan a Chrysalis, de a rajta lévő vezérlőből a jelek szerint hiányzik néhány elengedhetetlen funkcionalitás. Van lehetőség azonban egy ésszerű alapértelmezett, Chrysalis használatát lehetővé tevő funkciókkal ellátott vezérlőre frissíteni. Ehhez látogasson el a "{0}" oldalra.`,
-    gotoUpdate: "Irány a {0} oldal",
+    gotoUpdate: "Vezérlő frissítés",
     reconnect: "Újracsatlakozás",
     reconnectDescription: `Elképzelhető, hogy hibásan ismertük fel a billentyűzet által kínált funkcionalitást, vagy az is, hogy a billentyűzet még nem állt teljesen rendelkezésre mikor csatlakozni próbáltunk. Ebben az esetben az "{0}" gombra kattintva újra megpróbálunk csatlakozni.`
   }


### PR DESCRIPTION
![screenshot from 2019-01-18 10-04-56](https://user-images.githubusercontent.com/17243/51376404-85345b00-1b08-11e9-9ad2-c00963d38d7f.png)

- The call to action button is much more to the point (#216)
- The explanatory text is also shorter and to the point: just explain why we're on this screen, and let the followup screen do the rest (#217)

This does not address #218, that's a bit more involved than changing text, and requires slightly deeper changes, so I will address it in a separate PR.