### PR TITLE
Do not ask for confirmation when saving

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -170,8 +170,12 @@ class App extends React.Component {
     await navigate("/keyboard-select");
   };
 
-  cancelContext = () => {
-    this.setState({ cancelPendingOpen: true });
+  cancelContext = dirty => {
+    if (dirty) {
+      this.setState({ cancelPendingOpen: true });
+    } else {
+      this.doCancelContext();
+    }
   };
   doCancelContext = () => {
     this.setState({

--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -74,6 +74,14 @@ function Header({
     setBoardMenuAnchor(null);
   }
 
+  function contextOnClick() {
+    if (contextBar) {
+      cancelContext(true);
+    } else {
+      openMainMenu();
+    }
+  }
+
   return (
     <AppBar
       position="static"
@@ -84,7 +92,7 @@ function Header({
         <Button
           className={classes.menuButton}
           color="inherit"
-          onClick={contextBar ? cancelContext : openMainMenu}
+          onClick={contextOnClick}
         >
           {contextBar ? <CloseIcon /> : <MenuIcon />}
           <Typography


### PR DESCRIPTION
We should only show a prompt when discarding unsaved changes, not when we're explicitly saving them. To achieve this, `App.cancelContext()` now takes a `dirty` argument, and only pops up the dialog when the flag is set. Cancelling the context will set the dirty flag, any other call-site will not.

In practice, this fixes #335.
