### PR TITLE
Set our discord link to a redirect

### DIFF
--- a/src/api/hardware-keyboardio-model01/index.js
+++ b/src/api/hardware-keyboardio-model01/index.js
@@ -33,7 +33,7 @@ const Model01 = {
       },
       {
         name: "Chat",
-        url: "https://discord.gg/4az77sf"
+        url: "https://keyboard.io/discord-invite"
       }
     ]
   },


### PR DESCRIPTION
so we can expire old links to combat spam.