### PR TITLE
Editor: Support cases where we have a colormap only

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -175,7 +175,7 @@ class App extends React.Component {
       device: null,
       pages: pages
     });
-    await navigate(pages.keymap ? "/editor" : "/welcome");
+    await navigate(pages.keymap || pages.colormap ? "/editor" : "/welcome");
     return commands;
   };
 

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -38,6 +38,7 @@ const English = {
       welcome: "Welcome",
       editor: "Layout & Colormap Editor",
       layoutEditor: "Layout Editor",
+      colormapEditor: "Colormap Editor",
       firmwareUpdate: "Firmware Update",
       keyboardSettings: "Keyboard Settings",
       preferences: "Preferences",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -37,6 +37,7 @@ const Hungarian = {
       welcome: "Üdvözlet",
       editor: "Kiosztás & színtérkép szerkesztő",
       layoutEditor: "Kiosztás szerkesztő",
+      colormapEditor: "Színtérkép szerkesztő",
       firmwareUpdate: "Vezérlő frissítés",
       keyboardSettings: "Billentyűzet beállítások",
       preferences: "Beállítások",


### PR DESCRIPTION
The Editor screen already had support for cases where we only have a keymap, but no colormap; it also supported having both; but it lacked support for the case where we only have a colormap.

There are many valid reasons for not having an editable keymap, and not having the `EEPROMKeymap` plugin enabled at all. This patch reworks the Editor screen a bit so that we support firmware with said plugin disabled, too.

Fixes #496.
