### PR TITLE
Add Jetbrains and VSCode workspace config folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /package-lock.json
 /yarn-error.log
 /*.png
+/.vscode
+/.idea


### PR DESCRIPTION
## What

Adds lines to gitignore that will ignore workspace configuration folders for vscode and jetbrains IDEs.
See: 

https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-
https://code.visualstudio.com/docs/getstarted/settings

## Why

These are fairly common IDEs and it will help keep future commits and contributions clean.