### PR TITLE
LayoutEditor: Update for the default/custom split

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@chrysalis-api/colormap": "~0.0.7",
     "@chrysalis-api/focus": "~0.0.8",
     "@chrysalis-api/hardware": "^0.0.2",
-    "@chrysalis-api/keymap": "~0.0.14",
+    "@chrysalis-api/keymap": "~0.0.15",
     "@material-ui/core": "^3.9.1",
     "@material-ui/icons": "^3.0.1",
     "@material-ui/lab": "^3.0.0-alpha.29",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -188,12 +188,12 @@ class App extends React.Component {
       connected: true,
       device: null,
       pages: {
-        keymap: commands.includes("keymap.map") > 0,
+        keymap: commands.includes("keymap.custom") > 0,
         colormap:
           commands.includes("colormap.map") > 0 &&
           commands.includes("palette") > 0
       },
-      Page: commands.includes("keymap.map") > 0 ? LayoutEditor : Welcome
+      Page: commands.includes("keymap.custom") > 0 ? LayoutEditor : Welcome
     });
   };
 

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -78,6 +78,7 @@ const English = {
       Blank: "Blank",
       "Unknown keycodes": "Unknown keycodes"
     },
+    useCustom: "Use custom layers only",
     defaultLayer: "Default layer",
     clearLayer: "Clear layer...",
     copyFrom: "Copy from layer...",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -78,6 +78,7 @@ const Hungarian = {
       Blank: "Üres gombok",
       "Unknown keycodes": "Ismeretlen kódok"
     },
+    useCustom: "Kizárólag testreszabott rétegek használata",
     defaultLayer: "Alapértelmezett réteg",
     clearLayer: "Réteg ürítése...",
     copyFrom: "Réteg másolás máshonnan...",

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,10 +820,10 @@
     "@chrysalis-api/hardware-pjrc-teensy" "^0.0.3"
     "@chrysalis-api/hardware-technomancy-atreus" "^0.0.12"
 
-"@chrysalis-api/keymap@~0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.14.tgz#b12557a793e6ac2a656904f165f6a16b58d31832"
-  integrity sha512-JqTG29MBPlgzwOFf7N/qOnk9nouFQwIQrM9LjsW/u5mceybnZ+dD5/dOcOAR1hysYqCwK29Vg1feUDPp+T7czg==
+"@chrysalis-api/keymap@~0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.15.tgz#a141a36840b09ff2a3867e46b7f65d2e3095bcc9"
+  integrity sha512-nvgEFONCBC18P7d9S9K0eUzqUmPhkYkY0SLPg5Y8TjHgoecqoDGmXIm+L9wfgQOKEE7V7HcZ6/eDTaURYtbixw==
   dependencies:
     "@chrysalis-api/focus" "~0.0.8"
 
@@ -2133,9 +2133,9 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-"browser-serialport@git+https://github.com/noopkat/browser-serialport.git#c8628c41c11890d3058875994c15f83f2df8185b":
+"browser-serialport@https://github.com/noopkat/browser-serialport#c8628c41c11890d3058875994c15f83f2df8185b":
   version "2.0.3"
-  resolved "git+https://github.com/noopkat/browser-serialport.git#c8628c41c11890d3058875994c15f83f2df8185b"
+  resolved "https://github.com/noopkat/browser-serialport#c8628c41c11890d3058875994c15f83f2df8185b"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
This is a major update to the LayoutEditor, which updates it to support the default/custom split on the protocol level. While there, added the option to hide default layers, and to set the `keymap.onlyCustom` flag too.

We also copy the default layers into EEPROM and toggle onlyCustom on if we see that the EEPROM layers are all transparent.

Fixes #228.

See screenshots [here](https://github.com/keyboardio/Chrysalis/issues/228#issuecomment-457874928)