### PR TITLE
App: Do the Editor / Welcome routing in `onKeyboardConnect`

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -143,20 +143,21 @@ class App extends React.Component {
     }
 
     focus.setLayerSize(focus.device);
+    const pages = {
+      keymap:
+        commands.includes("keymap.custom") > 0 ||
+        commands.includes("keymap.map") > 0,
+      colormap:
+        commands.includes("colormap.map") > 0 &&
+        commands.includes("palette") > 0
+    };
 
     this.setState({
       connected: true,
       device: null,
-      pages: {
-        keymap:
-          commands.includes("keymap.custom") > 0 ||
-          commands.includes("keymap.map") > 0,
-        colormap:
-          commands.includes("colormap.map") > 0 &&
-          commands.includes("palette") > 0
-      }
+      pages: pages
     });
-    await navigate("./");
+    await navigate(pages.keymap ? "/editor" : "/welcome");
     return commands;
   };
 

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -45,7 +45,6 @@ import Hardware from "@chrysalis-api/hardware";
 import usb from "usb";
 
 import i18n from "../i18n";
-import { navigate } from "../routerHistory";
 
 const styles = theme => ({
   loader: {
@@ -215,12 +214,7 @@ class KeyboardSelect extends React.Component {
     const { devices } = this.state;
 
     try {
-      const commands = await this.props.onConnect(
-        devices[this.state.selectedPortIndex]
-      );
-      await navigate(
-        commands.includes("keymap.custom") > 0 ? "/editor" : "/welcome"
-      );
+      await this.props.onConnect(devices[this.state.selectedPortIndex]);
     } catch (err) {
       this.setState({
         opening: false


### PR DESCRIPTION
Do the Editor / Welcome routing in `onKeyboardConnect` instead of doing it in `KeyboardSelect`. This way we can avoid the `navigate(".")`, which screws up the reconnect on the Welcome screen.

Fixes #333.
