### PR TITLE
Clearing a layer causes Chrysalis to crash if there is no color map

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -476,7 +476,7 @@ class Editor extends React.Component {
           .map(() => ({ keyCode: 0xffff }));
       }
 
-      let newColormap;
+      let newColormap = [];
       if (state.hasColormap) {
         newColormap = state.colorMap.slice();
         if (newColormap.length > 0) {


### PR DESCRIPTION
## To reproduce

1. connect a keyboard with no colormap / no colormap set (atreus2 worked for me)
2. In the editor screen, attempt to clear any layer.

## Screenshot

![crash_clear_layer](https://user-images.githubusercontent.com/410558/82132746-5d0e4800-97a0-11ea-9f04-2e934671855d.gif)
