### PR TITLE
hardware: Add (flashing) support for generic Teensy devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@chrysalis-api/hardware-dygma-raise": "~0.0.4",
     "@chrysalis-api/hardware-ez-ergodox": "~0.0.10",
     "@chrysalis-api/hardware-keyboardio-model01": "~0.0.16",
+    "@chrysalis-api/hardware-pjrc-teensy": "^0.0.1",
     "@chrysalis-api/hardware-technomancy-atreus": "~0.0.11",
     "@chrysalis-api/keymap": "~0.0.13",
     "@material-ui/core": "^3.6.0",

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -47,6 +47,7 @@ import {
 import { Atreus } from "@chrysalis-api/hardware-technomancy-atreus";
 import { Raise } from "@chrysalis-api/hardware-dygma-raise";
 import { ErgoDox } from "@chrysalis-api/hardware-ez-ergodox";
+import { GenericTeensy } from "@chrysalis-api/hardware-pjrc-teensy";
 
 import usb from "usb";
 
@@ -117,7 +118,12 @@ class KeyboardSelect extends React.Component {
 
   findNonSerialKeyboards = deviceList => {
     const devices = usb.getDeviceList().map(device => device.deviceDescriptor);
-    const supportedDevices = [Model01Bootloader, Atreus, ErgoDox];
+    const supportedDevices = [
+      Model01Bootloader,
+      Atreus,
+      ErgoDox,
+      GenericTeensy
+    ];
     devices.forEach(desc => {
       supportedDevices.forEach(device => {
         if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,6 +882,13 @@
     "@chrysalis-api/flash" "^0.0.5"
     react "^16.5.2"
 
+"@chrysalis-api/hardware-pjrc-teensy@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/hardware-pjrc-teensy/-/hardware-pjrc-teensy-0.0.1.tgz#e3dfdd992b7d319d7db556101855d5c150918d19"
+  integrity sha512-6oxEfNoGW51OOK40WxD23plGfQ2pVXS/zFqf7WhVF1LqZpxjYeRJZq9rqyR0wvIHNSeWC5URggIAGHWMYpHh8Q==
+  dependencies:
+    "@chrysalis-api/flash" "^0.0.5"
+
 "@chrysalis-api/hardware-technomancy-atreus@~0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@chrysalis-api/hardware-technomancy-atreus/-/hardware-technomancy-atreus-0.0.11.tgz#86800eb5217baaf5cc9131f820f1f1dd7fad2e89"


### PR DESCRIPTION
![screenshot from 2019-01-19 09-39-48](https://user-images.githubusercontent.com/17243/51424513-2c7bc580-1bcf-11e9-8eda-fb90d24208f1.png)

This is similar in spirit to #241, except it doesn't have a factory firmware, so one will be able - and forced - to select their own, based on what keyboard they have. This allows Chrysalis to flash any Teensy board with any firmware.

We'll have a nice explanation on the firmware update screen, once #221 is in place.