### PR TITLE
Add a way to reset EEPROM

### DIFF
--- a/src/renderer/components/ConfirmationDialog.js
+++ b/src/renderer/components/ConfirmationDialog.js
@@ -1,0 +1,50 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+
+import i18n from "../i18n";
+
+const ConfirmationDialog = props => {
+  return (
+    <Dialog
+      disableBackdropClick
+      open={props.open}
+      onClose={props.onCancel}
+      fullWidth
+    >
+      <DialogTitle>{props.title}</DialogTitle>
+      <DialogContent>{props.children}</DialogContent>
+      <DialogActions>
+        <Button onClick={props.onCancel} color="primary">
+          {i18n.dialog.cancel}
+        </Button>
+        <Button onClick={props.onConfirm} color="primary">
+          {i18n.dialog.ok}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { ConfirmationDialog as default };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -110,6 +110,13 @@ const English = {
       showHardcoded: "Show hardcoded layers",
       onlyCustom: "Use custom layers only",
       defaultLayer: "Default layer"
+    },
+    advancedOps: "Advanced keyboard settings & operations",
+    resetEEPROM: {
+      button: "Reset EEPROM to factory defaults",
+      dialogTitle: "Reset EEPROM to factory defaults?",
+      dialogContents: `This will reset the EEPROM to factory defaults.
+ You will lose all customizations made.`
     }
   },
   keyboardSelect: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -110,6 +110,13 @@ const Hungarian = {
       showHardcoded: "Beépített rétegek mutatása",
       onlyCustom: "Kizárólag testreszabott rétegek használata",
       defaultLayer: "Alapértelmezett réteg"
+    },
+    advancedOps: "Haladó billentyűzet beállítások és műveletek",
+    resetEEPROM: {
+      button: "EEPROM visszaállítása gyári alapbeállításokra",
+      dialogTitle: "Visszaállítja az EEPROM-ot gyári alapbeállításokra?",
+      dialogContents: `Ez visszaállítja az EEPROM-ot gyári alapbeállításokra.
+Minden testreszabott beállítás el fog veszni.`
     }
   },
   keyboardSelect: {

--- a/src/renderer/screens/Editor.js
+++ b/src/renderer/screens/Editor.js
@@ -55,6 +55,7 @@ import { KeymapDB } from "@chrysalis-api/keymap";
 import Palette from "./Editor/Palette";
 import KeySelector from "./Editor/KeySelector";
 import SaveChangesButton from "../components/SaveChangesButton";
+import ConfirmationDialog from "../components/ConfirmationDialog";
 import i18n from "../i18n";
 import settings from "electron-settings";
 
@@ -91,28 +92,6 @@ const styles = theme => ({
     padding: `6px ${theme.spacing.unit}px`
   }
 });
