### PR TITLE
KeyboardSelect: Let hardware plugins have more control over enumeration

### DIFF
--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -148,8 +148,14 @@ class KeyboardSelect extends React.Component {
     return new Promise(resolve => {
       focus
         .find(...Hardware.serial)
-        .then(devices => {
-          const list = this.findNonSerialKeyboards(devices);
+        .then(async devices => {
+          let supported_devices = [];
+          for (const device of devices) {
+            if (await focus.isDeviceSupported(device)) {
+              supported_devices.push(device);
+            }
+          }
+          const list = this.findNonSerialKeyboards(supported_devices);
           this.setState({
             loading: false,
             devices: list


### PR DESCRIPTION
When enumerating (USB Serial) devices, let the hardware plugins have more say in which variants of a device they support. By using the new `focus.isDeviceSupported()` method, they can do arbitrary checks and decide the device is not something they support, in which case it gets filtered out.

Depends on keyboardio/chrysalis-api#23, and is an alternative solution for #378.