### PR TITLE
tools/s3-upload: Redirect Chrysalis/latest/Chrysalis.*

### DIFF
--- a/tools/s3-upload.js
+++ b/tools/s3-upload.js
@@ -37,6 +37,13 @@ fileStream.on("open", () => {
       throw error;
     }
     if (data) {
+      s3.putObject({
+        Key: "Chrysalis/latest/Chrysalis." + extensions[process.env['TRAVIS_OS_NAME']],
+        WebsiteRedirectLocation: data.Location
+      }, error => {
+        if (error)
+          throw error;
+      });
       console.log("  ", data.Location)
     }
   });


### PR DESCRIPTION
On a successful upload, redirect `Chrysalis/latest/Chrysalis.$EXTENSION` to the current upload. This gives us a static URL that always points to the latest artifact.
