### PR TITLE
When navigating, always await for it to finish

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -96,12 +96,12 @@ class App extends React.Component {
           pages: {}
         });
         // Second call to `navigate` will actually render the proper route
-        navigate("/keyboard-select");
+        await navigate("/keyboard-select");
       }
     });
   }
 
-  toggleFlashing = () => {
+  toggleFlashing = async () => {
     this.flashing = !this.flashing;
     if (!this.flashing) {
       this.setState({
@@ -109,7 +109,7 @@ class App extends React.Component {
         device: null,
         pages: {}
       });
-      navigate("/keyboard-select");
+      await navigate("/keyboard-select");
     }
   };
 
@@ -122,7 +122,7 @@ class App extends React.Component {
         pages: {},
         device: port.device
       });
-      navigate("./welcome");
+      await navigate("./welcome");
       return;
     }
 
@@ -158,14 +158,14 @@ class App extends React.Component {
     );
   };
 
-  onKeyboardDisconnect = () => {
+  onKeyboardDisconnect = async () => {
     focus.close();
     this.setState({
       connected: false,
       device: null,
       pages: {}
     });
-    navigate("/keyboard-select");
+    await navigate("/keyboard-select");
   };
 
   cancelContext = () => {

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -216,7 +216,7 @@ class KeyboardSelect extends React.Component {
 
     try {
       await this.props.onConnect(devices[this.state.selectedPortIndex]);
-      navigate("/layout-editor");
+      await navigate("/layout-editor");
     } catch (err) {
       this.setState({
         opening: false

--- a/src/renderer/screens/Welcome.js
+++ b/src/renderer/screens/Welcome.js
@@ -125,7 +125,9 @@ class Welcome extends React.Component {
             <Button
               color="primary"
               variant="outlined"
-              onClick={navigate("/firmware-update")}
+              onClick={async () => {
+                await navigate("/firmware-update");
+              }}
             >
               {i18n.formatString(
                 i18n.welcome.gotoUpdate,


### PR DESCRIPTION
This should fix the remaining issues where we navigate somewhere that depends on focus being in one state, but isn't yet.

Fixes #302.
