### PR TITLE
Fixes: Crashes on import if colormap property is not present

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -602,7 +602,7 @@ class Editor extends React.Component {
             let newKeymap = this.state.keymap.custom.slice();
             newKeymap[currentLayer] = data.keymap.slice();
             let newColormap = this.state.colorMap.slice();
-            if (data.colormap.length > 0) {
+            if (data.colormap && data.colormap.length > 0) {
               newColormap[currentLayer] = data.colormap.slice();
             }
             console.log(currentLayer, newKeymap);
@@ -623,7 +623,7 @@ class Editor extends React.Component {
             let newKeymap = this.state.keymap.custom.slice();
             newKeymap[currentLayer - defLength] = data.keymap;
             let newColormap = this.state.colorMap.slice();
-            if (data.colormap.length > 0) {
+            if (data.colormap && data.colormap.length > 0) {
               newColormap[currentLayer - defLength] = data.colormap.slice();
             }
             return {


### PR DESCRIPTION
## Reproduce

### Option 1

1. Open export/import on an atreus 2 or keyboard with no colormap.
2. modify anything
3. click ok

### Option 2

1. Import a layer with no colormap. Here is the default layer 0 from the atreus2 (this is what was exported by Chrysalis):

```json
{
  "keymap": [
    {
      "keyCode": 20,
      "label": "Q"
    },
    {
      "keyCode": 26,
      "label": "W"
    },
    {
      "keyCode": 8,
      "label": "E"
    },
    {
      "keyCode": 21,
      "label": "R"
    },
    {
      "keyCode": 23,
      "label": "T"
    },
    {
      "keyCode": 0,
      "label": "Blocked",
      "verbose": "Disabled"
    },
    {
      "keyCode": 0,
      "label": "Blocked",
      "verbose": "Disabled"
    },
    {
      "keyCode": 28,
      "label": "Y"
    },
    {
      "keyCode": 24,
      "label": "U"
    },
    {
      "keyCode": 12,
      "label": "I"
    },
    {
      "keyCode": 18,
      "label": "O"
    },
    {
      "keyCode": 19,
      "label": "P"
    },
    {
      "keyCode": 4,
      "label": "A"
    },
    {
      "keyCode": 22,
      "label": "S"
    },
    {
      "keyCode": 7,
      "label": "D"
    },
    {
      "keyCode": 9,
      "label": "F"
    },
    {
      "keyCode": 10,
      "label": "G"
    },
    {
      "keyCode": 0,
      "label": "Blocked",
      "verbose": "Disabled"
    },
    {
      "keyCode": 0,
      "label": "Blocked",
      "verbose": "Disabled"
    },
    {
      "keyCode": 11,
      "label": "H"
    },
    {
      "keyCode": 13,
      "label": "J"
    },
    {
      "keyCode": 14,
      "label": "K"
    },
    {
      "keyCode": 15,
      "label": "L"
    },
    {
      "keyCode": 51,
      "label": ";"
    },
    {
      "keyCode": 29,
      "label": "Z"
    },
    {
      "keyCode": 27,
      "label": "X"
    },
    {
      "keyCode": 6,
      "label": "C"
    },
    {
      "keyCode": 25,
      "label": "V"
    },
    {
      "keyCode": 5,
      "label": "B"
    },
    {
      "keyCode": 53,
      "label": "`"
    },
    {
      "keyCode": 49,
      "label": "\\"
    },
    {
      "keyCode": 17,
      "label": "N"
    },
    {
      "keyCode": 16,
      "label": "M"
    },
    {
      "keyCode": 54,
      "label": ","
    },
    {
      "keyCode": 55,
      "label": "."
    },
    {
      "keyCode": 56,
      "label": "/"
    },
    {
      "keyCode": 41,
      "label": "Esc"
    },
    {
      "keyCode": 43,
      "label": "Tab"
    },
    {
      "keyCode": 227,
      "label": "LSuper",
      "verbose": "Left Super"
    },
    {
      "keyCode": 225,
      "label": "LShift",
      "verbose": "Left Shift"
    },
    {
      "keyCode": 42,
      "label": "Bksp",
      "verbose": "Backspace"
    },
    {
      "keyCode": 224,
      "label": "LCtrl",
      "verbose": "Left Control"
    },
    {
      "keyCode": 226,
      "label": "LAlt",
      "verbose": "Left Alt"
    },
    {
      "keyCode": 44,
      "label": "Space"
    },
    {
      "keyCode": 17451,
      "label": "1",
      "extraLabel": "ShiftTo"
    },
    {
      "keyCode": 45,
      "label": "-"
    },
    {
      "keyCode": 52,
      "label": "'"
    },
    {
      "keyCode": 40,
      "label": "Enter"
    }
  ],
  "palette": []
}
```
2. click ok

## Screenshot

![import_crash](https://user-images.githubusercontent.com/410558/82133208-669aae80-97a6-11ea-8621-636560571e93.gif)


An alternative solution could be to force the colormap property on export even if there isn't one present, however it is likely best to assume all data from a user is dangerous.