### PR TITLE
Optionally disable the sandbox on the AppImage build

### DIFF
--- a/build/afterPackHook.js
+++ b/build/afterPackHook.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+
+const renameAsync = util.promisify(fs.rename);
+const unlinkAsync = util.promisify(fs.unlink);
+
+module.exports = async function(context) {
+  // Replace the app launcher on linux only.
+  if (process.platform !== 'linux') {
+    return;
+  }
+
+  const executableName = context.packager.executableName;
+  const sourceExecutable = path.join(context.appOutDir, executableName);
+  const targetExecutable = path.join(context.appOutDir, `${executableName}-bin`);
+  const launcherScript = path.join(
+    context.appOutDir,
+    'resources',
+    'launcher.sh'
+  );
+
+  return Promise.all([
+    // rename chrysalis to chrysalis-bin
+    renameAsync(sourceExecutable, targetExecutable),
+
+    // rename launcher script to chrysalis
+    renameAsync(launcherScript, sourceExecutable)
+  ]);
+};

--- a/build/launcher.sh
+++ b/build/launcher.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+set -e
+
+UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/chrysalis-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,14 @@
       "target": [
         "AppImage"
       ]
-    }
+    },
+    "afterPack": "./build/afterPackHook.js",
+    "extraResources": [
+      {
+        "from": "./build/launcher.sh",
+        "to": "launcher.sh"
+      }
+    ]
   },
   "dependencies": {
     "@material-ui/core": "^3.9.2",


### PR DESCRIPTION
On Linux, sandboxing requires either a suid root helper (which we can't ship in the AppImage build), running as root (which is something we'd rather avoid), or unprivileged user namespace cloning (which is only available on more recent kernels). Since we do not want to run as root, and we'd like users to run Chrysalis without having to explicitly pass arguments to it, on Linux, we wrap the launcher.

The wrapper checks for the necessary kernel feature, and disables the sandbox if the feature is not available. This is still a better and safer experience than running as root, or than the user having to explicitly run Chrysalis with `--no-sandbox`.

This is only done on Linux, and only for the AppImage build. Running `yarn run start` will still require the extra flag.
