### PR TITLE
KeyboardSelect: Check device permissions on Linux

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -16,6 +16,7 @@
 
 import SerialPort from "serialport";
 import Delimiter from "@serialport/parser-delimiter";
+import fs from "fs";
 
 global.chrysalis_focus_instance = null;
 
@@ -116,6 +117,17 @@ class Focus {
     }
     this._port = null;
     this.device = null;
+  }
+
+  async isDeviceAccessible(port) {
+    if (process.platform !== "linux") return true;
+
+    try {
+      fs.accessSync(port.path, fs.constants.R_OK | fs.constants.W_OK);
+    } catch (e) {
+      return false;
+    }
+    return true;
   }
 
   async isDeviceSupported(port) {

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -160,7 +160,8 @@ const English = {
     noDevices: "No keyboards found!",
     connect: "Connect",
     disconnect: "Disconnect",
-    scan: "Scan keyboards"
+    scan: "Scan keyboards",
+    permissionError: `Insufficient permissions, please make sure the device file is read- and writeable!`
   },
   firmwareUpdate: {
     dialog: {

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -151,7 +151,10 @@ class KeyboardSelect extends React.Component {
         .then(async devices => {
           let supported_devices = [];
           for (const device of devices) {
-            if (await focus.isDeviceSupported(device)) {
+            device.accessible = await focus.isDeviceAccessible(device);
+            if (device.accessible && (await focus.isDeviceSupported(device))) {
+              supported_devices.push(device);
+            } else if (!device.accessible) {
               supported_devices.push(device);
             }
           }
@@ -313,9 +316,17 @@ class KeyboardSelect extends React.Component {
       </Button>
     );
 
-    let connectionButton;
+    let connectionButton, permissionWarning;
     let focus = new Focus();
     const selectedDevice = devices && devices[this.state.selectedPortIndex];
+
+    if (selectedDevice && !selectedDevice.accessible) {
+      permissionWarning = (
+        <Typography variant="body1" color="error" className={classes.error}>
+          {i18n.t("keyboardSelect.permissionError")}
+        </Typography>
+      );
+    }
 
     if (
       focus.device &&
@@ -339,6 +350,7 @@ class KeyboardSelect extends React.Component {
       connectionButton = (
         <Button
           disabled={
+            (selectedDevice ? !selectedDevice.accessible : false) ||
             this.state.opening ||
             (this.state.devices && this.state.devices.length == 0)
           }
@@ -374,6 +386,7 @@ class KeyboardSelect extends React.Component {
           <CardContent className={classes.content}>
             {preview}
             {port}
+            {permissionWarning}
           </CardContent>
           <Divider variant="middle" />
           <CardActions className={classes.cardActions}>


### PR DESCRIPTION
On Linux, before allowing to connect to a keyboard, check that the device file has read and write permissions. If it is not, disable the connect button, and display an error.

Fixes #500.
