### PR TITLE
(#382) multiple select LEDs

### DIFF
--- a/src/renderer/components/ColorPalette/ColorButton.js
+++ b/src/renderer/components/ColorPalette/ColorButton.js
@@ -21,6 +21,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
+import ColorizeIcon from "@material-ui/icons/Colorize";
 import { setButtonSizeTamplate } from "../../../renderer/utils/setTemplates";
 
 ColorButton.propTypes = {
@@ -29,7 +30,8 @@ ColorButton.propTypes = {
   setIsFocus: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
   color: PropTypes.object.isRequired,
-  disabled: PropTypes.bool.isRequired
+  disabled: PropTypes.bool.isRequired,
+  isSelected: PropTypes.bool
 };
 
 const styles = theme => ({
@@ -38,20 +40,24 @@ const styles = theme => ({
     margin: 5,
     borderRadius: 5,
     cursor: "pointer",
+    color: "white",
     [theme.breakpoints.down("sm")]: {
       ...setButtonSizeTamplate(35)
     }
+  },
+  whiteButton: {
+    color: "black"
   }
 });
 
 const styleDisabled = {
-  background: `rgb(155, 155, 155)`,
+  background: "rgb(155, 155, 155)",
   pointerEvents: "none",
   cursor: "default"
 };
 
 ///Minimum value for rendering border on white button
-const minWhiteColorValue = 220;
+const minWhiteColorValue = 140;
 
 /**
  * Reactjs functional component that create color button
@@ -61,15 +67,23 @@ const minWhiteColorValue = 220;
  * @param {number} index Current index of button
  * @param {object} color Current color of button
  * @param {boolean} disabled Property that disable component
+ * @param {boolean} isSelected Property is true if multiple select LEDs
  */
 function ColorButton(props) {
-  const { classes, setIsFocus, isFocus, index, color, disabled } = props;
+  const {
+    classes,
+    setIsFocus,
+    isFocus,
+    index,
+    color,
+    disabled,
+    isSelected
+  } = props;
 
   ///Checks background is white or not
   const isWhiteColor =
     color.r >= minWhiteColorValue &&
-    color.g >= minWhiteColorValue &&
-    color.b >= minWhiteColorValue;
+    (color.g >= minWhiteColorValue && color.b >= minWhiteColorValue);
 
   const style = {
     background: `rgb(${color.r}, ${color.g}, ${color.b})`
@@ -89,7 +103,9 @@ function ColorButton(props) {
       style={disabled ? styleDisabled : isFocus ? styleInFocus : style}
       onClick={setIsFocus.bind(this, index, color)}
     >
-      {""}
+      {isFocus && isSelected && (
+        <ColorizeIcon className={isWhiteColor ? classes.whiteButton : null} />
+      )}
     </Button>
   );
 }

--- a/src/renderer/components/ColorPalette/ColorButton.js
+++ b/src/renderer/components/ColorPalette/ColorButton.js
@@ -39,13 +39,9 @@ const styles = theme => ({
     margin: 5,
     borderRadius: 5,
     cursor: "pointer",
-    color: "white",
     [theme.breakpoints.down("sm")]: {
       ...setButtonSizeTamplate(35)
     }
-  },
-  whiteButton: {
-    color: "black"
   }
 });
 

--- a/src/renderer/components/ColorPalette/ColorButton.js
+++ b/src/renderer/components/ColorPalette/ColorButton.js
@@ -21,7 +21,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
-import ColorizeIcon from "@material-ui/icons/Colorize";
 import { setButtonSizeTamplate } from "../../../renderer/utils/setTemplates";
 
 ColorButton.propTypes = {
@@ -67,18 +66,9 @@ const minWhiteColorValue = 140;
  * @param {number} index Current index of button
  * @param {object} color Current color of button
  * @param {boolean} disabled Property that disable component
- * @param {boolean} isSelected Property is true if multiple select LEDs
  */
 function ColorButton(props) {
-  const {
-    classes,
-    setIsFocus,
-    isFocus,
-    index,
-    color,
-    disabled,
-    isSelected
-  } = props;
+  const { classes, setIsFocus, isFocus, index, color, disabled } = props;
 
   ///Checks background is white or not
   const isWhiteColor =
@@ -103,9 +93,7 @@ function ColorButton(props) {
       style={disabled ? styleDisabled : isFocus ? styleInFocus : style}
       onClick={setIsFocus.bind(this, index, color)}
     >
-      {isFocus && isSelected && (
-        <ColorizeIcon className={isWhiteColor ? classes.whiteButton : null} />
-      )}
+      {""}
     </Button>
   );
 }

--- a/src/renderer/components/ColorPalette/ColorButtonsArea.js
+++ b/src/renderer/components/ColorPalette/ColorButtonsArea.js
@@ -30,7 +30,8 @@ ColorButtonsArea.propTypes = {
   indexFocusButton: PropTypes.number.isRequired,
   setIsFocus: PropTypes.func.isRequired,
   palette: PropTypes.array.isRequired,
-  disabled: PropTypes.bool.isRequired
+  disabled: PropTypes.bool.isRequired,
+  colorButtonIsSelected: PropTypes.bool.isRequired
 };
 
 const styles = theme => ({
@@ -50,6 +51,7 @@ const styles = theme => ({
  * @param {function} setIsFocus Callback function from ColorPalette component. Parameters are: first - index of color button in palette (from 0 to 15), second - object with keys that defining colors using the Red-green-blue-alpha (RGBA) model, third - event
  * @param {array} palette Array of colors. Format [{r: 200, g: 200, b: 200, rgb: "rgb(200, 200, 200)"}, ...]
  * @param {boolean} disabled Property that disable component
+ * @param {boolean} colorButtonIsSelected Prop is true if color button signalise for multiple select LEDs
  */
 function ColorButtonsArea(props) {
   const {
@@ -58,7 +60,8 @@ function ColorButtonsArea(props) {
     indexFocusButton,
     setIsFocus,
     palette,
-    disabled
+    disabled,
+    colorButtonIsSelected
   } = props;
 
   /**
@@ -89,6 +92,7 @@ function ColorButtonsArea(props) {
             color={i === indexFocusButton ? colorFocusButton : colorButton}
             setIsFocus={setIsFocus}
             disabled={disabled}
+            isSelected={colorButtonIsSelected}
           />
         ))}
       </Grid>

--- a/src/renderer/components/ColorPalette/ColorButtonsArea.js
+++ b/src/renderer/components/ColorPalette/ColorButtonsArea.js
@@ -26,12 +26,11 @@ import ColorButton from "./ColorButton";
 
 ColorButtonsArea.propTypes = {
   classes: PropTypes.object.isRequired,
-  colorFocusButton: PropTypes.object.isRequired,
-  indexFocusButton: PropTypes.number.isRequired,
+  colorFocusButton: PropTypes.object,
+  indexFocusButton: PropTypes.any,
   setIsFocus: PropTypes.func.isRequired,
   palette: PropTypes.array.isRequired,
-  disabled: PropTypes.bool.isRequired,
-  colorButtonIsSelected: PropTypes.bool.isRequired
+  disabled: PropTypes.bool.isRequired
 };
 
 const styles = theme => ({
@@ -51,7 +50,6 @@ const styles = theme => ({
  * @param {function} setIsFocus Callback function from ColorPalette component. Parameters are: first - index of color button in palette (from 0 to 15), second - object with keys that defining colors using the Red-green-blue-alpha (RGBA) model, third - event
  * @param {array} palette Array of colors. Format [{r: 200, g: 200, b: 200, rgb: "rgb(200, 200, 200)"}, ...]
  * @param {boolean} disabled Property that disable component
- * @param {boolean} colorButtonIsSelected Prop is true if color button signalise for multiple select LEDs
  */
 function ColorButtonsArea(props) {
   const {
@@ -60,8 +58,7 @@ function ColorButtonsArea(props) {
     indexFocusButton,
     setIsFocus,
     palette,
-    disabled,
-    colorButtonIsSelected
+    disabled
   } = props;
 
   /**
@@ -74,8 +71,10 @@ function ColorButtonsArea(props) {
    * Change "colorButtonsAmount", if prop "colorFocusButton" is different
    */
   useEffect(() => {
-    colorButtonsAmount[indexFocusButton] = { ...colorFocusButton };
-    setColorButtonsAmount(colorButtonsAmount);
+    if (indexFocusButton !== null) {
+      colorButtonsAmount[indexFocusButton] = { ...colorFocusButton };
+      setColorButtonsAmount(colorButtonsAmount);
+    }
   }, [colorFocusButton]);
 
   /**
@@ -92,7 +91,6 @@ function ColorButtonsArea(props) {
             color={i === indexFocusButton ? colorFocusButton : colorButton}
             setIsFocus={setIsFocus}
             disabled={disabled}
-            isSelected={colorButtonIsSelected}
           />
         ))}
       </Grid>

--- a/src/renderer/components/ColorPalette/ColorPalette.js
+++ b/src/renderer/components/ColorPalette/ColorPalette.js
@@ -111,7 +111,7 @@ function ColorPalette(props) {
         ...palette[selected]
       });
     }
-  }, [selected]);
+  }, [selected, palette]);
 
   /**
    * Change "colorFocusButton" and pick color of button from PickerColorButton component in functional component state

--- a/src/renderer/components/ColorPalette/ColorPalette.js
+++ b/src/renderer/components/ColorPalette/ColorPalette.js
@@ -24,6 +24,7 @@ import Paper from "@material-ui/core/Paper";
 import ColorButtonsArea from "./ColorButtonsArea";
 import PickerColorButton from "./PickerColorButton";
 import { setColorTamplate } from "../../../renderer/utils/setTemplates";
+import i18n from "../../i18n";
 
 ColorPalette.propTypes = {
   classes: PropTypes.object.isRequired,
@@ -32,8 +33,9 @@ ColorPalette.propTypes = {
   onColorPick: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   selected: PropTypes.any,
-  isMultiSelected: PropTypes.bool.isRequired,
-  isColorButtonSelected: PropTypes.bool.isRequired
+  isColorButtonSelected: PropTypes.bool.isRequired,
+  onColorButtonSelect: PropTypes.func.isRequired,
+  onBottomMenuOpenClose: PropTypes.func.isRequired
 };
 
 const styles = theme => ({
@@ -68,6 +70,8 @@ const styles = theme => ({
  * @param {number} selected Number of selected color button in palette (from 0 to 15)
  * @param {boolean} isMultiSelected Property of state Editor.js component, that gives a possibility to change colors of keyboard
  * @param {boolean} isColorButtonSelected Property for disabled PickerColorButton
+ * @param {function} onColorButtonSelect Callback function from Editor component for change state of selected color button in palette
+ * @param {function} onBottomMenuOpenClose Callback function from Editor component for open(close) bottom menu
  */
 function ColorPalette(props) {
   const {
@@ -77,8 +81,9 @@ function ColorPalette(props) {
     onColorPick,
     disabled,
     selected,
-    isMultiSelected,
-    isColorButtonSelected
+    isColorButtonSelected,
+    onColorButtonSelect,
+    onBottomMenuOpenClose
   } = props;
 
   /**
@@ -116,9 +121,7 @@ function ColorPalette(props) {
    * @param {object} color Object with keys that defining colors using the Red-green-blue-alpha (RGBA) model
    */
   const toSetColorFocusButton = color => {
-    if (isMultiSelected) {
-      onColorPick(indexFocusButton, color.r, color.g, color.b);
-    }
+    onColorPick(indexFocusButton, color.r, color.g, color.b);
     setColorFocusButton(setColorTamplate(color));
   };
 
@@ -131,27 +134,13 @@ function ColorPalette(props) {
     if (e.ctrlKey || e.shiftKey) return;
     if (index === indexFocusButton) {
       setIndexFocusButton(!indexFocusButton);
-      onColorSelect("");
+      onColorButtonSelect("one_button_click");
       return;
     }
-    if (isMultiSelected && index !== indexFocusButton) {
-      setIndexFocusButton(index);
-      setColorFocusButton(setColorTamplate(color));
-      onColorSelect(index, "second");
-      return;
-    }
-    if (!isMultiSelected) {
-      setIndexFocusButton(index);
-      setColorFocusButton(setColorTamplate(color));
-      onColorSelect("");
-    }
-    if (!isMultiSelected && index !== indexFocusButton) {
-      onColorSelect(index, "second");
-      return;
-    }
-    if (isMultiSelected) {
-      onColorSelect(index);
-    }
+    onColorButtonSelect("another_button_click");
+    setIndexFocusButton(index);
+    setColorFocusButton(setColorTamplate(color));
+    onColorSelect(index);
   };
 
   const propsToArea = {
@@ -162,22 +151,23 @@ function ColorPalette(props) {
     disabled
   };
 
-  const propsToPicker = {
-    colorFocusButton,
-    onColorSelect,
-    onColorPick,
-    indexFocusButton
-  };
-
   return (
-    <div className={classes.root}>
+    <div
+      className={classes.root}
+      id="color-palette"
+      onClick={e => {
+        onBottomMenuOpenClose(e, "color_palette");
+      }}
+    >
       <Paper className={classes.palette}>
         <ColorButtonsArea {...propsToArea} />
         <PickerColorButton
           setColorFocusButton={toSetColorFocusButton}
           disabled={disabled || !isColorButtonSelected}
-          {...propsToPicker}
-        />
+          colorFocusButton={colorFocusButton}
+        >
+          {i18n.components.pickerColorButton}
+        </PickerColorButton>
       </Paper>
     </div>
   );

--- a/src/renderer/components/ColorPalette/ColorPalette.js
+++ b/src/renderer/components/ColorPalette/ColorPalette.js
@@ -31,7 +31,9 @@ ColorPalette.propTypes = {
   palette: PropTypes.array.isRequired,
   onColorPick: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
-  selected: PropTypes.number.isRequired
+  selected: PropTypes.number.isRequired,
+  onColorButtonSelect: PropTypes.func.isRequired,
+  colorButtonIsSelected: PropTypes.bool.isRequired
 };
 
 const styles = theme => ({
@@ -64,6 +66,8 @@ const styles = theme => ({
  * @param {function} onColorPick Callback function from Editor component for change color of buttons in ColorPalette. Parameters are: first - index of color button in palette (from 0 to 15), second - index of color (r: from 0 to 255), third - index of color (g: from 0 to 255), fourth - index of color (b: from 0 to 255)
  * @param {boolean} disabled Property that disable component
  * @param {number} selected Number of selected color button in palette (from 0 to 15)
+ * @param {function} onColorButtonSelect Callback function from Editor component for change state of color button
+ * @param {boolean} colorButtonIsSelected Prop is true if color button signalise for multiple select LEDs
  */
 function ColorPalette(props) {
   const {
@@ -72,7 +76,9 @@ function ColorPalette(props) {
     palette,
     onColorPick,
     disabled,
-    selected
+    selected,
+    onColorButtonSelect,
+    colorButtonIsSelected
   } = props;
 
   /**
@@ -113,10 +119,11 @@ function ColorPalette(props) {
    * @param {number} index Number of value in array that focusing by mouse
    * @param {object} color Object with keys that defining colors using the Red-green-blue-alpha (RGBA) model
    */
-  const setIsFocus = (index, color) => {
+  const setIsFocus = (index, color, e) => {
+    if (e.ctrlKey || e.shiftKey) onColorButtonSelect(index);
+    onColorSelect(index);
     setIndexFocusButton(index);
     setColorFocusButton(setColorTamplate(color));
-    onColorSelect(index);
   };
 
   const propsToChild = {
@@ -124,7 +131,8 @@ function ColorPalette(props) {
     indexFocusButton,
     setIsFocus,
     palette,
-    disabled
+    disabled,
+    colorButtonIsSelected
   };
 
   return (

--- a/src/renderer/components/ColorPalette/ColorPalette.js
+++ b/src/renderer/components/ColorPalette/ColorPalette.js
@@ -34,8 +34,7 @@ ColorPalette.propTypes = {
   disabled: PropTypes.bool.isRequired,
   selected: PropTypes.any,
   isColorButtonSelected: PropTypes.bool.isRequired,
-  onColorButtonSelect: PropTypes.func.isRequired,
-  onBottomMenuOpenClose: PropTypes.func.isRequired
+  onColorButtonSelect: PropTypes.func.isRequired
 };
 
 const styles = theme => ({
@@ -71,7 +70,6 @@ const styles = theme => ({
  * @param {boolean} isMultiSelected Property of state Editor.js component, that gives a possibility to change colors of keyboard
  * @param {boolean} isColorButtonSelected Property for disabled PickerColorButton
  * @param {function} onColorButtonSelect Callback function from Editor component for change state of selected color button in palette
- * @param {function} onBottomMenuOpenClose Callback function from Editor component for open(close) bottom menu
  */
 function ColorPalette(props) {
   const {
@@ -82,8 +80,7 @@ function ColorPalette(props) {
     disabled,
     selected,
     isColorButtonSelected,
-    onColorButtonSelect,
-    onBottomMenuOpenClose
+    onColorButtonSelect
   } = props;
 
   /**
@@ -152,13 +149,7 @@ function ColorPalette(props) {
   };
 
   return (
-    <div
-      className={classes.root}
-      id="color-palette"
-      onClick={e => {
-        onBottomMenuOpenClose(e, "color_palette");
-      }}
-    >
+    <div className={classes.root}>
       <Paper className={classes.palette}>
         <ColorButtonsArea {...propsToArea} />
         <PickerColorButton

--- a/src/renderer/components/ColorPalette/PickerColorButton.js
+++ b/src/renderer/components/ColorPalette/PickerColorButton.js
@@ -28,8 +28,11 @@ import PaletteIcon from "@material-ui/icons/Palette";
 PickerColorButton.propTypes = {
   classes: PropTypes.object.isRequired,
   setColorFocusButton: PropTypes.func.isRequired,
-  colorFocusButton: PropTypes.object.isRequired,
-  disabled: PropTypes.bool.isRequired
+  colorFocusButton: PropTypes.object,
+  disabled: PropTypes.bool.isRequired,
+  onColorSelect: PropTypes.func.isRequired,
+  onColorPick: PropTypes.func.isRequired,
+  indexFocusButton: PropTypes.any
 };
 
 const styles = {
@@ -52,13 +55,19 @@ const styles = {
  * @param {function} setColorFocusButton Callback function from ColorPalette component
  * @param {object} colorFocusButton Object with keys that defining colors using the Red-green-blue-alpha (RGBA) model for focus button
  * @param {boolean} disabled Property that disable component
+ * @param {function} onColorSelect Callback function from Editor component for change color of buttons in keyboard. Parameter is index of color button in palette (from 0 to 15)
+ * @param {function} onColorPick Callback function from Editor component for change color of buttons in ColorPalette. Parameters are: first - index of color button in palette (from 0 to 15), second - index of color (r: from 0 to 255), third - index of color (g: from 0 to 255), fourth - index of color (b: from 0 to 255)
+ * @param {number, null} indexFocusButton Number of focus button (from 0 to 15)
  */
 function PickerColorButton(props) {
   const {
     classes,
     setColorFocusButton,
     colorFocusButton: color,
-    disabled
+    disabled,
+    onColorSelect,
+    onColorPick,
+    indexFocusButton
   } = props;
 
   /**
@@ -68,17 +77,20 @@ function PickerColorButton(props) {
   const [anchorEl, setAnchorEl] = useState(null);
 
   /**
-   * Change "anchorEl" in functional component state to open Color Picker
+   * Change "anchorEl" in functional component state to open Color Picker and elements of state Editor.js by onColorSelect function
    */
   const handleClick = e => {
     setAnchorEl(e.currentTarget);
+    onColorSelect("picker");
   };
 
   /**
-   * Change "anchorEl" in functional component state to close Color Picker
+   * Change "anchorEl" in functional component state to close Color Picker pick color of button in state Editor.js by onColorPick function
    */
   const handleClose = () => {
     setAnchorEl(null);
+    if (indexFocusButton !== null)
+      onColorPick(indexFocusButton, color.r, color.g, color.b);
   };
 
   /// Set the value to open (close) Popover element

--- a/src/renderer/components/ColorPalette/PickerColorButton.js
+++ b/src/renderer/components/ColorPalette/PickerColorButton.js
@@ -22,6 +22,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import { SketchPicker } from "react-color";
 import Fab from "@material-ui/core/Fab";
+import Tooltip from "@material-ui/core/Tooltip";
 import Popover from "@material-ui/core/Popover";
 import PaletteIcon from "@material-ui/icons/Palette";
 
@@ -29,10 +30,7 @@ PickerColorButton.propTypes = {
   classes: PropTypes.object.isRequired,
   setColorFocusButton: PropTypes.func.isRequired,
   colorFocusButton: PropTypes.object,
-  disabled: PropTypes.bool.isRequired,
-  onColorSelect: PropTypes.func.isRequired,
-  onColorPick: PropTypes.func.isRequired,
-  indexFocusButton: PropTypes.any
+  disabled: PropTypes.bool.isRequired
 };
 
 const styles = {
@@ -55,19 +53,13 @@ const styles = {
  * @param {function} setColorFocusButton Callback function from ColorPalette component
  * @param {object} colorFocusButton Object with keys that defining colors using the Red-green-blue-alpha (RGBA) model for focus button
  * @param {boolean} disabled Property that disable component
- * @param {function} onColorSelect Callback function from Editor component for change color of buttons in keyboard. Parameter is index of color button in palette (from 0 to 15)
- * @param {function} onColorPick Callback function from Editor component for change color of buttons in ColorPalette. Parameters are: first - index of color button in palette (from 0 to 15), second - index of color (r: from 0 to 255), third - index of color (g: from 0 to 255), fourth - index of color (b: from 0 to 255)
- * @param {number, null} indexFocusButton Number of focus button (from 0 to 15)
  */
 function PickerColorButton(props) {
   const {
     classes,
     setColorFocusButton,
     colorFocusButton: color,
-    disabled,
-    onColorSelect,
-    onColorPick,
-    indexFocusButton
+    disabled
   } = props;
 
   /**
@@ -77,57 +69,56 @@ function PickerColorButton(props) {
   const [anchorEl, setAnchorEl] = useState(null);
 
   /**
-   * Change "anchorEl" in functional component state to open Color Picker and elements of state Editor.js by onColorSelect function
+   * Change "anchorEl" in functional component state to open Color Picker
    */
   const handleClick = e => {
     setAnchorEl(e.currentTarget);
-    onColorSelect("picker");
   };
 
   /**
-   * Change "anchorEl" in functional component state to close Color Picker pick color of button in state Editor.js by onColorPick function
+   * Change "anchorEl" in functional component state to close Color Picker pick color of button
    */
   const handleClose = () => {
     setAnchorEl(null);
-    if (indexFocusButton !== null)
-      onColorPick(indexFocusButton, color.r, color.g, color.b);
   };
 
   /// Set the value to open (close) Popover element
   const open = Boolean(anchorEl);
 
   return (
-    <div className={classes.root}>
-      <Fab
-        color="primary"
-        className={classes.fab}
-        onClick={handleClick}
-        disabled={disabled}
-      >
-        <PaletteIcon className={classes.icon} />
-      </Fab>
-      <Popover
-        id={"simple-popover"}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "left"
-        }}
-        transformOrigin={{
-          vertical: "bottom",
-          horizontal: "right"
-        }}
-      >
-        <SketchPicker
-          color={color}
-          onChange={color => {
-            setColorFocusButton(color.rgb);
+    <Tooltip placement="top-start" title={props.children}>
+      <div className={classes.root}>
+        <Fab
+          color="primary"
+          className={classes.fab}
+          onClick={handleClick}
+          disabled={disabled}
+        >
+          <PaletteIcon className={classes.icon} />
+        </Fab>
+        <Popover
+          id={"simple-popover"}
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: "top",
+            horizontal: "left"
           }}
-        />
-      </Popover>
-    </div>
+          transformOrigin={{
+            vertical: "bottom",
+            horizontal: "right"
+          }}
+        >
+          <SketchPicker
+            color={color}
+            onChange={color => {
+              setColorFocusButton(color.rgb);
+            }}
+          />
+        </Popover>
+      </div>
+    </Tooltip>
   );
 }
 

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -25,7 +25,8 @@ const English = {
     save: {
       success: "Saved!",
       saveChanges: "Save Changes"
-    }
+    },
+    pickerColorButton: "Change color"
   },
   dialog: {
     ok: "Ok",

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -558,15 +558,14 @@ class Editor extends React.Component {
     this.setState({ importExportDialogOpen: false });
   };
   importLayer = data => {
-    const { keymap } = this.state;
     if (data.colormap.length > 0) this.setState({ colorMap: data.colormap });
     if (data.palette.length > 0) this.setState({ palette: data.palette });
     if (data.keymap.length > 0) {
       const { currentLayer } = this.state;
-      if (keymap.onlyCustom) {
+      if (this.state.keymap.onlyCustom) {
         if (currentLayer >= 0) {
           this.setState(state => {
-            let newKeymap = keymap.custom[currentLayer].slice();
+            let newKeymap = this.state.keymap.custom[currentLayer].slice();
             newKeymap[currentLayer] = data.keymap.slice();
             console.log(currentLayer, newKeymap);
             return {
@@ -579,10 +578,12 @@ class Editor extends React.Component {
           });
         }
       } else {
-        if (currentLayer >= keymap.default.length) {
+        if (currentLayer >= this.state.keymap.default.length) {
           this.setState(state => {
-            const defLength = keymap.default.length;
-            let newKeymap = keymap.custom[currentLayer - defLength].slice();
+            const defLength = this.state.keymap.default.length;
+            let newKeymap = this.state.keymap.custom[
+              currentLayer - defLength
+            ].slice();
             newKeymap[currentLayer - defLength] = data.keymap;
 
             return {

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -113,7 +113,8 @@ class Editor extends React.Component {
     mode: "layout",
     clearConfirmationOpen: false,
     copyFromOpen: false,
-    importExportDialogOpen: false
+    importExportDialogOpen: false,
+    colorButtonIsSelected: false
   };
   keymapDB = new KeymapDB();
 
@@ -223,25 +224,52 @@ class Editor extends React.Component {
       return;
     }
 
-    this.setState(state => {
-      if (
-        state.colorMap.length > 0 &&
-        layer >= 0 &&
-        layer < state.colorMap.length
-      ) {
+    if (this.state.colorButtonIsSelected && this.state.currentKeyIndex !== -1) {
+      this.setState(state => {
+        const { selectedPaletteColor } = this.state;
+        let colormap = state.colorMap.slice();
+        colormap[layer][ledIndex] = selectedPaletteColor;
         return {
-          currentLayer: layer,
+          colorMap: colormap,
+          modified: true,
           currentKeyIndex: keyIndex,
-          currentLedIndex: ledIndex,
-          selectedPaletteColor: state.colorMap[layer][ledIndex]
+          currentLedIndex: ledIndex
         };
-      } else {
-        return {
-          currentLayer: layer,
-          currentKeyIndex: keyIndex
-        };
-      }
-    });
+      });
+      this.props.startContext();
+    } else {
+      this.setState(state => {
+        if (
+          state.colorMap.length > 0 &&
+          layer >= 0 &&
+          layer < state.colorMap.length
+        ) {
+          return {
+            currentLayer: layer,
+            currentKeyIndex: keyIndex,
+            currentLedIndex: ledIndex,
+            selectedPaletteColor: state.colorMap[layer][ledIndex]
+          };
+        } else {
+          return {
+            currentLayer: layer,
+            currentKeyIndex: keyIndex
+          };
+        }
+      });
+    }
+  };
+
+  onColorButtonSelect = colorButtonIndex => {
+    if (colorButtonIndex !== this.state.selectedPaletteColor) {
+      this.setState({
+        colorButtonIsSelected: false
+      });
+    } else {
+      this.setState({
+        colorButtonIsSelected: !this.state.colorButtonIsSelected
+      });
+    }
   };
 
   selectLayer = event => {
@@ -651,6 +679,8 @@ class Editor extends React.Component {
                   isReadOnly || currentLayer > this.state.colorMap.length
                 }
                 onColorSelect={this.onColorSelect}
+                onColorButtonSelect={this.onColorButtonSelect}
+                colorButtonIsSelected={this.state.colorButtonIsSelected}
                 palette={this.state.palette}
                 onColorPick={this.onColorPick}
                 selected={this.state.selectedPaletteColor}


### PR DESCRIPTION
### **Update step for #381** 

**Enhancements:**
1) bottom menu doesn't hidden after starting app, and after switching between `colored` and `keys` panels (depends to #396)
2) `button-Pallete` disabled in case `color-button` not on active stage

- to reproduce Multiple selection is just should activate (make a click) a `color-button` and than click to any keys you would like to change a color (except current key => cause it will hide the panel)
- to  turn off `color-button` - just click once again on it
- to know what the color is on current key - press `CTRL` and click the key - `color-button` turning on (as box-shadows around)

Also added a prevention for `color-button` - in case using `CTRL` and click to the `color-button` nothing will changes (its lock to prevent during clicking the key)


********************************
**Will be updated:**

- Click any the key - to allocate it.
- To hide a bottom panel - click to the same key again.

This case avoid to make a current (allocated) key become a coloured 

*To resolve it and hide bottom menu I have suggest a next functionality: 
just click outside the keyboard, 
and to turn bottom panel back - ckick to any key again (the function as is). 