### PR TITLE
Editors: Copy layers from, not to

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -80,13 +80,13 @@ const English = {
     },
     defaultLayer: "Default layer",
     clearLayer: "Clear layer...",
-    copyTo: "Copy to layer...",
+    copyFrom: "Copy from layer...",
     dualUse: "Modifier when held, normal key otherwise",
     dualUseLayer: "Layer shift when held, normal key otherwise"
   },
   colormapEditor: {
     clearLayer: "Clear layer...",
-    copyTo: "Copy to layer..."
+    copyFrom: "Copy from layer..."
   },
   settings: {
     devtools: "Developer tools",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -80,13 +80,13 @@ const Hungarian = {
     },
     defaultLayer: "Alapértelmezett réteg",
     clearLayer: "Réteg ürítése...",
-    copyTo: "Réteg másolás...",
+    copyFrom: "Réteg másolás máshonnan...",
     dualUse: "Nyomvatartáskor módosító, normál gomb egyébként",
     dualUseLayer: "Nyomvatartáskor réteg váltó, normál gomb egyébként"
   },
   colormapEditor: {
     clearLayer: "Réteg ürítése...",
-    copyTo: "Réteg másolás..."
+    copyFrom: "Réteg másolás máshonnan..."
   },
   settings: {
     devtools: "Fejlesztői eszközök",

--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -155,22 +155,21 @@ class ColormapEditor extends React.Component {
     this.setState({ moreAnchorEl: null });
   };
 
-  copyToLayerMenu = () => {
+  copyFromLayerMenu = () => {
     this.setState(state => ({
       copyMenuExpanded: !state.copyMenuExpanded
     }));
   };
 
-  copyToLayer = layer => {
+  copyFromLayer = layer => {
     this.setState(state => {
       let newMap = state.colorMap.slice();
-      newMap[layer] = state.colorMap[state.currentLayer].slice();
+      newMap[state.currentLayer] = state.colorMap[layer].slice();
       this.props.startContext();
       return {
         colorMap: newMap,
         copyMenuExpanded: false,
         moreAnchorEl: null,
-        currentLayer: layer,
         modified: true
       };
     });
@@ -226,7 +225,7 @@ class ColormapEditor extends React.Component {
           className={classes.layerItem}
           key={key}
           disabled={index == currentLayer}
-          onClick={() => this.copyToLayer(index)}
+          onClick={() => this.copyFromLayer(index)}
         >
           {label}
         </MenuItem>
@@ -245,9 +244,9 @@ class ColormapEditor extends React.Component {
           <MenuItem onClick={this.clearLayer}>
             {i18n.colormapEditor.clearLayer}
           </MenuItem>
-          <MenuItem onClick={this.copyToLayerMenu}>
+          <MenuItem onClick={this.copyFromLayerMenu}>
             <span style={{ marginRight: "1em" }}>
-              {i18n.colormapEditor.copyTo}
+              {i18n.colormapEditor.copyFrom}
             </span>
             {copyMenuExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </MenuItem>

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -194,22 +194,21 @@ class LayoutEditor extends React.Component {
     this.setState({ moreAnchorEl: null });
   };
 
-  copyToLayerMenu = () => {
+  copyFromLayerMenu = () => {
     this.setState(state => ({
       copyMenuExpanded: !state.copyMenuExpanded
     }));
   };
 
-  copyToLayer = layer => {
+  copyFromLayer = layer => {
     this.setState(state => {
       let newKeymap = state.keymap.slice();
-      newKeymap[layer] = state.keymap[state.currentLayer].slice();
+      newKeymap[state.currentLayer] = state.keymap[layer].slice();
       this.props.startContext();
       return {
         keymap: newKeymap,
         copyMenuExpanded: false,
         moreAnchorEl: null,
-        currentLayer: layer,
         modified: true
       };
     });
@@ -288,14 +287,12 @@ class LayoutEditor extends React.Component {
       const label = i18n.formatString(i18n.components.layer, index),
         key = "copy-layer-" + index.toString();
 
-      if (index < this.state.roLayers) return null;
-
       return (
         <MenuItem
           className={classes.layerItem}
           key={key}
           disabled={index == currentLayer}
-          onClick={() => this.copyToLayer(index)}
+          onClick={() => this.copyFromLayer(index)}
         >
           {label}
         </MenuItem>
@@ -317,9 +314,12 @@ class LayoutEditor extends React.Component {
           >
             {i18n.layoutEditor.clearLayer}
           </MenuItem>
-          <MenuItem onClick={this.copyToLayerMenu}>
+          <MenuItem
+            onClick={this.copyFromLayerMenu}
+            disabled={currentLayer < this.state.roLayers}
+          >
             <span style={{ marginRight: "1em" }}>
-              {i18n.layoutEditor.copyTo}
+              {i18n.layoutEditor.copyFrom}
             </span>
             {copyMenuExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </MenuItem>


### PR DESCRIPTION
Copying layers from another one is a much more straightforward operation than copying to, primarily because we're on the layer to be destroyed when we begin. As such, there's less chance of shooting ourselves in the face.

Fixes #226.
