### PR TITLE
Fix notification dismissability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "electron-devtools-installer": "^2.2.4",
     "electron-settings": "^3.2.0",
     "electron-window-state": "^5.0.3",
-    "notistack": "^0.5.1",
+    "notistack": "^0.9.7",
     "prop-types": "^15.7.2",
     "react": "16.8.5",
     "react-color": "^2.14.1",

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -27,16 +27,20 @@ import App from "./App";
 import Error from "./Error";
 import "../styles/keymap.css";
 
-const dismissButton = (
-  <IconButton color="inherit" size="small">
-    <CloseIcon />
-  </IconButton>
-);
+const notistackRef = React.createRef();
+const onClickDismiss = key => () => {
+  notistackRef.current.closeSnackbar(key);
+};
 
 try {
   ReactDOM.render(
     <SnackbarProvider
-      action={dismissButton}
+      ref={notistackRef}
+      action={key => (
+        <IconButton color="inherit" size="small" onClick={onClickDismiss(key)}>
+          <CloseIcon />
+        </IconButton>
+      )}
       maxSnack={4}
       autoHideDuration={null}
     >

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -149,9 +149,8 @@ class FirmwareUpdate extends React.Component {
       await this._flash();
     } catch (e) {
       console.error(e);
-      this.props.enqueueSnackbar(i18n.firmwareUpdate.flashing.error, {
-        variant: "error",
-        action: (
+      const action = key => (
+        <React.Fragment>
           <Button
             variant="contained"
             onClick={() => {
@@ -163,7 +162,18 @@ class FirmwareUpdate extends React.Component {
           >
             Troubleshooting
           </Button>
-        )
+          <Button
+            onClick={() => {
+              this.props.closeSnackbar(key);
+            }}
+          >
+            Dismiss
+          </Button>
+        </React.Fragment>
+      );
+      this.props.enqueueSnackbar(i18n.firmwareUpdate.flashing.error, {
+        variant: "error",
+        action: action
       });
       this.props.toggleFlashing();
       this.props.onDisconnect();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6005,6 +6005,13 @@ hoist-non-react-statics@^3.2.1:
   dependencies:
     react-is "^16.7.0"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -8680,13 +8687,15 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
-notistack@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.5.1.tgz#a8b62586afdfbe4c2080d67ea034bf784711f520"
-  integrity sha512-Pym0iWYCDFsC3imDL+zx4lWjkeEu6s/mlIDq6m+VRpHPPNFJErNcHCqo+xakvkkpOOR3fz4Y802GtMk8GDFVIA==
+notistack@^0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.9.7.tgz#4475db65ec365c1d38244c66285e81f525ea0abb"
+  integrity sha512-OztbtaIiCMR7QdcDGXTcYu96Uuvu26k41d7cnMGdf4NaKkAX06fsLPAlodGPj4HrMjMBUl8nvUQ3LmQOS6kHWQ==
   dependencies:
     classnames "^2.2.6"
-    prop-types "^15.6.2"
+    hoist-non-react-statics "^3.3.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
 
 npm-bundled@^1.0.1:
   version "1.0.5"
@@ -10089,6 +10098,11 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-is@^16.8.6:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Upgrade the `notistack` dependency, so we have a version with which we can do dismissability the way we want. Also update the default notification buttons to take advantage of this, and teach the error notification from flashing to have a dismiss button aswell.

Fixes #446.
