### PR TITLE
Only display the colormap editor switch if colormap is supported

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -37,6 +37,7 @@ const English = {
     menu: {
       welcome: "Welcome",
       editor: "Layout & Colormap Editor",
+      layoutEditor: "Layout Editor",
       firmwareUpdate: "Firmware Update",
       keyboardSettings: "Keyboard Settings",
       preferences: "Preferences",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -36,6 +36,7 @@ const Hungarian = {
     menu: {
       welcome: "Üdvözlet",
       editor: "Kiosztás & színtérkép szerkesztő",
+      layoutEditor: "Kiosztás szerkesztő",
       firmwareUpdate: "Vezérlő frissítés",
       keyboardSettings: "Billentyűzet beállítások",
       preferences: "Beállítások",

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -734,34 +734,42 @@ class Editor extends React.Component {
     const layerMenu = (defaultLayerMenu || []).concat(customLayerMenu);
     const { mode } = this.state;
 
+    const editorSwitchToggle = palette.length > 0 && keymap.custom.length > 0;
+    let title;
+    if (palette.length > 0) {
+      title = i18n.app.menu.editor;
+    } else {
+      title = i18n.app.menu.layoutEditor;
+    }
+
     return (
       <React.Fragment>
-        <Portal container={this.props.titleElement}>
-          {i18n.app.menu.editor}
-        </Portal>
+        <Portal container={this.props.titleElement}>{title}</Portal>
         <Portal container={this.props.appBarElement}>
           <Toolbar>
-            <ToggleButtonGroup
-              value={mode}
-              exclusive
-              className={classes.tbg}
-              onChange={(_, mode) => {
-                this.setMode(mode);
-              }}
-            >
-              <ToggleButton value="layout" disabled={mode == "layout"}>
-                <Tooltip title={i18n.editor.layoutMode}>
-                  <KeyboardIcon />
-                </Tooltip>
-              </ToggleButton>
-              {palette.length && (
-                <ToggleButton value="colormap" disabled={mode == "colormap"}>
-                  <Tooltip title={i18n.editor.colormapMode}>
-                    <PaletteIcon />
+            {editorSwitchToggle && (
+              <ToggleButtonGroup
+                value={mode}
+                exclusive
+                className={classes.tbg}
+                onChange={(_, mode) => {
+                  this.setMode(mode);
+                }}
+              >
+                <ToggleButton value="layout" disabled={mode == "layout"}>
+                  <Tooltip title={i18n.editor.layoutMode}>
+                    <KeyboardIcon />
                   </Tooltip>
                 </ToggleButton>
-              )}
-            </ToggleButtonGroup>
+                {palette.length && (
+                  <ToggleButton value="colormap" disabled={mode == "colormap"}>
+                    <Tooltip title={i18n.editor.colormapMode}>
+                      <PaletteIcon />
+                    </Tooltip>
+                  </ToggleButton>
+                )}
+              </ToggleButtonGroup>
+            )}
             <div className={classes.grow} />
             <FormControl className={classes.layerSelect}>
               <Select


### PR DESCRIPTION
If the connected keyboard has a zero-length palette, do not display the layout/colormap switch button, and only mention "Layout Editor" in the title.

Fixes #477.

![Screenshot from 2020-03-08 19-20-25](https://user-images.githubusercontent.com/17243/76168675-331e2100-6172-11ea-889a-9dbbd0ac0f55.png)
