### PR TITLE
KeyboardSettings: Support the in-context appbar

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -225,6 +225,9 @@ class App extends React.Component {
               <KeyboardSettings
                 path="/keyboard-settings"
                 titleElement={() => document.querySelector("#page-title")}
+                startContext={this.startContext}
+                cancelContext={this.cancelContext}
+                inContext={this.state.contextBar}
               />
               <Preferences
                 path="/preferences"

--- a/src/renderer/screens/KeyboardSettings.js
+++ b/src/renderer/screens/KeyboardSettings.js
@@ -112,6 +112,13 @@ class KeyboardSettings extends React.Component {
     });
   }
 
+  UNSAFE_componentWillReceiveProps = nextProps => {
+    if (this.props.inContext && !nextProps.inContext) {
+      this.componentDidMount();
+      this.setState({ modified: false });
+    }
+  };
+
   toggleAdvanced = () => {
     this.setState(state => ({
       advanced: !state.advanced
@@ -128,6 +135,7 @@ class KeyboardSettings extends React.Component {
         onlyCustom: checked
       }
     }));
+    this.props.startContext();
   };
 
   selectDefaultLayer = event => {
@@ -135,6 +143,7 @@ class KeyboardSettings extends React.Component {
       defaultLayer: event.target.value,
       modified: true
     });
+    this.props.startContext();
   };
 
   setShowDefaults = event => {
@@ -142,6 +151,7 @@ class KeyboardSettings extends React.Component {
       showDefaults: event.target.checked,
       modified: true
     });
+    this.props.startContext();
   };
 
   saveKeymapChanges = async () => {
@@ -153,6 +163,7 @@ class KeyboardSettings extends React.Component {
     await focus.command("settings.defaultLayer", defaultLayer);
     settings.set("keymap.showDefaults", showDefaults);
     this.setState({ modified: false });
+    this.props.cancelContext();
   };
 
   render() {


### PR DESCRIPTION
When there are pending changes, display the in-context AppBar. This allows us to cancel pending changes.

![screenshot from 2019-02-22 13-39-17](https://user-images.githubusercontent.com/17243/53243148-42d1e100-36a7-11e9-87d4-8da65dd46a6b.png)
