### PR TITLE
App.js: Fix onKeyboardConnect()'s navigate targets

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -154,7 +154,7 @@ class App extends React.Component {
       }
     });
     await navigate(
-      commands.includes("keymap.custom") > 0 ? "./layout-editor" : "./welcome"
+      commands.includes("keymap.custom") > 0 ? "/layout-editor" : "/welcome"
     );
   };
 

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -45,7 +45,6 @@ import Hardware from "@chrysalis-api/hardware";
 import usb from "usb";
 
 import i18n from "../i18n";
-import { navigate } from "../routerHistory";
 
 const styles = theme => ({
   loader: {
@@ -216,7 +215,6 @@ class KeyboardSelect extends React.Component {
 
     try {
       await this.props.onConnect(devices[this.state.selectedPortIndex]);
-      await navigate("/layout-editor");
     } catch (err) {
       this.setState({
         opening: false


### PR DESCRIPTION
We should be navigating to `/layout-editor` or `/welcome`, not `./layout-editor` or `./welcome`. The distinction is important, the router doesn't know how to handle the latter ones.

Fixing this navigation means we do not need the one in KeyboardSelect anymore.

These two together restore the functionality of landing on the Welcome screen when Focus wasn't detected on the keyboard.
