### PR TITLE
Formatting for Homebrew commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ Click on the badge for your operating system's packaging system above
 
 ### macOS Homebrew
 
+```
 brew update && brew upgrade
 brew cask install chrysalis
+```
 
 
 ## Reporting issues


### PR DESCRIPTION
The existing markdown renders as a single line, which errors when pasted into a terminal:

```
$ brew update && brew upgrade brew cask install chrysalis
Already up-to-date.
Error: No available formula with the name "brew"
```