### PR TITLE
Add "Right Alt" in parens to AltGr

### DIFF
--- a/src/api/keymap/db/modifiers.js
+++ b/src/api/keymap/db/modifiers.js
@@ -66,7 +66,7 @@ const ModifiersTable = {
       code: 230,
       labels: {
         primary: "RAlt",
-        verbose: "AltGr"
+        verbose: "AltGr (Right Alt)"
       }
     },
     {


### PR DESCRIPTION
Currently the "Modifiers & Locks" keymap has "LEFT ALT" and "ALTGR"

![image](https://user-images.githubusercontent.com/1095826/82093147-94112a80-96c8-11ea-8be7-ebb5fb02a063.png)

This PR updates the UI to add Right Alt in parens next to AltGr, for those who are unsure of what is AltGr.