### PR TITLE
Editor: Don't touch the colormap when we're out of bounds

### DIFF
--- a/src/renderer/screens/Editor.js
+++ b/src/renderer/screens/Editor.js
@@ -284,7 +284,11 @@ class Editor extends React.Component {
     }
 
     this.setState(state => {
-      if (state.colorMap.length > 0) {
+      if (
+        state.colorMap.length > 0 &&
+        layer > 0 &&
+        layer < state.colorMap.length
+      ) {
         return {
           currentLayer: layer,
           currentKeyIndex: keyIndex,
@@ -441,9 +445,11 @@ class Editor extends React.Component {
       return;
     }
 
+    const { currentLayer, currentLedIndex } = this.state;
+    if (currentLayer < 0 || currentLayer >= this.state.colorMap.length) return;
+
     this.setState(state => {
       let colormap = state.colorMap.slice();
-      const { currentLayer, currentLedIndex } = this.state;
       colormap[currentLayer][currentLedIndex] = colorIndex;
 
       return {
@@ -642,6 +648,9 @@ class Editor extends React.Component {
           )) ||
             (mode == "colormap" && (
               <Palette
+                disabled={
+                  isReadOnly || currentLayer > this.state.colorMap.length
+                }
                 palette={this.state.palette}
                 onColorSelect={this.onColorSelect}
                 onColorPick={this.onColorPick}

--- a/src/renderer/screens/Editor/Palette.js
+++ b/src/renderer/screens/Editor/Palette.js
@@ -62,6 +62,7 @@ class Palette extends React.Component {
       const itemKey = "palette-index-" + index.toString();
       return (
         <ColorBox
+          disabled={this.props.disabled}
           selected={index == this.props.selected}
           key={itemKey}
           color={color}
@@ -74,6 +75,7 @@ class Palette extends React.Component {
       const itemKey = "palette-index-" + (index + 8).toString();
       return (
         <ColorBox
+          disabled={this.props.disabled}
           selected={index + 8 == this.props.selected}
           key={itemKey}
           color={color}
@@ -91,6 +93,7 @@ class Palette extends React.Component {
         <Fade in={this.props.selected != -1}>
           <div className={classes.picker}>
             <MaterialPicker
+              disabled={this.props.disabled}
               className={classes.pickerInner}
               color={color}
               onChangeComplete={this.onColorPick}


### PR DESCRIPTION
When we're on a negative layer, or a layer higher than the length of the colormap, don't touch the colormap.

Fixes #342.

This isn't perfect, the colormap editor controls aren't properly disabled - but they don't do anything in these cases, which is a bit better than crashing. Adding disabled support for those controls is a bit more involved, will do that in a separate PR at some point.