### PR TITLE
Bug: In dark mode, header text should be white

### DIFF
--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -89,15 +89,10 @@ function Header({
       id="appbar"
     >
       <Toolbar variant="dense">
-        <Button
-          className={classes.menuButton}
-          color="inherit"
-          onClick={contextOnClick}
-        >
+        <Button className={classes.menuButton} onClick={contextOnClick}>
           {contextBar ? <CloseIcon /> : <MenuIcon />}
           <Typography
             variant="h6"
-            color="inherit"
             className={classes.pageMenu}
             id="page-title"
           />
@@ -113,7 +108,6 @@ function Header({
           <Button
             onClick={openBoardMenu}
             disabled={!device.urls}
-            color="inherit"
             className="button"
           >
             {i18n.t("app.device")}: {device.displayName}


### PR DESCRIPTION
## Description
In Dark mode, the header text was not changing colors. It appears that this was due to the `color: inherit` property being set. Removing this, the header text now respects the theme color.

## Screenshots
### before
light
![image](https://user-images.githubusercontent.com/410558/80871422-c9019400-8c69-11ea-9e88-d442e536be99.png)
dark
![image](https://user-images.githubusercontent.com/410558/80871432-d880dd00-8c69-11ea-8d55-0e3351d40d36.png)
### after
light
![image](https://user-images.githubusercontent.com/410558/80871457-f9493280-8c69-11ea-96cd-a6e7be04008b.png)

dark
![image](https://user-images.githubusercontent.com/410558/80871449-ec2c4380-8c69-11ea-8656-bf9ee575e4a9.png)

---
Issue : #471 