### PR TITLE
Editor: Handle the corner case of no custom keymap better

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@chrysalis-api/colormap": "~0.0.8",
     "@chrysalis-api/focus": "~0.0.9",
     "@chrysalis-api/hardware": "^0.0.7",
-    "@chrysalis-api/keymap": "~0.0.17",
+    "@chrysalis-api/keymap": "^0.0.18",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.1",
     "@material-ui/lab": "^3.0.0-alpha.30",

--- a/src/renderer/screens/Editor.js
+++ b/src/renderer/screens/Editor.js
@@ -196,7 +196,7 @@ class Editor extends React.Component {
         }
       }
 
-      if (empty && !keymap.onlyCustom) {
+      if (empty && !keymap.onlyCustom && keymap.custom.length > 0) {
         console.log("Custom keymap is empty, copying defaults");
         for (let i = 0; i < keymap.default.length; i++) {
           keymap.custom[i] = keymap.default[i].slice();
@@ -634,9 +634,10 @@ class Editor extends React.Component {
             </div>
           </Toolbar>
         </Portal>
-        {this.state.keymap.custom.length == 0 && (
-          <LinearProgress variant="query" />
-        )}
+        {this.state.keymap.custom.length == 0 &&
+          this.state.keymap.default.length == 0 && (
+            <LinearProgress variant="query" />
+          )}
         {layer}
         <Slide in={this.getCurrentKey() != -1} direction="up" unmountOnExit>
           {(mode == "layout" && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,10 +831,10 @@
     "@chrysalis-api/hardware-softhruf-splitography" "^0.0.3"
     "@chrysalis-api/hardware-technomancy-atreus" "^0.0.13"
 
-"@chrysalis-api/keymap@~0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.17.tgz#e15f4e5b13e89f38097f1e005ea36aa2689a057a"
-  integrity sha512-/OBdPI7YtwNX1dojxxE1aRxDRGd74q9yLEBrGFL7/PyH9L49JiNIZsOtUNLFTALcUZN96iimAaByIcbcA+i6tw==
+"@chrysalis-api/keymap@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.18.tgz#3425ae71a6ee9d7ed81accff330f3e2bb807d977"
+  integrity sha512-dRH0ZTgT57aNWl3y3nTrEZEhvoInC6oCgecSQ5bNaXcMO/oBj8L3n2hK8vsFcVinWLInJ9mFkpGVU3rH1wLKgA==
   dependencies:
     "@chrysalis-api/focus" "^0.0.9"
 


### PR DESCRIPTION
If we have no custom keymap, we should force onlyCustom off (this is done by the updated `@chrysalis-api/keymap` package). We should not copy the default layers to custom if custom was an empty array.

Together, these fix #336.
