### PR TITLE
Editor: Initial layer export/import support

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -98,7 +98,9 @@ const English = {
     dualUse: "Modifier when held, normal key otherwise",
     dualUseLayer: "Layer shift when held, normal key otherwise",
     layoutMode: "Edit the keyboard layout",
-    colormapMode: "Edit the colormap"
+    colormapMode: "Edit the colormap",
+    importExport: "Import/Export the current layer",
+    importExportDescription: `The data below can be freely edited, or copied elsewhere to be pasted back for importing. This is the internal representation of Chrysalis state, handle with care.`
   },
   preferences: {
     devtools: "Developer tools",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -99,7 +99,9 @@ const Hungarian = {
     dualUse: "Nyomvatartáskor módosító, normál gomb egyébként",
     dualUseLayer: "Nyomvatartáskor réteg váltó, normál gomb egyébként",
     layoutMode: "Billentyűzetkiosztás szerkesztése",
-    colormapMode: "Színtérkép szerkesztése"
+    colormapMode: "Színtérkép szerkesztése",
+    importExport: "Aktuális réteg importálása/exportálása",
+    importExportDescription: `Az alábbi adatok szabadon szerkeszthetőek, vagy máshova másolhatóak, hogy később vissza lehessen illeszteni. Ezek az adatok a Chrysalis belső adatszerkezetét tükrözik, óvatosan szerkessze.`
   },
   preferences: {
     devtools: "Fejlesztői eszközök",


### PR DESCRIPTION
This is an initial approximation of the layer import/export feature, an MVP of sorts.

It's still a work in progress, with a few known issues:

- [x] State handling between the layer and the dialog is not good. Once the dialog is opened once, the textarea contents are never updated again, even if they change on the layer.
- [x] We should have some text about what the text boxes are for, to not scare those who have no idea what these strange things are.
- [x] There is no error checking. We should queue an error snackbar on JSON parse error, or on any other error.
- [x] Merge the different text boxes into one big box

![screenshot from 2019-02-22 17-34-34](https://user-images.githubusercontent.com/17243/53256702-c2bc7300-36c8-11e9-92a0-7ce20aa5b5a8.png)
