### PR TITLE
Add an option to restore factory defaults during flashing

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -167,12 +167,20 @@ const English = {
       firmwareFiles: "Firmware files",
       allFiles: "All files"
     },
+    options: {
+      onFlash: "Restore to factory defaults when flashing",
+      title: "Firmware update options"
+    },
     flashing: {
       error: "Error flashing the firmware",
       troubleshooting: "Troubleshooting",
       success: "Firmware flashed successfully!",
       button: "Update",
       buttonSuccess: "Updated!"
+    },
+    confirmDialog: {
+      title: "Replace the firmware and reset to factory defaults?",
+      contents: `This will replace the firmware on the device, and reset all settings to factory defaults. You will lose all customizations made.`
     },
     defaultFirmware: "Chrysalis {0} default",
     defaultFirmwareDescription: "Minimal, without bells and whistles",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2019  Keyboardio, Inc.
+ * Copyright (C) 2019, 2020  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -150,12 +150,20 @@ Minden testreszabott beállítás el fog veszni.`
       firmwareFiles: "Vezérlő állományok",
       allFiles: "Minden állomány"
     },
+    options: {
+      onFlash: "Gyári alapbeállításokra visszaállás vezérlő frissítéskor",
+      title: "Vezérlő frissítés beállítások"
+    },
     flashing: {
       error: "Hiba a vezérlő frissítése közben",
       troubleshooting: "Hibaelhárítás",
       success: "Vezérlő sikeresen frissítve!",
       button: "Frissítés",
       buttonSuccess: "Frissítve!"
+    },
+    confirmDialog: {
+      title: "Felülírja a vezérlőt, és visszaáll gyári beállításokra?",
+      contents: `Ezzel felülírja az eszköz vezérlőjét, és visszaáll a gyári beállításokra. Minden testreszabott beállítás el fog veszni.`
     },
     defaultFirmware: "Chrysalis {0} alapértelmezett",
     defaultFirmwareDescription: "Minimális, extrák nélkül",

--- a/src/renderer/screens/Preferences/KeyboardSettings.js
+++ b/src/renderer/screens/Preferences/KeyboardSettings.js
@@ -40,6 +40,7 @@ import Focus from "../../../api/focus";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import SaveChangesButton from "../../components/SaveChangesButton";
 import i18n from "../../i18n";
+import clearEEPROM from "../../utils/clearEEPROM";
 
 import settings from "electron-settings";
 
@@ -389,29 +390,21 @@ KeyboardSettings.propTypes = {
 
 class AdvancedKeyboardSettings extends React.Component {
   state = {
-    EEPROMClearConfirmationOpen: false
+    EEPROMResetConfirmationOpen: false
   };
 
-  clearEEPROM = async () => {
-    const focus = new Focus();
-
+  resetEEPROM = async () => {
     await this.setState({ working: true });
-    this.closeEEPROMClearConfirmation();
+    this.closeEEPROMResetConfirmation();
 
-    let eeprom = await focus.command("eeprom.contents");
-    eeprom = eeprom
-      .split(" ")
-      .filter(v => v.length > 0)
-      .map(() => 255)
-      .join(" ");
-    await focus.command("eeprom.contents", eeprom);
+    await clearEEPROM();
     this.setState({ working: false });
   };
-  openEEPROMClearConfirmation = () => {
-    this.setState({ EEPROMClearConfirmationOpen: true });
+  openEEPROMResetConfirmation = () => {
+    this.setState({ EEPROMResetConfirmationOpen: true });
   };
-  closeEEPROMClearConfirmation = () => {
-    this.setState({ EEPROMClearConfirmationOpen: false });
+  closeEEPROMResetConfirmation = () => {
+    this.setState({ EEPROMResetConfirmationOpen: false });
   };
 
   render() {
@@ -433,7 +426,7 @@ class AdvancedKeyboardSettings extends React.Component {
               disabled={this.state.working}
               variant="contained"
               color="secondary"
-              onClick={this.openEEPROMClearConfirmation}
+              onClick={this.openEEPROMResetConfirmation}
             >
               {i18n.keyboardSettings.resetEEPROM.button}
             </Button>
@@ -441,9 +434,9 @@ class AdvancedKeyboardSettings extends React.Component {
         </Card>
         <ConfirmationDialog
           title={i18n.keyboardSettings.resetEEPROM.dialogTitle}
-          open={this.state.EEPROMClearConfirmationOpen}
-          onConfirm={this.clearEEPROM}
-          onCancel={this.closeEEPROMClearConfirmation}
+          open={this.state.EEPROMResetConfirmationOpen}
+          onConfirm={this.resetEEPROM}
+          onCancel={this.closeEEPROMResetConfirmation}
         >
           {i18n.keyboardSettings.resetEEPROM.dialogContents}
         </ConfirmationDialog>

--- a/src/renderer/utils/clearEEPROM.js
+++ b/src/renderer/utils/clearEEPROM.js
@@ -1,0 +1,32 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Focus from "../../api/focus";
+
+const clearEEPROM = async () => {
+  const focus = new Focus();
+
+  let eeprom = await focus.command("eeprom.contents");
+  eeprom = eeprom
+    .split(" ")
+    .filter(v => v.length > 0)
+    .map(() => 255)
+    .join(" ");
+  await focus.command("eeprom.contents", eeprom);
+};
+
+export { clearEEPROM as default };


### PR DESCRIPTION
While we can reset the EEPROM post-flash, it's easier if we can do both at once.

## Firmware update

![Screenshot from 2020-03-28 10-40-48](https://user-images.githubusercontent.com/17243/77820272-58eb7580-70e1-11ea-934b-30763a127851.png)

## Confirmation

![Screenshot from 2020-03-28 10-40-56](https://user-images.githubusercontent.com/17243/77820283-6274dd80-70e1-11ea-96ac-5810d28ff3bd.png)