### PR TITLE
Add Num Lock key

### DIFF
--- a/src/api/keymap/db/miscellaneous.js
+++ b/src/api/keymap/db/miscellaneous.js
@@ -25,6 +25,13 @@ const MiscellaneousTable = {
       }
     },
     {
+      code: 83,
+      labels: {
+        primary: "NumLK",
+        verbose: "Num Lock"
+      }
+    },
+    {
       code: 71,
       labels: {
         primary: "ScrlLK",


### PR DESCRIPTION
Adds a label and keycode for the Num Lock key.

I've validated the keycode using the "Unknown keycodes" entry in Chrysalis and confirmed it sends the correct Num Lock code on Windows 10.