### PR TITLE
Better keymap sizing

### DIFF
--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -25,7 +25,8 @@
   font-weight: 700;
   min-width: 550px;
   min-height: 280px;
-  max-width: 85%;
+  height: calc(100vh - 300px);
+  max-width: calc(100vw - 128px);
 }
 
 .extraKey {


### PR DESCRIPTION
When sizing the keymap, adjust it to the actual screen sizes instead of doing guess-work.

This gets rid of the vertical scrollbar in most cases. It does set a minimum size, at which point scrollbars will appear. But until then, it's resizing nicely.