### PR TITLE
When clearing layers, clear to unspecified instead of zero

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -181,7 +181,7 @@ class ColormapEditor extends React.Component {
       let newMap = state.colorMap.slice();
       newMap[state.currentLayer] = Array(newMap[0].length)
         .fill()
-        .map(() => 0);
+        .map(() => 0xf);
       this.props.startContext();
       return {
         colorMap: newMap,

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -220,7 +220,7 @@ class LayoutEditor extends React.Component {
       let newKeymap = state.keymap.slice();
       newKeymap[state.currentLayer] = Array(newKeymap[0].length)
         .fill()
-        .map(() => ({ keyCode: 0 }));
+        .map(() => ({ keyCode: 0xffff }));
       this.props.startContext();
       return {
         keymap: newKeymap,


### PR DESCRIPTION
When we clear a layer, we want to set it back to its default state with an empty EEPROM, which is all bits set.

Fixes #209.
