### PR TITLE
FirmwareUpdate: UI improvements

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -118,7 +118,6 @@ const English = {
     selected: "Selected firmware",
     custom: "Custom firmware",
     description: `Updating or "flashing" your keyboard's firmware is how we teach it new tricks. Chrysalis will install a new version of your keyboard's firmware which includes support for customizing the key layout, as well as other features. If you've previously customized your keyboard's firmware, this will overwrite your custom firmware. You can always find the source code of the firmware Chrysalis is installing here:`,
-    tooling: `Your keyboard requires an external tool ({0}) for flashing. Please make sure that it is available, and on the PATH, otherwise Chrysalis will not be able to upload new firmware.`,
     postUpload: `Once the upload is done, Chrysalis will take you back to the keyboard selection screen.`
   },
   welcome: {

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -114,14 +114,12 @@ const English = {
       button: "Update",
       buttonSuccess: "Updated!"
     },
-    repo: `To see what is included in the default firmware, please see the {0} repository.`,
     defaultFirmware: "Chrysalis {0} default",
-    updatingTitle: "Updating the firmware",
     selected: "Selected firmware",
     custom: "Custom firmware",
-    description: `Updating the firmware is a safe process, it's very hard to brick your keyboard even with bad firmware, as most keyboards provide a way to go stay in bootloader mode, where new firmware can be flashed. Nevertheless, updating the firmware will overwrite the previous one. If you customised your firmware, make sure you're flashing one that you are comfortable with. If you wish to proceed, please consult the documentation of your keyboard to see how to enable uploading new firmware, and then press the {0} button to continue.`,
+    description: `Updating or "flashing" your keyboard's firmware is how we teach it new tricks. Chrysalis will install a new version of your keyboard's firmware which includes support for customizing the key layout, as well as other features. If you've previously customized your keyboard's firmware, this will overwrite your custom firmware. You can always find the source code of the firmware Chrysalis is installing here:`,
     tooling: `Your keyboard requires an external tool ({0}) for flashing. Please make sure that it is available, and on the PATH, otherwise Chrysalis will not be able to upload new firmware.`,
-    postUpload: `Once the upload is finished - either successfully or with errors -, you will be taken back to the initial keyboard selection screen. This is normal.`
+    postUpload: `Once the upload is done, Chrysalis will take you back to the keyboard selection screen.`
   },
   welcome: {
     title: "Welcome to Chrysalis",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -115,7 +115,7 @@ const English = {
       buttonSuccess: "Updated!"
     },
     repo: `To see what is included in the default firmware, please see the {0} repository.`,
-    defaultFirmware: "Default firmware",
+    defaultFirmware: "Chrysalis {0} default",
     updatingTitle: "Updating the firmware",
     selected: "Selected firmware",
     custom: "Custom firmware",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -114,14 +114,12 @@ const Hungarian = {
       button: "Frissítés",
       buttonSuccess: "Frissítve!"
     },
-    repo: `Látogasson el a {0} gyűjtemény oldalára, ha kiváncsi pontosan mit tartalmaz az alapértelmezett vezérlő.`,
     defaultFirmware: "Chrysalis {0} alapértelmezett",
-    updatingTitle: "Vezérlő frissítés",
     selected: "Kiválasztott vezérlő",
     custom: "Egyedi vezérlő",
-    description: `A vezérlő frissítés egy biztonságos folyamat, nagyon nehéz téglásítani a billentyűzetet, még akkor is, ha hibás vezérlőt töltünk rá. A legtöbb billentyűzettel megoldható, hogy programozható módban maradjon csatlakozáskor, függetlenül attól, milyen vezérlő van rajta. A vezérlő frissítése azzal jár, hogy a meglévő program felülíródik. Ha testre szabta a programját, kérjük győződjön meg róla, hogy amire frissíteni akar, megfelelő. Amennyiben folytatni kívánja, kérjük olvassa el a billentyűzete dokumentációjának vezérlő frissítésről szóló részét, majd nyomja meg a {0} gombot.`,
-    tooling: `A billentyűzet vezérlőjének frissítéséhez külső programra ({0}) van szükség. Kérjük tegye a programot elérhetővé a Chrysalis számára, különben nem fog tudni vezérlő frissítést feltölteni.`,
-    postUpload: `Amint a feltöltés befejeződött - sikeresen, vagy sikertelenül -, visszatérünk a kezdeti billentyűzet választó oldalra. Ez az elvárt működés.`
+    description: `A billentyűzet vezérlő frissítésevel tanítjuk új trükkökre. A Chrysalis olyan új vezérlőt fog telepíteni, mely tartalmazza az eszközöket melyek lehetővé teszik a kiosztás szerkesztését, és még más dolgokat is. Ha korábban már testreszabta a vezérlőt, akkor ez a művelet felül fogja azt írni. A Chrysalis által telepíthető vezérlő forrása mindig megtalálható az alábbi címen:`,
+    postUpload: `Amint a frissítés befejeződött, a Chrysalis vissza fogja vinni a billentyűzet választó képernyőre.`,
+    tooling: `A billentyűzet vezérlőjének frissítéséhez külső programra ({0}) van szükség. Kérjük tegye a programot elérhetővé a Chrysalis számára, különben nem fog tudni vezérlő frissítést feltölteni.`
   },
   welcome: {
     title: "Üdvözöljük!",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -115,7 +115,7 @@ const Hungarian = {
       buttonSuccess: "Frissítve!"
     },
     repo: `Látogasson el a {0} gyűjtemény oldalára, ha kiváncsi pontosan mit tartalmaz az alapértelmezett vezérlő.`,
-    defaultFirmware: "Alapértelmezett vezérlő",
+    defaultFirmware: "Chrysalis {0} alapértelmezett",
     updatingTitle: "Vezérlő frissítés",
     selected: "Kiválasztott vezérlő",
     custom: "Egyedi vezérlő",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -118,8 +118,7 @@ const Hungarian = {
     selected: "Kiválasztott vezérlő",
     custom: "Egyedi vezérlő",
     description: `A billentyűzet vezérlő frissítésevel tanítjuk új trükkökre. A Chrysalis olyan új vezérlőt fog telepíteni, mely tartalmazza az eszközöket melyek lehetővé teszik a kiosztás szerkesztését, és még más dolgokat is. Ha korábban már testreszabta a vezérlőt, akkor ez a művelet felül fogja azt írni. A Chrysalis által telepíthető vezérlő forrása mindig megtalálható az alábbi címen:`,
-    postUpload: `Amint a frissítés befejeződött, a Chrysalis vissza fogja vinni a billentyűzet választó képernyőre.`,
-    tooling: `A billentyűzet vezérlőjének frissítéséhez külső programra ({0}) van szükség. Kérjük tegye a programot elérhetővé a Chrysalis számára, különben nem fog tudni vezérlő frissítést feltölteni.`
+    postUpload: `Amint a frissítés befejeződött, a Chrysalis vissza fogja vinni a billentyűzet választó képernyőre.`
   },
   welcome: {
     title: "Üdvözöljük!",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -149,7 +149,6 @@ class FirmwareUpdate extends React.Component {
   render() {
     const { classes } = this.props;
     const { firmwareFilename } = this.state;
-    let focus = new Focus();
 
     let filename = null;
     if (firmwareFilename) {
@@ -179,12 +178,6 @@ class FirmwareUpdate extends React.Component {
     } catch (_) {
       hasDefaultFirmware = false;
     }
-
-    const tooling = focus.device && focus.device.flashTool && (
-      <Typography component="p" gutterBottom>
-        {i18n.formatString(i18n.firmwareUpdate.tooling, focus.device.flashTool)}
-      </Typography>
-    );
 
     const firmwareSelect = (
       <FormControl>
@@ -226,7 +219,6 @@ class FirmwareUpdate extends React.Component {
                 Chrysalis-Firmware-Bundle
               </a>
             </Typography>
-            {tooling}
             <Typography component="p" gutterBottom>
               {i18n.firmwareUpdate.postUpload}
             </Typography>

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -19,6 +19,7 @@ import React from "react";
 import Electron from "electron";
 import path from "path";
 import fs from "fs";
+import { version } from "../../../package.json";
 
 import Focus from "@chrysalis-api/focus";
 
@@ -161,6 +162,10 @@ class FirmwareUpdate extends React.Component {
       filename = filename[filename.length - 1];
     }
 
+    const defaultFirmwareItemText = i18n.formatString(
+      i18n.firmwareUpdate.defaultFirmware,
+      version
+    );
     const defaultFirmwareItem = (
       <MenuItem
         selected={firmwareFilename == ""}
@@ -169,7 +174,7 @@ class FirmwareUpdate extends React.Component {
         <ListItemIcon>
           <SettingsBackupRestoreIcon />
         </ListItemIcon>
-        <ListItemText primary={i18n.firmwareUpdate.defaultFirmware} />
+        <ListItemText primary={defaultFirmwareItemText} />
       </MenuItem>
     );
     let hasDefaultFirmware = true;
@@ -180,8 +185,7 @@ class FirmwareUpdate extends React.Component {
     }
 
     const selectedFirmware =
-      filename ||
-      (hasDefaultFirmware ? i18n.firmwareUpdate.defaultFirmware : "");
+      filename || (hasDefaultFirmware ? defaultFirmwareItemText : "");
 
     const tooling = focus.device && focus.device.flashTool && (
       <Typography component="p" gutterBottom>

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -65,6 +65,9 @@ const styles = theme => ({
   custom: {
     marginTop: "auto",
     marginBottom: "auto"
+  },
+  repo: {
+    textAlign: "center"
   }
 });
 
@@ -215,26 +218,17 @@ class FirmwareUpdate extends React.Component {
         </Portal>
         <Card className={classes.card}>
           <CardContent>
-            <Typography variant="h5" component="h2" gutterBottom>
-              {i18n.firmwareUpdate.updatingTitle}
-            </Typography>
             <Typography component="p" gutterBottom>
-              {i18n.formatString(
-                i18n.firmwareUpdate.description,
-                i18n.firmwareUpdate.flashing.button
-              )}
+              {i18n.firmwareUpdate.description}
+            </Typography>
+            <Typography component="p" gutterBottom className={classes.repo}>
+              <a href="https://github.com/keyboardio/Chrysalis-Firmware-Bundle#readme">
+                Chrysalis-Firmware-Bundle
+              </a>
             </Typography>
             {tooling}
             <Typography component="p" gutterBottom>
               {i18n.firmwareUpdate.postUpload}
-            </Typography>
-            <Typography component="p">
-              {i18n.formatString(
-                i18n.firmwareUpdate.repo,
-                <a href="https://github.com/keyboardio/Chrysalis-Firmware-Bundle#readme">
-                  Chrysalis-Firmware-Bundle
-                </a>
-              )}
             </Typography>
           </CardContent>
           <Divider variant="middle" />


### PR DESCRIPTION
![screenshot from 2019-01-18 12-35-28](https://user-images.githubusercontent.com/17243/51384759-98055a80-1b1d-11e9-95bf-3fbbdf225df2.png)
![screenshot from 2019-01-18 12-35-42](https://user-images.githubusercontent.com/17243/51384771-9a67b480-1b1d-11e9-81c2-22dc064ceefb.png)

- The title text is gone, the screen title is sufficient (#222)
- The text has been simplified, pretty much replaced (#222)
- The selector is a dropdown now (#220)
- The default firmware is now better specified and less ambigous (#219)