### PR TITLE
keymap: Move the various *Lock keys to modifiers

### DIFF
--- a/src/api/keymap/db/miscellaneous.js
+++ b/src/api/keymap/db/miscellaneous.js
@@ -1,5 +1,5 @@
 /* chrysalis-keymap -- Chrysalis keymap library
- * Copyright (C) 2018  Keyboardio, Inc.
+ * Copyright (C) 2018-2020  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -22,20 +22,6 @@ const MiscellaneousTable = {
       labels: {
         primary: "PrnScr",
         verbose: "Print Screen"
-      }
-    },
-    {
-      code: 83,
-      labels: {
-        primary: "NumLK",
-        verbose: "Num Lock"
-      }
-    },
-    {
-      code: 71,
-      labels: {
-        primary: "ScrlLK",
-        verbose: "Scroll Lock"
       }
     },
     {

--- a/src/api/keymap/db/modifiers.js
+++ b/src/api/keymap/db/modifiers.js
@@ -18,7 +18,7 @@ import { withModifiers } from "./utils";
 import { guiLabel } from "./gui";
 
 const ModifiersTable = {
-  groupName: "Modifiers",
+  groupName: "Modifiers & Locks",
   keys: [
     {
       code: 224,
@@ -74,6 +74,27 @@ const ModifiersTable = {
       labels: {
         primary: "R" + guiLabel,
         verbose: "Right " + guiLabel
+      }
+    },
+    {
+      code: 57,
+      labels: {
+        primary: "CapsLK",
+        verbose: "Caps Lock"
+      }
+    },
+    {
+      code: 83,
+      labels: {
+        primary: "NumLK",
+        verbose: "Num Lock"
+      }
+    },
+    {
+      code: 71,
+      labels: {
+        primary: "ScrlLK",
+        verbose: "Scroll Lock"
       }
     }
   ]

--- a/src/api/keymap/db/punctuation.js
+++ b/src/api/keymap/db/punctuation.js
@@ -1,5 +1,5 @@
 /* chrysalis-keymap -- Chrysalis keymap library
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -83,13 +83,6 @@ const PunctuationTable = {
       code: 56,
       labels: {
         primary: "/"
-      }
-    },
-    {
-      code: 57,
-      labels: {
-        primary: "CapsLK",
-        verbose: "Caps Lock"
       }
     },
     {


### PR DESCRIPTION
Move Caps Lock, Scroll Lock, and Num Lock to the modifiers group, and rename it to "Modifiers & Locks".
