### PR TITLE
Add a progress bar to the FirmwareUpdate screen

### DIFF
--- a/src/api/hardware-keyboardio-atreus2/index.js
+++ b/src/api/hardware-keyboardio-atreus2/index.js
@@ -49,7 +49,8 @@ const Atreus2 = {
     }
   },
 
-  flash: async (port, filename) => {
+  flashSteps: ["bootloaderTrigger", "bootloaderWait", "flash"],
+  flash: async (port, filename, options) => {
     const board = {
       name: "Keyboardio Atreus",
       baud: 9600,
@@ -58,7 +59,7 @@ const Atreus2 = {
       signature: new Buffer.from([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
       closeOnFlashComplete: false
     };
-    return Avr109(board, port, filename);
+    return Avr109(board, port, filename, options);
   }
 };
 

--- a/src/api/hardware-keyboardio-model01/index.js
+++ b/src/api/hardware-keyboardio-model01/index.js
@@ -57,7 +57,8 @@ const Model01 = {
     }
   },
 
-  flash: async (port, filename) => {
+  flashSteps: ["bootloaderTrigger", "bootloaderWait", "flash"],
+  flash: async (port, filename, options) => {
     const board = {
       name: "Keyboardio Model 01",
       baud: 9600,
@@ -66,7 +67,7 @@ const Model01 = {
       signature: new Buffer.from([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
       closeOnFlashComplete: false
     };
-    return Avr109(board, port, filename);
+    return Avr109(board, port, filename, options);
   }
 };
 

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -177,7 +177,13 @@ const English = {
       troubleshooting: "Troubleshooting",
       success: "Firmware flashed successfully!",
       button: "Update",
-      buttonSuccess: "Updated!"
+      buttonSuccess: "Updated!",
+      steps: {
+        factoryRestore: "Restoring factory defaults",
+        bootloaderTrigger: "Triggering bootloader",
+        bootloaderWait: "Waiting for bootloader",
+        flash: "Flashing"
+      }
     },
     confirmDialog: {
       title: "Replace the firmware and reset to factory defaults?",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -160,7 +160,13 @@ Minden testreszabott beállítás el fog veszni.`
       troubleshooting: "Hibaelhárítás",
       success: "Vezérlő sikeresen frissítve!",
       button: "Frissítés",
-      buttonSuccess: "Frissítve!"
+      buttonSuccess: "Frissítve!",
+      steps: {
+        factoryRestore: "Gyári beállítások visszaállítása",
+        bootloaderTrigger: "Programozó indítása",
+        bootloaderWait: "Várakozás a programozóra",
+        flash: "Frissítés"
+      }
     },
     confirmDialog: {
       title: "Felülírja a vezérlőt, és visszaáll gyári beállításokra?",


### PR DESCRIPTION
# Description

Knowing what's happening, what we're waiting for, is very valuable information, both for the user, and for developers too, when working on bug reports. To this end, lets display a progress bar when flashing is in progress, giving a rough outline about where we are in the process.

At the moment, this is only implemented for boards using the Avr109 flashing protocol. The others will display a progress stepper too, but with a single element only, for now.

Fixes #492.

# Screenshots

The progress bar is not shown until the "Update" button is pressed:

![Screenshot from 2020-04-02 12-00-18](https://user-images.githubusercontent.com/17243/78235874-8d907000-74d9-11ea-94bc-23840da5f6b1.png)

Without the factory reset option set, we start by triggering the bootloader, and then waiting for it:

![Screenshot from 2020-04-02 12-01-48](https://user-images.githubusercontent.com/17243/78236132-e3fdae80-74d9-11ea-8dcb-a8721a9b811c.png)

And finally, we flash:

![Screenshot from 2020-04-02 12-02-25](https://user-images.githubusercontent.com/17243/78236206-f972d880-74d9-11ea-89c2-f974cb3f56bf.png)

---

With the factory reset enabled, we have an additional step in the beginning:

![Screenshot from 2020-04-02 12-04-38](https://user-images.githubusercontent.com/17243/78236347-27581d00-74da-11ea-88a2-7fd5e4aa2e7e.png)
