### PR TITLE
LayoutEditor update to support legacy firmware

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     }
   },
   "dependencies": {
-    "@chrysalis-api/colormap": "~0.0.7",
+    "@chrysalis-api/colormap": "^0.0.7",
     "@chrysalis-api/focus": "^0.0.9",
     "@chrysalis-api/hardware": "^0.0.2",
-    "@chrysalis-api/keymap": "~0.0.15",
+    "@chrysalis-api/keymap": "^0.0.16",
     "@material-ui/core": "^3.9.1",
     "@material-ui/icons": "^3.0.1",
     "@material-ui/lab": "^3.0.0-alpha.29",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -188,12 +188,18 @@ class App extends React.Component {
       connected: true,
       device: null,
       pages: {
-        keymap: commands.includes("keymap.custom") > 0,
+        keymap:
+          commands.includes("keymap.custom") > 0 ||
+          commands.includes("keymap.map") > 0,
         colormap:
           commands.includes("colormap.map") > 0 &&
           commands.includes("palette") > 0
       },
-      Page: commands.includes("keymap.custom") > 0 ? LayoutEditor : Welcome
+      Page:
+        commands.includes("keymap.custom") > 0 ||
+        commands.includes("keymap.map") > 0
+          ? LayoutEditor
+          : Welcome
     });
   };
 

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -146,12 +146,20 @@ class LayoutEditor extends React.Component {
     let layer = parseInt(this.state.currentLayer),
       keyIndex = parseInt(this.state.currentKeyIndex);
 
-    if (layer < 0) {
-      layer += this.state.keymap.default.length;
-      return this.state.keymap.default[layer][keyIndex].keyCode;
-    }
+    if (this.state.keymap.useCustom) {
+      if (layer < 0) {
+        layer += this.state.keymap.default.length;
+        return this.state.keymap.default[layer][keyIndex].keyCode;
+      }
 
-    return this.state.keymap.custom[layer][keyIndex].keyCode;
+      return this.state.keymap.custom[layer][keyIndex].keyCode;
+    } else {
+      const offset = this.state.keymap.default.length;
+      if (layer < this.state.keymap.default.length)
+        return this.state.keymap.default[layer][keyIndex].keyCode;
+
+      return this.state.keymap.custom[layer - offset][keyIndex].keyCode;
+    }
   }
 
   onKeyChange = keyCode => {
@@ -166,7 +174,10 @@ class LayoutEditor extends React.Component {
 
     this.setState(state => {
       let keymap = state.keymap.custom.slice();
-      keymap[layer][keyIndex] = this.keymapDB.parse(keyCode);
+      const l = state.keymap.useCustom
+        ? layer
+        : layer - state.keymap.default.length;
+      keymap[l][keyIndex] = this.keymapDB.parse(keyCode);
       return {
         keymap: {
           default: state.keymap.default,

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -225,7 +225,7 @@ class LayoutEditor extends React.Component {
   };
 
   onDefaultLayerChange = async event => {
-    const defLayer = event.target.checked ? event.target.value : 127;
+    const defLayer = event.target.checked ? event.target.value : 126;
     this.setState({
       defaultLayer: defLayer
     });
@@ -237,7 +237,7 @@ class LayoutEditor extends React.Component {
   componentDidMount() {
     this.scanKeyboard().then(() => {
       this.setState(state => ({
-        currentLayer: state.defaultLayer == 127 ? 0 : state.defaultLayer
+        currentLayer: state.defaultLayer >= 126 ? 0 : state.defaultLayer
       }));
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,7 +741,7 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@chrysalis-api/colormap@~0.0.7":
+"@chrysalis-api/colormap@^0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@chrysalis-api/colormap/-/colormap-0.0.7.tgz#807d3907010c6c78153b7b82445fe3e9df90dd77"
   integrity sha512-EF1mKojhFWT4G9uwh0C2wy4kJbEWpuNssvWE5x4bKAN/3ndZQMva4sfK3AhhspqeaG5Kn5Z8hpsKin2gnSP1JQ==
@@ -827,10 +827,10 @@
     "@chrysalis-api/hardware-pjrc-teensy" "^0.0.3"
     "@chrysalis-api/hardware-technomancy-atreus" "^0.0.12"
 
-"@chrysalis-api/keymap@~0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.15.tgz#a141a36840b09ff2a3867e46b7f65d2e3095bcc9"
-  integrity sha512-nvgEFONCBC18P7d9S9K0eUzqUmPhkYkY0SLPg5Y8TjHgoecqoDGmXIm+L9wfgQOKEE7V7HcZ6/eDTaURYtbixw==
+"@chrysalis-api/keymap@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.16.tgz#1ecb3c57bbe15dfc5575a609b22538859021f163"
+  integrity sha512-kHlIQwZTmPosn/x9ieC/YvLFvYDymYGcg3o2nQwmkdybVRrM1hs3qgVxqHLVg2NV67FQLvA6iQYxUIEn8Zr5yw==
   dependencies:
     "@chrysalis-api/focus" "~0.0.8"
 


### PR DESCRIPTION
This fixes a few issues with `LayoutEditor`, in case we aren't using `keymap.onlyCustom` (affects both legacy and current firmware). It also updates the `@chrysalis-api/keymap` library (which supports legacy firmware now). A few checks were also updated to allow displaying the layout editor even when the keyboard runs an older firmware.

Fixes #271.