### PR TITLE
MainMenu: If there's a new version of Chrysalis. notify the user

### DIFF
--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -42,6 +42,7 @@ import ExitMenuItem from "./ExitMenuItem";
 import KeyboardMenuItem from "./KeyboardSelectMenuItem";
 import PreferencesMenuItem from "./PreferencesMenuItem";
 import KeyboardSettingsMenuItem from "./KeyboardSettingsMenuItem";
+import UpgradeMenuItem from "./UpgradeMenuItem";
 import openURL from "../../utils/openURL";
 
 const styles = theme => ({
@@ -205,6 +206,7 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
               className={classes.version}
             />
           </ListItem>
+          <UpgradeMenuItem />
         </List>
       </div>
     </Drawer>

--- a/src/renderer/components/MainMenu/UpgradeMenuItem.js
+++ b/src/renderer/components/MainMenu/UpgradeMenuItem.js
@@ -1,0 +1,53 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from "react";
+
+import Divider from "@material-ui/core/Divider";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+
+import i18n from "../../i18n";
+import { version } from "../../../../package.json";
+import getLatestVersion from "../../utils/getLatestVersion";
+
+function UpgradeMenuItem() {
+  const [latestVersion, setLatestVersion] = useState(null);
+
+  if (!latestVersion) {
+    getLatestVersion().then(v => {
+      setLatestVersion(v);
+    });
+    return null;
+  }
+
+  if (latestVersion.version <= version) return null;
+
+  return (
+    <React.Fragment>
+      <Divider />
+      <ListItem button component="a" href={latestVersion.url}>
+        <ListItemText
+          primary={i18n.app.menu.upgradeAvailable}
+          secondary={latestVersion.version}
+        />
+      </ListItem>
+    </React.Fragment>
+  );
+}
+
+export { UpgradeMenuItem as default };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -43,7 +43,8 @@ const English = {
       exit: "Exit Chrysalis",
       keyboardSection: "Keyboard",
       chrysalisSection: "Chrysalis",
-      miscSection: "Miscellaneous"
+      miscSection: "Miscellaneous",
+      upgradeAvailable: "An upgrade is available!"
     },
     deviceMenu: {
       Homepage: "Homepage",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -43,7 +43,8 @@ const Hungarian = {
       exit: "Kilépés",
       keyboardSection: "Billentyűzet",
       chrysalisSection: "Chrysalis",
-      miscSection: "Egyéb"
+      miscSection: "Egyéb",
+      upgradeAvailable: "Frissítés érhető el!"
     },
     deviceMenu: {
       Homepage: "Honlap",

--- a/src/renderer/utils/getLatestVersion.js
+++ b/src/renderer/utils/getLatestVersion.js
@@ -1,0 +1,104 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import http from "http";
+import https from "https";
+import { version } from "../../../package.json";
+
+let __latestVersion; // foobar
+
+const getLatestVersionFromS3 = async () => {
+  const extensions = {
+    linux: "AppImage",
+    darwin: "dmg",
+    windows: "exe"
+  };
+  const options = {
+    method: "HEAD",
+    host: "kaleidoscope-builds.s3.amazonaws.com",
+    port: "80",
+    path: "/Chrysalis/latest/Chrysalis." + extensions[process.platform]
+  };
+
+  return new Promise(resolve => {
+    const req = http.request(options, result => {
+      const uri = decodeURIComponent(
+        result.headers["x-amz-website-redirect-location"]
+      ).split("/");
+      let version = uri[uri.length - 1].split("-")[1];
+      version = version.substring(
+        0,
+        version.length - extensions[process.platform].length - 1
+      );
+      resolve({
+        version: version,
+        url: result.headers["x-amz-website-redirect-location"]
+      });
+    });
+    req.end();
+  });
+};
+
+const getLatestVersionFromGitHub = async () => {
+  const options = {
+    method: "GET",
+    host: "api.github.com",
+    path: "/repos/keyboardio/Chrysalis/releases",
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": `Chrysalis/${version}`
+    }
+  };
+  const extensions = {
+    linux: "AppImage",
+    darwin: "dmg",
+    windows: "exe"
+  };
+  const extension = extensions[process.platform];
+
+  return new Promise(resolve => {
+    let data = "";
+    const req = https.request(options, response => {
+      response.on("data", chunk => {
+        data += chunk;
+      });
+      response.on("end", () => {
+        data = JSON.parse(data)[0];
+        const release = data.name.split(" ")[1];
+        resolve({
+          version: release,
+          url: `https://github.com/keyboardio/Chrysalis/releases/download/chrysalis-${release}/Chrysalis-${release}.${extension}`
+        });
+      });
+    });
+    req.end();
+  });
+};
+
+const getLatestVersion = async () => {
+  if (__latestVersion) return __latestVersion;
+
+  if (version.indexOf("+") > 0) {
+    __latestVersion = await getLatestVersionFromS3();
+  } else {
+    __latestVersion = await getLatestVersionFromGitHub();
+  }
+
+  return __latestVersion;
+};
+
+export { getLatestVersion as default };


### PR DESCRIPTION
If there's a new version of Chrysalis available (detected once on startup), display an upgrade notice in the main menu, below the Chrysalis version.

Fixes #314.

![screenshot from 2019-02-10 00-28-26](https://user-images.githubusercontent.com/17243/52527562-cdd7d200-2cca-11e9-8712-e0927f9268c9.png)

Opens a direct link to the latest version (not to the latest symlink), so it is saved with a versioned filename.