### PR TITLE
Flashing process fixes

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -29,6 +29,9 @@ async function Avr109Bootloader(board, port, filename) {
 
   return new Promise((resolve, reject) => {
     try {
+      if (port.isOpen) {
+        port.close();
+      }
       avrgirl.flash(filename, async error => {
         if (error) {
           console.log(error);

--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -28,19 +28,25 @@ async function Avr109Bootloader(board, port, filename) {
   });
 
   return new Promise((resolve, reject) => {
-    avrgirl.flash(filename, async error => {
-      if (error) {
-        console.log(error);
-        try {
-          avrgirl.connection.serialPort.close();
-        } catch (_) {
-          /* ignore the error */
+    try {
+      avrgirl.flash(filename, async error => {
+        if (error) {
+          console.log(error);
+          if (avrgirl.connection.serialPort.isOpen) {
+            try {
+              avrgirl.connection.serialPort.close();
+            } catch (_) {
+              /* ignore the error */
+            }
+          }
+          reject(error);
+        } else {
+          resolve();
         }
-        reject(error);
-      } else {
-        resolve();
-      }
-    });
+      });
+    } catch (e) {
+      reject(e);
+    }
   });
 }
 

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -112,7 +112,7 @@ class Focus {
   }
 
   close() {
-    if (this._port) {
+    if (this._port && this._port.isOpen) {
       this._port.close();
     }
     this._port = null;

--- a/src/renderer/components/ConfirmationDialog.js
+++ b/src/renderer/components/ConfirmationDialog.js
@@ -29,6 +29,7 @@ const ConfirmationDialog = props => {
   return (
     <Dialog
       disableBackdropClick
+      disableEscapeKeyDown
       open={props.open}
       onClose={props.onCancel}
       fullWidth


### PR DESCRIPTION
These fixes improve the flashing process in various ways:

- When asking for confirmation (such as when we're about to restore factory settings during flashing) the dialogs will now ignore the `Esc` key, so when we hold it to enter bootloader mode, we no longer cancel the process.
- The error handling in the Avr109 flasher was substantially improved: we no longer pollute the developer console with errors unless there really is one. In other words, we only try to close the serialport if it is open, and we try to catch more errors from AvrGirl, to report them accurately instead of ending up with an uncaught exception.