### PR TITLE
Initial Dark mode support

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -28,6 +28,9 @@ import { LocationProvider, Router } from "@reach/router";
 
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { withStyles } from "@material-ui/core/styles";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import { lightTheme } from "../styles/lightTheme";
+import { darkTheme } from "../styles/darkTheme";
 
 import usb from "usb";
 import { withSnackbar } from "notistack";
@@ -64,6 +67,7 @@ class App extends React.Component {
     super(props);
 
     this.state = {
+      darkMode: settings.get("ui.darkMode"),
       connected: false,
       device: null,
       pages: {},
@@ -104,6 +108,14 @@ class App extends React.Component {
       }
     });
   }
+
+  toggleDarkMode = () => {
+    const nextDarkModeState = !this.state.darkMode;
+    this.setState({
+      darkMode: nextDarkModeState
+    });
+    settings.set("ui.darkMode", nextDarkModeState);
+  };
 
   toggleFlashing = async () => {
     this.flashing = !this.flashing;
@@ -201,69 +213,73 @@ class App extends React.Component {
       (this.state.device && this.state.device.info);
 
     return (
-      <div className={classes.root}>
-        <LocationProvider history={history}>
-          <CssBaseline />
-          <Header
-            contextBar={contextBar}
-            connected={connected}
-            pages={pages}
-            device={device}
-            cancelContext={this.cancelContext}
-          />
-          <main className={classes.content}>
-            <Router>
-              <Welcome
-                path="/welcome"
-                device={this.state.device}
-                onConnect={this.onKeyboardConnect}
-                titleElement={() => document.querySelector("#page-title")}
-              />
-              <KeyboardSelect
-                path="/keyboard-select"
-                onConnect={this.onKeyboardConnect}
-                onDisconnect={this.onKeyboardDisconnect}
-                titleElement={() => document.querySelector("#page-title")}
-              />
-              <Editor
-                path="/editor"
-                onDisconnect={this.onKeyboardDisconnect}
-                startContext={this.startContext}
-                cancelContext={this.cancelContext}
-                inContext={this.state.contextBar}
-                titleElement={() => document.querySelector("#page-title")}
-                appBarElement={() => document.querySelector("#appbar")}
-              />
-              <FirmwareUpdate
-                path="/firmware-update"
-                device={this.state.device}
-                toggleFlashing={this.toggleFlashing}
-                onDisconnect={this.onKeyboardDisconnect}
-                titleElement={() => document.querySelector("#page-title")}
-              />
-              <KeyboardSettings
-                path="/keyboard-settings"
-                titleElement={() => document.querySelector("#page-title")}
-                startContext={this.startContext}
-                cancelContext={this.cancelContext}
-                inContext={this.state.contextBar}
-              />
-              <Preferences
-                path="/preferences"
-                titleElement={() => document.querySelector("#page-title")}
-              />
-            </Router>
-          </main>
-        </LocationProvider>
-        <ConfirmationDialog
-          title={i18n.app.cancelPending.title}
-          open={this.state.cancelPendingOpen}
-          onConfirm={this.doCancelContext}
-          onCancel={this.cancelContextCancellation}
-        >
-          {i18n.app.cancelPending.content}
-        </ConfirmationDialog>
-      </div>
+      <MuiThemeProvider theme={this.state.darkMode ? darkTheme : lightTheme}>
+        <div className={classes.root}>
+          <LocationProvider history={history}>
+            <CssBaseline />
+            <Header
+              contextBar={contextBar}
+              connected={connected}
+              pages={pages}
+              device={device}
+              cancelContext={this.cancelContext}
+            />
+            <main className={classes.content}>
+              <Router>
+                <Welcome
+                  path="/welcome"
+                  device={this.state.device}
+                  onConnect={this.onKeyboardConnect}
+                  titleElement={() => document.querySelector("#page-title")}
+                />
+                <KeyboardSelect
+                  path="/keyboard-select"
+                  onConnect={this.onKeyboardConnect}
+                  onDisconnect={this.onKeyboardDisconnect}
+                  titleElement={() => document.querySelector("#page-title")}
+                />
+                <Editor
+                  path="/editor"
+                  onDisconnect={this.onKeyboardDisconnect}
+                  startContext={this.startContext}
+                  cancelContext={this.cancelContext}
+                  inContext={this.state.contextBar}
+                  titleElement={() => document.querySelector("#page-title")}
+                  appBarElement={() => document.querySelector("#appbar")}
+                />
+                <FirmwareUpdate
+                  path="/firmware-update"
+                  device={this.state.device}
+                  toggleFlashing={this.toggleFlashing}
+                  onDisconnect={this.onKeyboardDisconnect}
+                  titleElement={() => document.querySelector("#page-title")}
+                />
+                <KeyboardSettings
+                  path="/keyboard-settings"
+                  titleElement={() => document.querySelector("#page-title")}
+                  startContext={this.startContext}
+                  cancelContext={this.cancelContext}
+                  inContext={this.state.contextBar}
+                />
+                <Preferences
+                  path="/preferences"
+                  titleElement={() => document.querySelector("#page-title")}
+                  darkMode={this.state.darkMode}
+                  toggleDarkMode={this.toggleDarkMode}
+                />
+              </Router>
+            </main>
+          </LocationProvider>
+          <ConfirmationDialog
+            title={i18n.app.cancelPending.title}
+            open={this.state.cancelPendingOpen}
+            onConfirm={this.doCancelContext}
+            onCancel={this.cancelContextCancellation}
+          >
+            {i18n.app.cancelPending.content}
+          </ConfirmationDialog>
+        </div>
+      </MuiThemeProvider>
     );
   }
 }

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -106,7 +106,8 @@ const English = {
     devtools: "Developer tools",
     language: "Language",
     interface: "Interface",
-    advanced: "Advanced"
+    advanced: "Advanced",
+    darkMode: "Dark mode"
   },
   keyboardSettings: {
     advanced: "Advanced",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -107,7 +107,8 @@ const Hungarian = {
     devtools: "Fejlesztői eszközök",
     language: "Nyelv",
     interface: "Felhasználói felület",
-    advanced: "Haladó beállítások"
+    advanced: "Haladó beállítások",
+    darkMode: "Sötét mód"
   },
   keyboardSettings: {
     advanced: "Haladó beállítások",

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -118,7 +118,7 @@ class Preferences extends React.Component {
   };
 
   render() {
-    const { classes } = this.props;
+    const { classes, darkMode, toggleDarkMode } = this.props;
 
     const language = i18n.getLanguage();
     const languages = i18n.getAvailableLanguages().map(code => {
@@ -138,6 +138,10 @@ class Preferences extends React.Component {
       >
         {languages}
       </Select>
+    );
+
+    const darkModeSwitch = (
+      <Switch checked={darkMode} onChange={toggleDarkMode} value="devtools" />
     );
 
     const devToolsSwitch = (
@@ -168,6 +172,13 @@ class Preferences extends React.Component {
               control={languageSelect}
               labelPlacement="start"
               label={i18n.preferences.language}
+            />
+            <FormControlLabel
+              className={classes.control}
+              classes={{ label: classes.grow }}
+              control={darkModeSwitch}
+              labelPlacement="start"
+              label={i18n.preferences.darkMode}
             />
           </CardContent>
         </Card>

--- a/src/styles/darkTheme.js
+++ b/src/styles/darkTheme.js
@@ -1,0 +1,10 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+
+export const darkTheme = createMuiTheme({
+  palette: {
+    type: "dark"
+  },
+  typography: {
+    useNextVariants: true
+  }
+});

--- a/src/styles/lightTheme.js
+++ b/src/styles/lightTheme.js
@@ -1,0 +1,10 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+
+export const lightTheme = createMuiTheme({
+  palette: {
+    type: "light"
+  },
+  typography: {
+    useNextVariants: true
+  }
+});


### PR DESCRIPTION
Initial support for manual switching to the stock Material UI dark theme with preference being saved using electron-settings.

Signed-off-by: Tré Ammatuna <tre@tretuna.com>