### PR TITLE
Editor: Fix editing the colormap on layer 0

### DIFF
--- a/src/renderer/screens/Editor.js
+++ b/src/renderer/screens/Editor.js
@@ -355,7 +355,7 @@ class Editor extends React.Component {
     this.setState(state => {
       if (
         state.colorMap.length > 0 &&
-        layer > 0 &&
+        layer >= 0 &&
         layer < state.colorMap.length
       ) {
         return {


### PR DESCRIPTION
When deciding whether to set the colors, we wanted to avoid setting it for negative layers (ie, when using custom layers only, but having default layers shown, and being on a default layer). However, the comparison was done wrong, we compared `layer > 0` instead of `layer >= 0`. This fixes that, and setting colors on the base layer works again now.

Fixes #352.
