### PR TITLE
travis: Disable filter_secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ os:
   - linux
   - osx
   - windows
+# This (filter_secrets) is generally unsafe, but we only run builds for master,
+# so it is acceptable. If we remove the branch restriction, remove this too.
+# If Windows builds on Travis are fixed, and work when secrets are in use,
+# remove this too.
+filter_secrets: false
 matrix:
   allow_failures:
     - os: windows


### PR DESCRIPTION
Disable `filter_secrets`, which hopefully makes our windows builds work. In general, this wouldn't be a safe thing, because a malicious pull request could leak our secrets. But we only run builds for master, not for pull requests or any other branch, so what we do is well controlled, and shouldn't leak any.
