### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem. If possible, please also include a log from the "developer console". You can access it by pressing `Control + Shift + I`. When it appears, right click inside it, and select "Save as", and attach the saved file to this report.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Chrysalis Version: [e.g. 0.4.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ testing is done on **Ubuntu** 18.04 LTS, **Windows** 10, and **OSX** Mojave.
 The protocol Chrysalis uses to communicate with the keyboard requires USB serial
 support, which is known to be problematic on Windows prior to Windows 10.
 
+## Reporting issues
+
+Chrysalis is alpha quality software. There will be bugs, missing features and
+non-obvious things. Reporting any and all of these help us make the software
+better, please feel free to [open issues][issues] liberally!
+
+ [issues]: https://github.com/keyboardio/Chrysalis/issues
+
 ## Development
 
 To launch the development environment, simply type `yarn && yarn start`. To do a


### PR DESCRIPTION
This adds GitHub issue templates for bugs & feature requests. These include a bit of guidance about what we need to deal with them (like explaining how to collect logs from the developer console in case of a bug report).

It also updates the README to encourage filing issues.