### PR TITLE
Move a few less-than-common settings from LayoutEditor to Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@material-ui/lab": "^3.0.0-alpha.29",
     "classnames": "^2.2.6",
     "electron-devtools-installer": "^2.2.4",
+    "electron-settings": "^3.2.0",
     "notistack": "^0.4.0",
     "prop-types": "^15.6.2",
     "react": "16.8.0-alpha.1",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -78,8 +78,6 @@ const English = {
       Blank: "Blank",
       "Unknown keycodes": "Unknown keycodes"
     },
-    useCustom: "Use custom layers only",
-    defaultLayer: "Default layer",
     clearLayer: "Clear layer...",
     copyFrom: "Copy from layer...",
     dualUse: "Modifier when held, normal key otherwise",
@@ -93,7 +91,14 @@ const English = {
     devtools: "Developer tools",
     language: "Language",
     interface: "Interface",
-    advanced: "Advanced"
+    advanced: "Advanced",
+    keymap: {
+      title: "Keymap settings",
+      noDefault: "No default",
+      showDefaults: "Show default layers",
+      onlyCustom: "Use custom layers only",
+      defaultLayer: "Default layer"
+    }
   },
   keyboardSelect: {
     unknown: "Unknown",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -78,8 +78,6 @@ const Hungarian = {
       Blank: "Üres gombok",
       "Unknown keycodes": "Ismeretlen kódok"
     },
-    useCustom: "Kizárólag testreszabott rétegek használata",
-    defaultLayer: "Alapértelmezett réteg",
     clearLayer: "Réteg ürítése...",
     copyFrom: "Réteg másolás máshonnan...",
     dualUse: "Nyomvatartáskor módosító, normál gomb egyébként",
@@ -93,7 +91,14 @@ const Hungarian = {
     devtools: "Fejlesztői eszközök",
     language: "Nyelv",
     interface: "Felhasználói felület",
-    advanced: "Haladó beállítások"
+    advanced: "Haladó beállítások",
+    keymap: {
+      title: "Kiosztás beállításai",
+      noDefault: "Nincs alapértelmezett réteg",
+      showDefaults: "Beépített rétegek mutatása",
+      onlyCustom: "Kizárólag testreszabott rétegek használata",
+      defaultLayer: "Alapértelmezett réteg"
+    }
   },
   keyboardSelect: {
     unknown: "Ismeretlen",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,6 +2687,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3747,6 +3752,14 @@ electron-publish@20.38.5:
     fs-extra-p "^7.0.0"
     lazy-val "^1.0.3"
     mime "^2.4.0"
+
+electron-settings@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/electron-settings/-/electron-settings-3.2.0.tgz#01461e153f95b6f18adbe0c360c70898eb0f43c3"
+  integrity sha512-7U+vDKd5Gch4Z9K6FjGq80eB3Anwz2GuPc2h/6hOiuvZrS1w+UNPcAA0oAU8G1s9sWAVEadCsr4ZJR6J4iTdzA==
+  dependencies:
+    clone "^2.1.1"
+    jsonfile "^4.0.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.103:
   version "1.3.108"


### PR DESCRIPTION
Now that we copy the built-in layers to EEPROM when we encounter an uninitialized EEPROM, having the default layer selector on the layer bar is not needed. Moved it to the Settings page. Fixes #288.

Similarly, selecting whether to use custom layers only or not belongs in Settings too. Fixes #286.

Likewise, whether to show or hide the default / built-in layers is also a setting, and belongs there. Since this is not saved on the keyboard, but we want to persist the setting, we're using `electron-settings` to store the setting on disk. Fixes #287 and fixes #277.

The moved settings do not take effect immediately like they used to, one needs to use the new "Save changes" button on the page. Fixes #285.

This also fixes #194, due to having figured out how to store settings.