-
-const ConfirmationDialog = props => {
-  return (
-    <Dialog
-      disableBackdropClick
-      open={props.open}
-      onClose={props.onCancel}
-      fullWidth
-    >
-      <DialogTitle>{props.title}</DialogTitle>
-      <DialogContent>{props.children}</DialogContent>
-      <DialogActions>
-        <Button onClick={props.onCancel} color="primary">
-          {i18n.dialog.cancel}
-        </Button>
-        <Button onClick={props.onConfirm} color="primary">
-          {i18n.dialog.ok}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-};
 
 const CopyFromDialog = props => {
   const [selectedLayer, setSelectedLayer] = useState(-1);

--- a/src/renderer/screens/KeyboardSettings.js
+++ b/src/renderer/screens/KeyboardSettings.js
@@ -86,7 +86,7 @@ const styles = theme => ({
 
 class KeyboardSettings extends React.Component {
   state = {
-    advanced: true,
+    advanced: false,
     keymap: {
       custom: [],
       default: [],
@@ -210,58 +210,57 @@ class KeyboardSettings extends React.Component {
         <Portal container={this.props.titleElement}>
           {i18n.app.menu.keyboardSettings}
         </Portal>
+        <Typography
+          variant="subtitle1"
+          component="h2"
+          className={classes.title}
+        >
+          {i18n.keyboardSettings.keymap.title}
+        </Typography>
+        <Card>
+          <CardContent>
+            <FormControl className={classes.group}>
+              <FormControlLabel
+                className={classes.control}
+                control={showDefaultLayersSwitch}
+                classes={{ label: classes.grow }}
+                labelPlacement="start"
+                label={i18n.keyboardSettings.keymap.showHardcoded}
+              />
+              <Divider />
+              <FormControlLabel
+                className={classes.control}
+                control={onlyCustomSwitch}
+                classes={{ label: classes.grow }}
+                labelPlacement="start"
+                label={i18n.keyboardSettings.keymap.onlyCustom}
+              />
+              <FormControlLabel
+                className={classes.control}
+                classes={{ label: classes.grow }}
+                control={defaultLayerSelect}
+                labelPlacement="start"
+                label={i18n.keyboardSettings.keymap.defaultLayer}
+              />
+            </FormControl>
+          </CardContent>
+          <CardActions className={classes.flex}>
+            <span className={classes.grow} />
+            <SaveChangesButton
+              onClick={this.saveKeymapChanges}
+              disabled={!modified}
+            >
+              {i18n.components.save.saveChanges}
+            </SaveChangesButton>
+          </CardActions>
+        </Card>
         <div className={classes.advanced}>
           <Button onClick={this.toggleAdvanced}>
             {i18n.keyboardSettings.advanced}
             {this.state.advanced ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
           </Button>
         </div>
-        <Collapse in={this.state.advanced} timeout="auto" unmountOnExit>
-          <Typography
-            variant="subtitle1"
-            component="h2"
-            className={classes.title}
-          >
-            {i18n.keyboardSettings.keymap.title}
-          </Typography>
-          <Card>
-            <CardContent>
-              <FormControl className={classes.group}>
-                <FormControlLabel
-                  className={classes.control}
-                  control={showDefaultLayersSwitch}
-                  classes={{ label: classes.grow }}
-                  labelPlacement="start"
-                  label={i18n.keyboardSettings.keymap.showHardcoded}
-                />
-                <Divider />
-                <FormControlLabel
-                  className={classes.control}
-                  control={onlyCustomSwitch}
-                  classes={{ label: classes.grow }}
-                  labelPlacement="start"
-                  label={i18n.keyboardSettings.keymap.onlyCustom}
-                />
-                <FormControlLabel
-                  className={classes.control}
-                  classes={{ label: classes.grow }}
-                  control={defaultLayerSelect}
-                  labelPlacement="start"
-                  label={i18n.keyboardSettings.keymap.defaultLayer}
-                />
-              </FormControl>
-            </CardContent>
-            <CardActions className={classes.flex}>
-              <span className={classes.grow} />
-              <SaveChangesButton
-                onClick={this.saveKeymapChanges}
-                disabled={!modified}
-              >
-                {i18n.components.save.saveChanges}
-              </SaveChangesButton>
-            </CardActions>
-          </Card>
-        </Collapse>
+        <Collapse in={this.state.advanced} timeout="auto" unmountOnExit />
       </div>
     );
   }


### PR DESCRIPTION
![screenshot from 2019-02-22 13-13-46](https://user-images.githubusercontent.com/17243/53241984-b2de6800-36a3-11e9-8b80-12c16bc0290b.png)
![screenshot from 2019-02-22 13-11-04](https://user-images.githubusercontent.com/17243/53241989-b7a31c00-36a3-11e9-9ddb-a2dadb532816.png)

EEPROM is cleared by pulling contents first, and replacing every byte with 255, so the same code will work for any size of EEPROM. It's perhaps a bit wasteful to do this, but it's always correct.

Fixes #283.