### PR TITLE
build/launcher.sh: If the file in /proc does not exist, treat it as no support

### DIFF
--- a/build/launcher.sh
+++ b/build/launcher.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 set -e
 
-UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
+UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null || echo 0)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/chrysalis-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"


### PR DESCRIPTION
If `/proc/sys/kernel/unprivileged_userns_clone` does not exist, do not fail and exit immediately, but assume that the feature is not available.

This should fix the app being unable to start on Fedora32.