### PR TITLE
FirmwareUpdate: Disconnect after a successful flash too

### DIFF
--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -141,6 +141,7 @@ class FirmwareUpdate extends React.Component {
         });
 
         this.props.toggleFlashing();
+        this.props.onDisconnect();
         resolve();
       }, 1000);
     });


### PR DESCRIPTION
When done with flashing, either successfully or not, we go back to the keyboard selection screen. At this point, the keyboard should not appear connected, because it really isn't.

This partially addresses #224.
