### PR TITLE
Split "Keyboard settings" out of "Settings"

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -37,6 +37,7 @@ import FirmwareUpdate from "./screens/FirmwareUpdate";
 import LayoutEditor from "./screens/LayoutEditor";
 import Preferences from "./screens/Preferences";
 import Welcome from "./screens/Welcome";
+import KeyboardSettings from "./screens/KeyboardSettings";
 import i18n from "./i18n";
 
 import Header from "./components/Header";
@@ -231,6 +232,10 @@ class App extends React.Component {
                 device={this.state.device}
                 toggleFlashing={this.toggleFlashing}
                 onDisconnect={this.onKeyboardDisconnect}
+                titleElement={() => document.querySelector("#page-title")}
+              />
+              <KeyboardSettings
+                path="/keyboard-settings"
                 titleElement={() => document.querySelector("#page-title")}
               />
               <Preferences

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -35,7 +35,7 @@ import KeyboardSelect from "./screens/KeyboardSelect";
 import ColormapEditor from "./screens/ColormapEditor";
 import FirmwareUpdate from "./screens/FirmwareUpdate";
 import LayoutEditor from "./screens/LayoutEditor";
-import Settings from "./screens/Settings";
+import Preferences from "./screens/Preferences";
 import Welcome from "./screens/Welcome";
 import i18n from "./i18n";
 
@@ -233,8 +233,8 @@ class App extends React.Component {
                 onDisconnect={this.onKeyboardDisconnect}
                 titleElement={() => document.querySelector("#page-title")}
               />
-              <Settings
-                path="/settings"
+              <Preferences
+                path="/preferences"
                 titleElement={() => document.querySelector("#page-title")}
               />
             </Router>

--- a/src/renderer/components/MainMenu/ChatMenuItem.js
+++ b/src/renderer/components/MainMenu/ChatMenuItem.js
@@ -22,9 +22,9 @@ import ListItemText from "@material-ui/core/ListItemText";
 import ChatIcon from "@material-ui/icons/Chat";
 import i18n from "../../i18n";
 
-export default function ChatMenuItem({ onClick }) {
+export default function ChatMenuItem({ onClick, className }) {
   return (
-    <ListItem button onClick={onClick}>
+    <ListItem button onClick={onClick} className={className}>
       <ListItemIcon>
         <ChatIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/ColormapMenuItem.js
+++ b/src/renderer/components/MainMenu/ColormapMenuItem.js
@@ -22,9 +22,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 import HighlightIcon from "@material-ui/icons/Highlight";
 import i18n from "../../i18n";
 
-export default function ColormapMenuItem({ selected, onClick }) {
+export default function ColormapMenuItem({ selected, onClick, className }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <HighlightIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/ExitMenuItem.js
+++ b/src/renderer/components/MainMenu/ExitMenuItem.js
@@ -22,9 +22,9 @@ import ListItemText from "@material-ui/core/ListItemText";
 import ExitToAppIcon from "@material-ui/icons/ExitToApp";
 import i18n from "../../i18n";
 
-export default function ExitMenuItem({ onClick }) {
+export default function ExitMenuItem({ onClick, className }) {
   return (
-    <ListItem button onClick={onClick}>
+    <ListItem button onClick={onClick} className={className}>
       <ListItemIcon>
         <ExitToAppIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/FeedbackMenuItem.js
+++ b/src/renderer/components/MainMenu/FeedbackMenuItem.js
@@ -22,9 +22,9 @@ import ListItemText from "@material-ui/core/ListItemText";
 import FeedbackIcon from "@material-ui/icons/Feedback";
 import i18n from "../../i18n";
 
-export default function FeedbackMenuItem({ onClick }) {
+export default function FeedbackMenuItem({ onClick, className }) {
   return (
-    <ListItem button onClick={onClick}>
+    <ListItem button onClick={onClick} className={className}>
       <ListItemIcon>
         <FeedbackIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/FlashMenuItem.js
+++ b/src/renderer/components/MainMenu/FlashMenuItem.js
@@ -22,9 +22,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import i18n from "../../i18n";
 
-export default function FlashMenuItem({ selected, onClick }) {
+export default function FlashMenuItem({ selected, onClick, className }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <CloudUploadIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/KeyboardSelectMenuItem.js
+++ b/src/renderer/components/MainMenu/KeyboardSelectMenuItem.js
@@ -24,10 +24,16 @@ import KeyboardIcon from "@material-ui/icons/Keyboard";
 export default function KeyboardMenuItem({
   keyboardSelectText,
   selected,
-  onClick
+  onClick,
+  className
 }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <KeyboardIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/KeyboardSettingsMenuItem.js
+++ b/src/renderer/components/MainMenu/KeyboardSettingsMenuItem.js
@@ -1,0 +1,43 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+import USBIcon from "@material-ui/icons/Usb";
+import i18n from "../../i18n";
+
+export default function KeyboardSettingsMenuItem({
+  selected,
+  onClick,
+  className
+}) {
+  return (
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
+      <ListItemIcon>
+        <USBIcon />
+      </ListItemIcon>
+      <ListItemText primary={i18n.app.menu.keyboardSettings} />
+    </ListItem>
+  );
+}

--- a/src/renderer/components/MainMenu/KeymapMenuItem.js
+++ b/src/renderer/components/MainMenu/KeymapMenuItem.js
@@ -22,9 +22,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
 import i18n from "../../i18n";
 
-export default function KeymapMenuItem({ selected, onClick }) {
+export default function KeymapMenuItem({ selected, onClick, className }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <KeyboardIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -41,6 +41,7 @@ import FeedbackMenuItem from "./FeedbackMenuItem";
 import ExitMenuItem from "./ExitMenuItem";
 import KeyboardMenuItem from "./KeyboardSelectMenuItem";
 import PreferencesMenuItem from "./PreferencesMenuItem";
+import KeyboardSettingsMenuItem from "./KeyboardSettingsMenuItem";
 import openURL from "../../utils/openURL";
 
 const styles = theme => ({
@@ -129,11 +130,18 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
                 />
               </Link>
             )}
-            <Link to="firmware-update" className={classes.link}>
+            <Link to="/firmware-update" className={classes.link}>
               <FlashMenuItem
-                selected={currentPage == "firmware-update"}
+                selected={currentPage == "/firmware-update"}
                 className={classes.menuItem}
-                onClick={() => setCurrentPage("firmware-update")}
+                onClick={() => setCurrentPage("/firmware-update")}
+              />
+            </Link>
+            <Link to="/keyboard-settings" className={classes.link}>
+              <KeyboardSettingsMenuItem
+                selected={currentPage == "/keyboard-settings"}
+                className={classes.menuItem}
+                onClick={() => setCurrentPage("/keyboard-settings")}
               />
             </Link>
           </List>

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -40,7 +40,7 @@ import ChatMenuItem from "./ChatMenuItem";
 import FeedbackMenuItem from "./FeedbackMenuItem";
 import ExitMenuItem from "./ExitMenuItem";
 import KeyboardMenuItem from "./KeyboardSelectMenuItem";
-import SettingsMenuItem from "./SettingsMenuItem";
+import PreferencesMenuItem from "./PreferencesMenuItem";
 import openURL from "../../utils/openURL";
 
 const styles = theme => ({
@@ -159,11 +159,11 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
               onClick={() => setCurrentPage("/keyboard-select")}
             />
           </Link>
-          <Link to="/settings" className={classes.link}>
-            <SettingsMenuItem
+          <Link to="/preferences" className={classes.link}>
+            <PreferencesMenuItem
               className={classes.menuItem}
-              selected={currentPage == "/settings"}
-              onClick={() => setCurrentPage("/settings")}
+              selected={currentPage == "/preferences"}
+              onClick={() => setCurrentPage("/preferences")}
             />
           </Link>
         </List>

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -25,6 +25,7 @@ import IconButton from "@material-ui/core/IconButton";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
+import ListSubheader from "@material-ui/core/ListSubheader";
 import { withStyles } from "@material-ui/core/styles";
 
 import logo from "../../logo-small.png";
@@ -58,6 +59,9 @@ const styles = theme => ({
   },
   link: {
     textDecoration: "none"
+  },
+  menuItem: {
+    paddingLeft: theme.spacing.unit * 4
   }
 });
 
@@ -84,49 +88,68 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
             </IconButton>
           </Link>
         </div>
-        <List className={classes.drawer}>
-          {connected && !pages.keymap && !pages.colormap && (
-            <Link to="/welcome" className={classes.link}>
-              <WelcomeMenu
-                selected={currentPage == "/welcome"}
-                onClick={() => setCurrentPage("/welcome")}
-              />
-            </Link>
-          )}
-          {pages.keymap && (
-            <Link
-              to="/layout-editor"
-              style={{
-                textDecoration: "none"
-              }}
-            >
-              <KeymapMenuItem
-                selected={currentPage == "/layout-editor"}
-                onClick={() => setCurrentPage("/layout-editor")}
-              />
-            </Link>
-          )}
-          {pages.colormap && (
-            <Link to="/colormap-editor" className={classes.link}>
-              <ColormapMenuItem
-                selected={currentPage == "/colormap-editor"}
-                onClick={() => setCurrentPage("/colormap-editor")}
-              />
-            </Link>
-          )}
-          {connected && (
+        {connected && (
+          <List
+            className={classes.drawer}
+            subheader={
+              <ListSubheader disableSticky>
+                {i18n.app.menu.keyboardSection}
+              </ListSubheader>
+            }
+          >
+            {!pages.keymap && !pages.colormap && (
+              <Link to="/welcome" className={classes.link}>
+                <WelcomeMenu
+                  selected={currentPage == "/welcome"}
+                  className={classes.menuItem}
+                  onClick={() => setCurrentPage("/welcome")}
+                />
+              </Link>
+            )}
+            {pages.keymap && (
+              <Link
+                to="/layout-editor"
+                style={{
+                  textDecoration: "none"
+                }}
+              >
+                <KeymapMenuItem
+                  selected={currentPage == "/layout-editor"}
+                  className={classes.menuItem}
+                  onClick={() => setCurrentPage("/layout-editor")}
+                />
+              </Link>
+            )}
+            {pages.colormap && (
+              <Link to="/colormap-editor" className={classes.link}>
+                <ColormapMenuItem
+                  selected={currentPage == "/colormap-editor"}
+                  className={classes.menuItem}
+                  onClick={() => setCurrentPage("/colormap-editor")}
+                />
+              </Link>
+            )}
             <Link to="firmware-update" className={classes.link}>
               <FlashMenuItem
                 selected={currentPage == "firmware-update"}
+                className={classes.menuItem}
                 onClick={() => setCurrentPage("firmware-update")}
               />
             </Link>
-          )}
-        </List>
-        <Divider />
-        <List className={classes.drawer}>
+          </List>
+        )}
+        {connected && <Divider />}
+        <List
+          className={classes.drawer}
+          subheader={
+            <ListSubheader disableSticky>
+              {i18n.app.menu.chrysalisSection}
+            </ListSubheader>
+          }
+        >
           <Link to="/keyboard-select" className={classes.link}>
             <KeyboardMenuItem
+              className={classes.menuItem}
               keyboardSelectText={
                 connected
                   ? i18n.app.menu.selectAnotherKeyboard
@@ -138,18 +161,33 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
           </Link>
           <Link to="/settings" className={classes.link}>
             <SettingsMenuItem
+              className={classes.menuItem}
               selected={currentPage == "/settings"}
               onClick={() => setCurrentPage("/settings")}
             />
           </Link>
         </List>
         <Divider />
-        <List className={classes.drawer}>
-          <ChatMenuItem onClick={openURL("https://discord.gg/GP473Fv")} />
+        <List
+          className={classes.drawer}
+          subheader={
+            <ListSubheader disableSticky>
+              {i18n.app.menu.miscSection}
+            </ListSubheader>
+          }
+        >
+          <ChatMenuItem
+            className={classes.menuItem}
+            onClick={openURL("https://discord.gg/GP473Fv")}
+          />
           <FeedbackMenuItem
+            className={classes.menuItem}
             onClick={openURL("https://github.com/keyboardio/Chrysalis/issues")}
           />
-          <ExitMenuItem onClick={() => Electron.remote.app.exit(0)} />
+          <ExitMenuItem
+            className={classes.menuItem}
+            onClick={() => Electron.remote.app.exit(0)}
+          />
         </List>
         <Divider />
         <List>

--- a/src/renderer/components/MainMenu/PreferencesMenuItem.js
+++ b/src/renderer/components/MainMenu/PreferencesMenuItem.js
@@ -22,7 +22,7 @@ import ListItemText from "@material-ui/core/ListItemText";
 import SettingsIcon from "@material-ui/icons/Settings";
 import i18n from "../../i18n";
 
-export default function SettingsMenuItem({ selected, onClick, className }) {
+export default function PreferencesMenuItem({ selected, onClick, className }) {
   return (
     <ListItem
       button
@@ -33,7 +33,7 @@ export default function SettingsMenuItem({ selected, onClick, className }) {
       <ListItemIcon>
         <SettingsIcon />
       </ListItemIcon>
-      <ListItemText primary={i18n.app.menu.settings} />
+      <ListItemText primary={i18n.app.menu.preferences} />
     </ListItem>
   );
 }

--- a/src/renderer/components/MainMenu/SettingsMenuItem.js
+++ b/src/renderer/components/MainMenu/SettingsMenuItem.js
@@ -22,9 +22,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 import SettingsIcon from "@material-ui/icons/Settings";
 import i18n from "../../i18n";
 
-export default function SettingsMenuItem({ selected, onClick }) {
+export default function SettingsMenuItem({ selected, onClick, className }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <SettingsIcon />
       </ListItemIcon>

--- a/src/renderer/components/MainMenu/WelcomeMenu.js
+++ b/src/renderer/components/MainMenu/WelcomeMenu.js
@@ -22,9 +22,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 import InfoIcon from "@material-ui/icons/Info";
 import i18n from "../../i18n";
 
-export default function WelcomeMenu({ selected, onClick }) {
+export default function WelcomeMenu({ selected, onClick, className }) {
   return (
-    <ListItem button selected={selected} onClick={onClick}>
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
       <ListItemIcon>
         <InfoIcon />
       </ListItemIcon>

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -34,7 +34,7 @@ const English = {
       layoutEditor: "Layout Editor",
       colormapEditor: "Colormap Editor",
       firmwareUpdate: "Firmware Update",
-      settings: "Settings",
+      preferences: "Preferences",
       selectAKeyboard: "Select a keyboard",
       selectAnotherKeyboard: "Select another keyboard",
       chat: "Real-time chat",
@@ -90,7 +90,7 @@ const English = {
     clearLayer: "Clear layer...",
     copyFrom: "Copy from layer..."
   },
-  settings: {
+  preferences: {
     devtools: "Developer tools",
     language: "Language",
     interface: "Interface",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -39,7 +39,10 @@ const English = {
       selectAnotherKeyboard: "Select another keyboard",
       chat: "Real-time chat",
       feedback: "Send feedback",
-      exit: "Exit Chrysalis"
+      exit: "Exit Chrysalis",
+      keyboardSection: "Keyboard",
+      chrysalisSection: "Chrysalis",
+      miscSection: "Miscellaneous"
     },
     deviceMenu: {
       Homepage: "Homepage",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -34,6 +34,7 @@ const English = {
       layoutEditor: "Layout Editor",
       colormapEditor: "Colormap Editor",
       firmwareUpdate: "Firmware Update",
+      keyboardSettings: "Keyboard Settings",
       preferences: "Preferences",
       selectAKeyboard: "Select a keyboard",
       selectAnotherKeyboard: "Select another keyboard",
@@ -94,6 +95,9 @@ const English = {
     devtools: "Developer tools",
     language: "Language",
     interface: "Interface",
+    advanced: "Advanced"
+  },
+  keyboardSettings: {
     advanced: "Advanced",
     keymap: {
       title: "Keymap settings",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -102,7 +102,7 @@ const English = {
     keymap: {
       title: "Keymap settings",
       noDefault: "No default",
-      showDefaults: "Show default layers",
+      showHardcoded: "Show hardcoded layers",
       onlyCustom: "Use custom layers only",
       defaultLayer: "Default layer"
     }

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -39,7 +39,10 @@ const Hungarian = {
       selectAnotherKeyboard: "Másik billentyűzet választás",
       chat: "Csevegőszoba",
       feedback: "Visszajelzés küldése",
-      exit: "Kilépés"
+      exit: "Kilépés",
+      keyboardSection: "Billentyűzet",
+      chrysalisSection: "Chrysalis",
+      miscSection: "Egyéb"
     },
     deviceMenu: {
       Homepage: "Honlap",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -34,6 +34,7 @@ const Hungarian = {
       layoutEditor: "Kiosztás szerkesztő",
       colormapEditor: "Színtérkép szerkesztő",
       firmwareUpdate: "Vezérlő frissítés",
+      keyboardSettings: "Billentyűzet beállítások",
       preferences: "Beállítások",
       selectAKeyboard: "Billentyűzet választás",
       selectAnotherKeyboard: "Másik billentyűzet választás",
@@ -94,6 +95,9 @@ const Hungarian = {
     devtools: "Fejlesztői eszközök",
     language: "Nyelv",
     interface: "Felhasználói felület",
+    advanced: "Haladó beállítások"
+  },
+  keyboardSettings: {
     advanced: "Haladó beállítások",
     keymap: {
       title: "Kiosztás beállításai",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -34,7 +34,7 @@ const Hungarian = {
       layoutEditor: "Kiosztás szerkesztő",
       colormapEditor: "Színtérkép szerkesztő",
       firmwareUpdate: "Vezérlő frissítés",
-      settings: "Beállítások",
+      preferences: "Beállítások",
       selectAKeyboard: "Billentyűzet választás",
       selectAnotherKeyboard: "Másik billentyűzet választás",
       chat: "Csevegőszoba",
@@ -90,7 +90,7 @@ const Hungarian = {
     clearLayer: "Réteg ürítése...",
     copyFrom: "Réteg másolás máshonnan..."
   },
-  settings: {
+  preferences: {
     devtools: "Fejlesztői eszközök",
     language: "Nyelv",
     interface: "Felhasználói felület",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -102,7 +102,7 @@ const Hungarian = {
     keymap: {
       title: "Kiosztás beállításai",
       noDefault: "Nincs alapértelmezett réteg",
-      showDefaults: "Beépített rétegek mutatása",
+      showHardcoded: "Beépített rétegek mutatása",
       onlyCustom: "Kizárólag testreszabott rétegek használata",
       defaultLayer: "Alapértelmezett réteg"
     }

--- a/src/renderer/screens/KeyboardSettings.js
+++ b/src/renderer/screens/KeyboardSettings.js
@@ -232,7 +232,7 @@ class KeyboardSettings extends React.Component {
                   control={showDefaultLayersSwitch}
                   classes={{ label: classes.grow }}
                   labelPlacement="start"
-                  label={i18n.keyboardSettings.keymap.showDefaults}
+                  label={i18n.keyboardSettings.keymap.showHardcoded}
                 />
                 <Divider />
                 <FormControlLabel

--- a/src/renderer/screens/KeyboardSettings.js
+++ b/src/renderer/screens/KeyboardSettings.js
@@ -1,0 +1,274 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
+import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import Collapse from "@material-ui/core/Collapse";
+import Divider from "@material-ui/core/Divider";
+import FilledInput from "@material-ui/core/FilledInput";
+import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Portal from "@material-ui/core/Portal";
+import Select from "@material-ui/core/Select";
+import Switch from "@material-ui/core/Switch";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+
+import Focus from "@chrysalis-api/focus";
+
+import SaveChangesButton from "../components/SaveChangesButton";
+import i18n from "../i18n";
+
+import settings from "electron-settings";
+
+const styles = theme => ({
+  root: {
+    ...theme.mixins.gutters(),
+    paddingTop: theme.spacing.unit * 2,
+    paddingBottom: theme.spacing.unit * 2,
+    margin: `0px ${theme.spacing.unit * 8}px`
+  },
+  title: {
+    marginTop: theme.spacing.unit * 4,
+    marginBottom: theme.spacing.unit
+  },
+  control: {
+    display: "flex",
+    marginRight: theme.spacing.unit * 2
+  },
+  group: {
+    display: "block"
+  },
+  grow: {
+    flexGrow: 1
+  },
+  flex: {
+    display: "flex"
+  },
+  select: {
+    paddingTop: theme.spacing.unit * 1,
+    width: 200
+  },
+  advanced: {
+    display: "flex",
+    justifyContent: "center",
+    marginTop: theme.spacing.unit * 4,
+    "& button": {
+      textTransform: "none",
+      "& span svg": {
+        marginLeft: "1.5em"
+      }
+    }
+  }
+});
+
+class KeyboardSettings extends React.Component {
+  state = {
+    advanced: true,
+    keymap: {
+      custom: [],
+      default: [],
+      onlyCustom: false
+    },
+    defaultLayer: 126,
+    modified: false,
+    showDefaults: false
+  };
+
+  componentDidMount() {
+    const focus = new Focus();
+    focus.command("keymap").then(keymap => {
+      this.setState({ keymap: keymap });
+    });
+    focus.command("settings.defaultLayer").then(layer => {
+      layer = layer ? parseInt(layer) : 126;
+      this.setState({ defaultLayer: layer <= 126 ? layer : 126 });
+    });
+
+    this.setState({
+      showDefaults: settings.get("keymap.showDefaults")
+    });
+  }
+
+  toggleAdvanced = () => {
+    this.setState(state => ({
+      advanced: !state.advanced
+    }));
+  };
+
+  setOnlyCustom = event => {
+    const checked = event.target.checked;
+    this.setState(state => ({
+      modified: true,
+      keymap: {
+        custom: state.keymap.custom,
+        default: state.keymap.default,
+        onlyCustom: checked
+      }
+    }));
+  };
+
+  selectDefaultLayer = event => {
+    this.setState({
+      defaultLayer: event.target.value,
+      modified: true
+    });
+  };
+
+  setShowDefaults = event => {
+    this.setState({
+      showDefaults: event.target.checked,
+      modified: true
+    });
+  };
+
+  saveKeymapChanges = async () => {
+    const focus = new Focus();
+
+    const { keymap, defaultLayer, showDefaults } = this.state;
+
+    await focus.command("keymap.onlyCustom", keymap.onlyCustom);
+    await focus.command("settings.defaultLayer", defaultLayer);
+    settings.set("keymap.showDefaults", showDefaults);
+    this.setState({ modified: false });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { keymap, defaultLayer, modified, showDefaults } = this.state;
+
+    const onlyCustomSwitch = (
+      <Switch
+        checked={keymap.onlyCustom}
+        value="onlyCustom"
+        onClick={this.setOnlyCustom}
+      />
+    );
+    const showDefaultLayersSwitch = (
+      <Switch
+        checked={showDefaults}
+        value="showDefaults"
+        onClick={this.setShowDefaults}
+      />
+    );
+    let layers;
+    if (keymap.onlyCustom) {
+      layers = keymap.custom.map((_, index) => {
+        return (
+          <MenuItem value={index} key={index}>
+            {i18n.formatString(i18n.components.layer, index)}
+          </MenuItem>
+        );
+      });
+    } else {
+      layers = keymap.default.concat(keymap.custom).map((_, index) => {
+        return (
+          <MenuItem value={index} key={index}>
+            {i18n.formatString(i18n.components.layer, index)}
+          </MenuItem>
+        );
+      });
+    }
+    const defaultLayerSelect = (
+      <Select
+        onChange={this.selectDefaultLayer}
+        value={defaultLayer}
+        variant="filled"
+        input={<FilledInput classes={{ input: classes.select }} />}
+      >
+        <MenuItem value={126}>
+          {i18n.keyboardSettings.keymap.noDefault}
+        </MenuItem>
+        {layers}
+      </Select>
+    );
+
+    return (
+      <div className={classes.root}>
+        <Portal container={this.props.titleElement}>
+          {i18n.app.menu.keyboardSettings}
+        </Portal>
+        <div className={classes.advanced}>
+          <Button onClick={this.toggleAdvanced}>
+            {i18n.keyboardSettings.advanced}
+            {this.state.advanced ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+          </Button>
+        </div>
+        <Collapse in={this.state.advanced} timeout="auto" unmountOnExit>
+          <Typography
+            variant="subtitle1"
+            component="h2"
+            className={classes.title}
+          >
+            {i18n.keyboardSettings.keymap.title}
+          </Typography>
+          <Card>
+            <CardContent>
+              <FormControl className={classes.group}>
+                <FormControlLabel
+                  className={classes.control}
+                  control={showDefaultLayersSwitch}
+                  classes={{ label: classes.grow }}
+                  labelPlacement="start"
+                  label={i18n.keyboardSettings.keymap.showDefaults}
+                />
+                <Divider />
+                <FormControlLabel
+                  className={classes.control}
+                  control={onlyCustomSwitch}
+                  classes={{ label: classes.grow }}
+                  labelPlacement="start"
+                  label={i18n.keyboardSettings.keymap.onlyCustom}
+                />
+                <FormControlLabel
+                  className={classes.control}
+                  classes={{ label: classes.grow }}
+                  control={defaultLayerSelect}
+                  labelPlacement="start"
+                  label={i18n.keyboardSettings.keymap.defaultLayer}
+                />
+              </FormControl>
+            </CardContent>
+            <CardActions className={classes.flex}>
+              <span className={classes.grow} />
+              <SaveChangesButton
+                onClick={this.saveKeymapChanges}
+                disabled={!modified}
+              >
+                {i18n.components.save.saveChanges}
+              </SaveChangesButton>
+            </CardActions>
+          </Card>
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+KeyboardSettings.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(KeyboardSettings);

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -23,12 +23,9 @@ import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp";
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
-import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import Collapse from "@material-ui/core/Collapse";
-import Divider from "@material-ui/core/Divider";
 import FilledInput from "@material-ui/core/FilledInput";
-import FormControl from "@material-ui/core/FormControl";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import MenuItem from "@material-ui/core/MenuItem";
 import Portal from "@material-ui/core/Portal";
@@ -37,12 +34,7 @@ import Switch from "@material-ui/core/Switch";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 
-import Focus from "@chrysalis-api/focus";
-
-import SaveChangesButton from "../components/SaveChangesButton";
 import i18n from "../i18n";
-
-import settings from "electron-settings";
 
 const styles = theme => ({
   root: {
@@ -88,15 +80,7 @@ const styles = theme => ({
 class Preferences extends React.Component {
   state = {
     devTools: false,
-    advanced: false,
-    keymap: {
-      custom: [],
-      default: [],
-      onlyCustom: false
-    },
-    defaultLayer: 126,
-    modified: false,
-    showDefaults: false
+    advanced: false
   };
 
   componentDidMount() {
@@ -107,19 +91,6 @@ class Preferences extends React.Component {
     });
     webContents.on("devtools-closed", () => {
       this.setState({ devTools: false });
-    });
-
-    const focus = new Focus();
-    focus.command("keymap").then(keymap => {
-      this.setState({ keymap: keymap });
-    });
-    focus.command("settings.defaultLayer").then(layer => {
-      layer = layer ? parseInt(layer) : 126;
-      this.setState({ defaultLayer: layer <= 126 ? layer : 126 });
-    });
-
-    this.setState({
-      showDefaults: settings.get("keymap.showDefaults")
     });
   }
 
@@ -141,43 +112,6 @@ class Preferences extends React.Component {
     this.setState(state => ({
       advanced: !state.advanced
     }));
-  };
-
-  setOnlyCustom = event => {
-    const checked = event.target.checked;
-    this.setState(state => ({
-      modified: true,
-      keymap: {
-        custom: state.keymap.custom,
-        default: state.keymap.default,
-        onlyCustom: checked
-      }
-    }));
-  };
-
-  selectDefaultLayer = event => {
-    this.setState({
-      defaultLayer: event.target.value,
-      modified: true
-    });
-  };
-
-  setShowDefaults = event => {
-    this.setState({
-      showDefaults: event.target.checked,
-      modified: true
-    });
-  };
-
-  saveKeymapChanges = async () => {
-    const focus = new Focus();
-
-    const { keymap, defaultLayer, showDefaults } = this.state;
-
-    await focus.command("keymap.onlyCustom", keymap.onlyCustom);
-    await focus.command("settings.defaultLayer", defaultLayer);
-    settings.set("keymap.showDefaults", showDefaults);
-    this.setState({ modified: false });
   };
 
   render() {
@@ -209,100 +143,6 @@ class Preferences extends React.Component {
         onChange={this.toggleDevTools}
         value="devtools"
       />
-    );
-
-    const { keymap, defaultLayer, modified, showDefaults } = this.state;
-    const onlyCustomSwitch = (
-      <Switch
-        checked={keymap.onlyCustom}
-        value="onlyCustom"
-        onClick={this.setOnlyCustom}
-      />
-    );
-    const showDefaultLayersSwitch = (
-      <Switch
-        checked={showDefaults}
-        value="showDefaults"
-        onClick={this.setShowDefaults}
-      />
-    );
-    let layers;
-    if (keymap.onlyCustom) {
-      layers = keymap.custom.map((_, index) => {
-        return (
-          <MenuItem value={index} key={index}>
-            {i18n.formatString(i18n.components.layer, index)}
-          </MenuItem>
-        );
-      });
-    } else {
-      layers = keymap.default.concat(keymap.custom).map((_, index) => {
-        return (
-          <MenuItem value={index} key={index}>
-            {i18n.formatString(i18n.components.layer, index)}
-          </MenuItem>
-        );
-      });
-    }
-    const defaultLayerSelect = (
-      <Select
-        onChange={this.selectDefaultLayer}
-        value={defaultLayer}
-        variant="filled"
-        input={<FilledInput classes={{ input: classes.select }} />}
-      >
-        <MenuItem value={126}>{i18n.preferences.keymap.noDefault}</MenuItem>
-        {layers}
-      </Select>
-    );
-    const focus = new Focus();
-    const keymapSettings = focus._port && (
-      <React.Fragment>
-        <Typography
-          variant="subtitle1"
-          component="h2"
-          className={classes.title}
-        >
-          {i18n.preferences.keymap.title}
-        </Typography>
-        <Card>
-          <CardContent>
-            <FormControl className={classes.group}>
-              <FormControlLabel
-                className={classes.control}
-                control={showDefaultLayersSwitch}
-                classes={{ label: classes.grow }}
-                labelPlacement="start"
-                label={i18n.preferences.keymap.showDefaults}
-              />
-              <Divider />
-              <FormControlLabel
-                className={classes.control}
-                control={onlyCustomSwitch}
-                classes={{ label: classes.grow }}
-                labelPlacement="start"
-                label={i18n.preferences.keymap.onlyCustom}
-              />
-              <FormControlLabel
-                className={classes.control}
-                classes={{ label: classes.grow }}
-                control={defaultLayerSelect}
-                labelPlacement="start"
-                label={i18n.preferences.keymap.defaultLayer}
-              />
-            </FormControl>
-          </CardContent>
-          <CardActions className={classes.flex}>
-            <span className={classes.grow} />
-            <SaveChangesButton
-              onClick={this.saveKeymapChanges}
-              disabled={!modified}
-            >
-              {i18n.components.save.saveChanges}
-            </SaveChangesButton>
-          </CardActions>
-        </Card>
-      </React.Fragment>
     );
 
     return (
@@ -353,7 +193,6 @@ class Preferences extends React.Component {
               />
             </CardContent>
           </Card>
-          {keymapSettings}
         </Collapse>
       </div>
     );

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -85,7 +85,7 @@ const styles = theme => ({
   }
 });
 
-class Settings extends React.Component {
+class Preferences extends React.Component {
   state = {
     devTools: false,
     advanced: false,
@@ -251,7 +251,7 @@ class Settings extends React.Component {
         variant="filled"
         input={<FilledInput classes={{ input: classes.select }} />}
       >
-        <MenuItem value={126}>{i18n.settings.keymap.noDefault}</MenuItem>
+        <MenuItem value={126}>{i18n.preferences.keymap.noDefault}</MenuItem>
         {layers}
       </Select>
     );
@@ -263,7 +263,7 @@ class Settings extends React.Component {
           component="h2"
           className={classes.title}
         >
-          {i18n.settings.keymap.title}
+          {i18n.preferences.keymap.title}
         </Typography>
         <Card>
           <CardContent>
@@ -273,7 +273,7 @@ class Settings extends React.Component {
                 control={showDefaultLayersSwitch}
                 classes={{ label: classes.grow }}
                 labelPlacement="start"
-                label={i18n.settings.keymap.showDefaults}
+                label={i18n.preferences.keymap.showDefaults}
               />
               <Divider />
               <FormControlLabel
@@ -281,14 +281,14 @@ class Settings extends React.Component {
                 control={onlyCustomSwitch}
                 classes={{ label: classes.grow }}
                 labelPlacement="start"
-                label={i18n.settings.keymap.onlyCustom}
+                label={i18n.preferences.keymap.onlyCustom}
               />
               <FormControlLabel
                 className={classes.control}
                 classes={{ label: classes.grow }}
                 control={defaultLayerSelect}
                 labelPlacement="start"
-                label={i18n.settings.keymap.defaultLayer}
+                label={i18n.preferences.keymap.defaultLayer}
               />
             </FormControl>
           </CardContent>
@@ -308,14 +308,14 @@ class Settings extends React.Component {
     return (
       <div className={classes.root}>
         <Portal container={this.props.titleElement}>
-          {i18n.app.menu.settings}
+          {i18n.app.menu.preferences}
         </Portal>
         <Typography
           variant="subtitle1"
           component="h2"
           className={classes.title}
         >
-          {i18n.settings.interface}
+          {i18n.preferences.interface}
         </Typography>
         <Card>
           <CardContent>
@@ -324,13 +324,13 @@ class Settings extends React.Component {
               classes={{ label: classes.grow }}
               control={languageSelect}
               labelPlacement="start"
-              label={i18n.settings.language}
+              label={i18n.preferences.language}
             />
           </CardContent>
         </Card>
         <div className={classes.advanced}>
           <Button onClick={this.toggleAdvanced}>
-            {i18n.settings.advanced}
+            {i18n.preferences.advanced}
             {this.state.advanced ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
           </Button>
         </div>
@@ -340,7 +340,7 @@ class Settings extends React.Component {
             component="h2"
             className={classes.title}
           >
-            {i18n.settings.devtools}
+            {i18n.preferences.devtools}
           </Typography>
           <Card>
             <CardContent>
@@ -349,7 +349,7 @@ class Settings extends React.Component {
                 classes={{ label: classes.grow }}
                 control={devToolsSwitch}
                 labelPlacement="start"
-                label={i18n.settings.devtools}
+                label={i18n.preferences.devtools}
               />
             </CardContent>
           </Card>
@@ -360,8 +360,8 @@ class Settings extends React.Component {
   }
 }
 
-Settings.propTypes = {
+Preferences.propTypes = {
   classes: PropTypes.object.isRequired
 };
 
-export default withStyles(styles)(Settings);
+export default withStyles(styles)(Preferences);


### PR DESCRIPTION
Lift out the keyboard settings from the Settings menu, and place them into their own screen. For clarity, we add subtitles to the side menu too.

The lift is achieved in three steps:
 - Adding subtitles to the drawer
 - Renaming `Settings` to `Preferences`
 - Lifting out `Keyboard Settings` from `Preferences`

## Screenshot

### Sidebar

![screenshot from 2019-02-06 09-50-01](https://user-images.githubusercontent.com/17243/52330204-1f473f00-29f5-11e9-8529-279c601f3e10.png)

### Keyboard settings

![screenshot from 2019-02-06 09-54-06](https://user-images.githubusercontent.com/17243/52330225-2e2df180-29f5-11e9-88be-5b98e2b00174.png)

Keyboard settings start with the "Advanced" settings exposed for now.

### Preferences

![screenshot from 2019-02-06 09-54-54](https://user-images.githubusercontent.com/17243/52330254-43a31b80-29f5-11e9-9fcc-cfc98fa520a6.png)

We're back to the older preferences, with no keyboard-related stuff.