### PR TITLE
Temporarily disable layer copying and import/export

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -751,17 +751,17 @@ class Editor extends React.Component {
             </FormControl>
             <div>
               <Tooltip title={i18n.editor.importExport}>
-                <IconButton onClick={this.importExportDialog}>
+                <IconButton onClick={this.importExportDialog} disabled>
                   <ImportExportIcon />
                 </IconButton>
               </Tooltip>
               <Tooltip title={i18n.editor.copyFrom}>
-                <IconButton disabled={isReadOnly} onClick={this.copyFromDialog}>
+                <IconButton disabled onClick={this.copyFromDialog}>
                   <FileCopyIcon />
                 </IconButton>
               </Tooltip>
               <Tooltip title={i18n.editor.clearLayer}>
-                <IconButton disabled={isReadOnly} onClick={this.confirmClear}>
+                <IconButton disabled onClick={this.confirmClear}>
                   <LayersClearIcon />
                 </IconButton>
               </Tooltip>


### PR DESCRIPTION
With layer copying and import/export being broken in almost all cases, disable them temporarily, until we come up with a proper fix.

Once a release is made, this commit shall be reverted.

This is a temporary workaround for #374 and #391. It doesn't fix either of them, just disables the functionality until we can deploy a proper fix. We disable it now so we can release a new Chrysalis.