### PR TITLE
KeyboardSettings: Idle time limit control

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -128,7 +128,21 @@ const English = {
       defaultLayer: "Default layer"
     },
     led: {
-      brightness: "Adjust LED brightness"
+      brightness: "Adjust LED brightness",
+      idleDisabled: "Disabled",
+      idleTimeLimit: "Idle time before LEDs turn off",
+      idle: {
+        oneMinute: "1 minute",
+        twoMinutes: "2 minutes",
+        threeMinutes: "3 minutes",
+        fourMinutes: "4 minutes",
+        fiveMinutes: "5 minutes",
+        tenMinutes: "10 minutes",
+        fifteenMinutes: "15 minutes",
+        twentyMinutes: "20 minutes",
+        thirtyMinutes: "30 minutes",
+        sixtyMinutes: "60 minutes"
+      }
     },
     advancedOps: "Advanced keyboard settings & operations",
     resetEEPROM: {

--- a/src/renderer/screens/Preferences/KeyboardSettings.js
+++ b/src/renderer/screens/Preferences/KeyboardSettings.js
@@ -65,6 +65,9 @@ const styles = theme => ({
     paddingTop: theme.spacing.unit * 1,
     width: 200
   },
+  selectContainer: {
+    marginTop: theme.spacing.unit * 2
+  },
   slider: {
     width: 300
   },
@@ -92,6 +95,7 @@ class KeyboardSettings extends React.Component {
       onlyCustom: false
     },
     ledBrightness: 255,
+    ledIdleTimeLimit: 0,
     defaultLayer: 126,
     modified: false,
     showDefaults: false,
@@ -110,6 +114,10 @@ class KeyboardSettings extends React.Component {
     focus.command("led.brightness").then(brightness => {
       brightness = brightness ? parseInt(brightness) : -1;
       this.setState({ ledBrightness: brightness });
+    });
+    focus.command("idleleds.time_limit").then(limit => {
+      limit = limit ? parseInt(limit) : -1;
+      this.setState({ ledIdleTimeLimit: limit });
     });
 
     this.setState({
@@ -145,6 +153,14 @@ class KeyboardSettings extends React.Component {
     this.props.startContext();
   };
 
+  selectIdleLEDTime = event => {
+    this.setState({
+      ledIdleTimeLimit: event.target.value,
+      modified: true
+    });
+    this.props.startContext();
+  };
+
   setShowDefaults = event => {
     this.setState({
       showDefaults: event.target.checked,
@@ -164,11 +180,19 @@ class KeyboardSettings extends React.Component {
   saveKeymapChanges = async () => {
     const focus = new Focus();
 
-    const { keymap, defaultLayer, showDefaults, ledBrightness } = this.state;
+    const {
+      keymap,
+      defaultLayer,
+      showDefaults,
+      ledBrightness,
+      ledIdleTimeLimit
+    } = this.state;
 
     await focus.command("keymap.onlyCustom", keymap.onlyCustom);
     await focus.command("settings.defaultLayer", defaultLayer);
     await focus.command("led.brightness", ledBrightness);
+    if (ledIdleTimeLimit >= 0)
+      await focus.command("idleleds.time_limit", ledIdleTimeLimit);
     settings.set("keymap.showDefaults", showDefaults);
     this.setState({ modified: false });
     this.props.cancelContext();
@@ -181,7 +205,8 @@ class KeyboardSettings extends React.Component {
       defaultLayer,
       modified,
       showDefaults,
-      ledBrightness
+      ledBrightness,
+      ledIdleTimeLimit
     } = this.state;
 
     const onlyCustomSwitch = (
@@ -237,6 +262,53 @@ class KeyboardSettings extends React.Component {
         onChange={this.setBrightness}
       />
     );
+    const idleControl = (
+      <Select
+        onChange={this.selectIdleLEDTime}
+        value={ledIdleTimeLimit}
+        variant="filled"
+        input={
+          <FilledInput
+            classes={{
+              root: classes.selectContainer,
+              input: classes.select
+            }}
+          />
+        }
+      >
+        <MenuItem value={0}>{i18n.keyboardSettings.led.idleDisabled}</MenuItem>
+        <MenuItem value={60}>
+          {i18n.keyboardSettings.led.idle.oneMinute}
+        </MenuItem>
+        <MenuItem value={120}>
+          {i18n.keyboardSettings.led.idle.twoMinutes}
+        </MenuItem>
+        <MenuItem value={180}>
+          {i18n.keyboardSettings.led.idle.threeMinutes}
+        </MenuItem>
+        <MenuItem value={240}>
+          {i18n.keyboardSettings.led.idle.fourMinutes}
+        </MenuItem>
+        <MenuItem value={300}>
+          {i18n.keyboardSettings.led.idle.fiveMinutes}
+        </MenuItem>
+        <MenuItem value={600}>
+          {i18n.keyboardSettings.led.idle.tenMinutes}
+        </MenuItem>
+        <MenuItem value={900}>
+          {i18n.keyboardSettings.led.idle.fifteenMinutes}
+        </MenuItem>
+        <MenuItem value={1200}>
+          {i18n.keyboardSettings.led.idle.twentyMinutes}
+        </MenuItem>
+        <MenuItem value={1800}>
+          {i18n.keyboardSettings.led.idle.thirtyMinutes}
+        </MenuItem>
+        <MenuItem value={3600}>
+          {i18n.keyboardSettings.led.idle.sixtyMinutes}
+        </MenuItem>
+      </Select>
+    );
 
     return (
       <React.Fragment>
@@ -273,6 +345,15 @@ class KeyboardSettings extends React.Component {
                 labelPlacement="start"
                 label={i18n.keyboardSettings.keymap.defaultLayer}
               />
+              {ledIdleTimeLimit >= 0 && (
+                <FormControlLabel
+                  className={classes.control}
+                  classes={{ label: classes.grow }}
+                  control={idleControl}
+                  labelPlacement="start"
+                  label={i18n.keyboardSettings.led.idleTimeLimit}
+                />
+              )}
               {ledBrightness >= 0 && (
                 <FormControlLabel
                   className={classes.control}


### PR DESCRIPTION
This implements an idle time limit control widget for the Keyboard Settings screen, on connected boards that support it.

![Screenshot from 2020-01-14 18-17-30](https://user-images.githubusercontent.com/17243/72366339-59878900-36fa-11ea-9343-976c7cd354b6.png)

Because it touches the same code as #456, to avoid conflicts, this is based on top of that PR. If need be, I can rebase it onto master.