### PR TITLE
Shade the main toolbar along with Mac preferences for Dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "productName": "Chrysalis",
     "artifactName": "${productName}-${version}.${ext}",
     "copyright": "Copyright © 2018, 2019 Keyboardio Inc.; distributed under the GPLv3",
+    "mac": {
+      "darkModeSupport": true
+    },
     "linux": {
       "target": [
         "AppImage"


### PR DESCRIPTION
Small update to make the main toolbar change along with the dark mode setting in MacOS.

Notes:
Does not affect the current manual user setting in preferences for `Dark mode`.
Does not show in dev mode, only on the final build. This is due to the fact that this is just a setting in `electron-builder`