### PR TITLE
Cancel the context state of the AppBar when a keyboard disconnects

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -105,6 +105,8 @@ class App extends React.Component {
         });
         focus.close();
         this.setState({
+          contextBar: false,
+          cancelPendingOpen: false,
           connected: false,
           device: null,
           pages: {}


### PR DESCRIPTION
If we have pending, unsaved actions, we put the AppBar in context mode. However, when the keyboard physically disconnects, we can no longer do anything about these unsaved actions. As such, lets put the AppBar back in normal mode, and cancel the context.

Fixes #393.
