### PR TITLE
Move the Layer dropdown, and change the layer clear icon

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -22,10 +22,10 @@ import classNames from "classnames";
 import Fade from "@material-ui/core/Fade";
 import FileCopyIcon from "@material-ui/icons/FileCopy";
 import FormControl from "@material-ui/core/FormControl";
-import HighlightOffIcon from "@material-ui/icons/HighlightOff";
 import IconButton from "@material-ui/core/IconButton";
 import ImportExportIcon from "@material-ui/icons/ImportExport";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
+import LayersClearIcon from "@material-ui/icons/LayersClear";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
@@ -624,7 +624,7 @@ class Editor extends React.Component {
               </Tooltip>
               <Tooltip title={i18n.editor.clearLayer}>
                 <IconButton disabled={isReadOnly} onClick={this.confirmClear}>
-                  <HighlightOffIcon />
+                  <LayersClearIcon />
                 </IconButton>
               </Tooltip>
             </div>

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -76,6 +76,9 @@ const styles = theme => ({
   layerItem: {
     paddingLeft: theme.spacing.unit * 4
   },
+  layerSelect: {
+    marginRight: theme.spacing.unit * 4
+  },
   tabWrapper: {
     flexDirection: "row",
     "& svg": {
@@ -600,7 +603,8 @@ class Editor extends React.Component {
                 </ToggleButton>
               )}
             </ToggleButtonGroup>
-            <FormControl>
+            <div className={classes.grow} />
+            <FormControl className={classes.layerSelect}>
               <Select
                 value={currentLayer}
                 classes={{ selectMenu: classes.layerSelectItem }}
@@ -610,7 +614,6 @@ class Editor extends React.Component {
                 {layerMenu}
               </Select>
             </FormControl>
-            <div className={classes.grow} />
             <div>
               <Tooltip title={i18n.editor.importExport}>
                 <IconButton onClick={this.importExportDialog}>


### PR DESCRIPTION
As discussed in #385, this moves the layer dropdown to the right side, and changes the layer clear icon.

![Screenshot from 2019-05-17 15-31-29](https://user-images.githubusercontent.com/17243/57931489-dbe45280-78b8-11e9-9910-e9ceda66a15c.png)
