### PR TITLE
Feature: Limit layer key bindings to layers available

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -870,6 +870,7 @@ class Editor extends React.Component {
               disabled={isReadOnly}
               onKeySelect={this.onKeyChange}
               currentKeyCode={this.getCurrentKey()}
+              keymap={keymap}
             />
           )) ||
             (mode == "colormap" && (

--- a/src/renderer/screens/Editor/KeySelector.js
+++ b/src/renderer/screens/Editor/KeySelector.js
@@ -173,6 +173,15 @@ const SHIFT_HELD = (1 << 3) << 8;
 const GUI_HELD = (1 << 4) << 8;
 
 class KeyGroupListUnwrapped extends React.Component {
+  getNumLayers = () => {
+    const { keymap } = this.props;
+    if (keymap) {
+      let layers = keymap.custom.length;
+      if (!keymap.onlyCustom) layers += keymap.default.length;
+      return layers;
+    }
+  };
+
   toggleMask = (mask, dualUseModifier) => {
     return () => {
       const { onKeySelect, selectedKey } = this.props;
@@ -370,19 +379,22 @@ class KeyGroupListUnwrapped extends React.Component {
     }
 
     const itemList = items || baseKeyCodeTable[group].keys;
+    const isLayersGroup = group === 9 || group === 10 || group === 19;
 
-    const keyList = itemList.map(key => {
-      return (
-        <KeyButton
-          key={key.code}
-          disabled={disabled}
-          keyInfo={key}
-          selected={key.code == keyCode}
-          onKeySelect={onKeySelect}
-          mask={mask}
-        />
-      );
-    });
+    const keyList = itemList
+      .slice(0, isLayersGroup ? this.getNumLayers() : undefined)
+      .map(key => {
+        return (
+          <KeyButton
+            key={key.code}
+            disabled={disabled}
+            keyInfo={key}
+            selected={key.code == keyCode}
+            onKeySelect={onKeySelect}
+            mask={mask}
+          />
+        );
+      });
 
     let modSelector;
     if (withModifiers) {
@@ -519,7 +531,7 @@ class KeySelector extends React.Component {
   };
 
   render() {
-    const { classes, currentKeyCode, disabled } = this.props;
+    const { classes, currentKeyCode, disabled, keymap } = this.props;
     const { anchorEl, selectedGroup, actualKeycode } = this.state;
 
     let groupIndex = selectedGroup,
@@ -597,6 +609,7 @@ class KeySelector extends React.Component {
             group={groupIndex}
             keyCode={actualKeycode}
             onKeySelect={this.onKeySelect}
+            keymap={keymap}
           />
         </div>
       </Paper>


### PR DESCRIPTION
## Description
When a user selects a key that would change layers or otherwise be bound to a layer, they are presented with a list that may not represent the layers available to their keyboard. This PR adds in a check to see if the keygroup being displayed represents layers, and then limits the layers shown to that available to the keyboard.

Currently, I applied this to the shiftTo, lockTo, and oneShotLayer keygroups (9,10,19). I am unsure if there are other layers that should be included.

## Screenshots
with layers limited

![image](https://user-images.githubusercontent.com/410558/80890760-9b721600-8c7c-11ea-8026-7d61c30dd664.png)

![image](https://user-images.githubusercontent.com/410558/80890818-1f2c0280-8c7d-11ea-906d-43f90cb1d827.png)

## To test
1. Plug in a keyboard
2. Visit the editor page
3. Select a modified keygroup in the keyselector (shift to layer, lock to layer, oneshot layer)
4. observe that the number of layers displayed is representative of the keyboard layers.

---
Issue: #473 