### PR TITLE
Do include the contents of static/ in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       {
         "from": "./build/launcher.sh",
         "to": "launcher.sh"
-      }
+      },
+      "static"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
When we added the special launcher for older Linux distributions, we overrode `build.extraResources` to include the launcher. However, said setting's default was to include the `static/` directory in the production builds.

This adds `static` back explicitly, so our production builds will have its contents bundled with them again.
