### PR TITLE
KeyboardSelect: Support devices that share the same VID+PID

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@chrysalis-api/colormap": "~0.0.7",
-    "@chrysalis-api/focus": "~0.0.8",
+    "@chrysalis-api/focus": "^0.0.9",
     "@chrysalis-api/hardware": "^0.0.2",
     "@chrysalis-api/keymap": "~0.0.15",
     "@material-ui/core": "^3.9.1",

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -312,9 +312,9 @@ class KeyboardSelect extends React.Component {
     const selectedDevice = devices && devices[this.state.selectedPortIndex];
 
     if (
-      focus._port &&
+      focus.device &&
       selectedDevice &&
-      selectedDevice.comName == focus._port.path
+      selectedDevice.device == focus.device
     ) {
       connectionButton = (
         <Button

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,6 +756,13 @@
     avrgirl-arduino "^3.0.0"
     teensy-loader "^0.1.1"
 
+"@chrysalis-api/focus@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/focus/-/focus-0.0.9.tgz#5ac1ee6a7936f9493a66d785d09d5e268b5e9f8e"
+  integrity sha512-/mSGoNmQ0jHf87bAOtgLtNexmHKunbJoLxRd/ZESkJBuNQGw8NC+AMIUuBTlbLIe7MQX1wtUgPXVHaX/zU6AaQ==
+  dependencies:
+    serialport "^6.2.2"
+
 "@chrysalis-api/focus@~0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@chrysalis-api/focus/-/focus-0.0.8.tgz#9312caba321d33c27ea1a7cca65b9b1081c5192d"


### PR DESCRIPTION
There are keyboards out there that share VID+PID with another. Instead of trying to choose one, or autodetect which one we have, place both onto the list, and let the end-user select the right one.

This requires an update to `@chrysalis-api/focus`, to a version that supports this case too.

![screenshot from 2019-02-03 14-34-00](https://user-images.githubusercontent.com/17243/52177424-cabb7e00-27c0-11e9-9861-1f7584b772b1.png)
