### PR TITLE
Change "cancel" to "discard" to avoid ambiguity

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -58,7 +58,7 @@ const English = {
       Chat: "Chat"
     },
     cancelPending: {
-      title: "Cancel pending changes?",
+      title: "Discard pending changes?",
       content: "You have unsaved changes. If you proceed, they will be lost."
     }
   },


### PR DESCRIPTION
Just a small fix for a classic UI issue.

<img width="633" alt="Screen Shot 2020-05-28 at 11 45 41 AM" src="https://user-images.githubusercontent.com/4381820/83181260-7b960c80-a0d9-11ea-9605-0d8f249b9c36.png">

Basically, it's asking "do you want to cancel these changes?" which makes the "Cancel" button ambiguous (will it cancel the changes, or cancel the cancel?)

Just changes the dialog title to "Discard pending changes?" for which the "OK" and "Cancel" options are less confusing.