### PR TITLE
FirmwareUpdate: Add support for experimental firmware

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -115,6 +115,9 @@ const English = {
       buttonSuccess: "Updated!"
     },
     defaultFirmware: "Chrysalis {0} default",
+    defaultFirmwareDescription: "Minimal, without bells and whistles",
+    experimentalFirmware: "Chrysalis {0} experimental",
+    experimentalFirmwareDescription: "Experimental, with more plugins enabled",
     selected: "Selected firmware",
     custom: "Custom firmware",
     description: `Updating or "flashing" your keyboard's firmware is how we teach it new tricks. Chrysalis will install a new version of your keyboard's firmware which includes support for customizing the key layout, as well as other features. If you've previously customized your keyboard's firmware, this will overwrite your custom firmware. You can always find the source code of the firmware Chrysalis is installing here:`,

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -115,6 +115,9 @@ const Hungarian = {
       buttonSuccess: "Frissítve!"
     },
     defaultFirmware: "Chrysalis {0} alapértelmezett",
+    defaultFirmwareDescription: "Minimális, extrák nélkül",
+    experimentalFirmware: "Chrysalis {0} kísérleti",
+    experimentalFirmwareDescription: "Experimental, extra kiegészítőkkel",
     selected: "Kiválasztott vezérlő",
     custom: "Egyedi vezérlő",
     description: `A billentyűzet vezérlő frissítésevel tanítjuk új trükkökre. A Chrysalis olyan új vezérlőt fog telepíteni, mely tartalmazza az eszközöket melyek lehetővé teszik a kiosztás szerkesztését, és még más dolgokat is. Ha korábban már testreszabta a vezérlőt, akkor ez a művelet felül fogja azt írni. A Chrysalis által telepíthető vezérlő forrása mindig megtalálható az alábbi címen:`,


### PR DESCRIPTION
We plan to narrow down the scope of the default firmware shipped with Chrysalis to avoid surprises, and to be closer to factory defaults. However, we'd still like to offer something with more bells and whistles - an experimental firmware.

Teach FirmwareUpdate to handle both, along with custom firmware.

![screenshot from 2019-01-20 22-22-26](https://user-images.githubusercontent.com/17243/51445268-854c7a80-1d03-11e9-8e88-f89eb5c31fd2.png)
