### PR TITLE
Add a LoadingScreen component

### DIFF
--- a/src/renderer/components/LoadingScreen.css
+++ b/src/renderer/components/LoadingScreen.css
@@ -1,0 +1,8 @@
+@keyframes spinning-loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/renderer/components/LoadingScreen.js
+++ b/src/renderer/components/LoadingScreen.js
@@ -1,0 +1,60 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+
+import i18n from "../i18n";
+import { getStatic } from "../config";
+import "./LoadingScreen.css";
+
+const styles = theme => ({
+  wrapper: {
+    margin: theme.spacing.unit * 4,
+    overflow: "hidden",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexDirection: "column",
+    padding: theme.spacing.unit * 4
+  },
+  logo: {
+    animationName: "spinning-loader",
+    animationIterationCount: "infinite",
+    animationDuration: "5s",
+    animationTimingFunction: "linear",
+    marginBottom: theme.spacing.unit * 4
+  }
+});
+
+function LoadingScreen(props) {
+  const logoPath = getStatic("/logo.png");
+  return (
+    <div className={props.classes.wrapper}>
+      <div className={props.classes.logo}>
+        <img src={logoPath} />
+      </div>
+      <Typography component="h2" variant="h2">
+        {i18n.t("components.loading")}
+      </Typography>
+    </div>
+  );
+}
+
+export default withStyles(styles)(LoadingScreen);

--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -19,6 +19,7 @@
 const isDevelopment = true;
 
 import path from "path";
+import * as url from "url";
 
 function getStaticPath() {
   if (process.env.NODE_ENV !== "production") {
@@ -31,4 +32,11 @@ function getStaticPath() {
   }
 }
 
-export { isDevelopment, getStaticPath };
+function getStatic(path) {
+  if (process.env.NODE_ENV !== "production") {
+    return url.resolve(window.location.origin, path);
+  }
+  return path.resolve(__static, path);
+}
+
+export { isDevelopment, getStaticPath, getStatic };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -26,7 +26,8 @@ const English = {
       success: "Saved!",
       saveChanges: "Save Changes"
     },
-    pickerColorButton: "Change color"
+    pickerColorButton: "Change color",
+    loading: "Reading data from device..."
   },
   dialog: {
     ok: "Ok",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -25,7 +25,8 @@ const Hungarian = {
     save: {
       success: "Elmentve!",
       saveChanges: "Mentés"
-    }
+    },
+    loading: "Adatok olvasása az eszközről..."
   },
   dialog: {
     ok: "Ok",

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -54,6 +54,7 @@ import i18n from "../../i18n";
 import settings from "electron-settings";
 import ImportExportDialog from "./ImportExportDialog";
 import { CopyFromDialog } from "./CopyFromDialog";
+import LoadingScreen from "../../components/LoadingScreen";
 
 const styles = theme => ({
   tbg: {
@@ -117,7 +118,8 @@ class Editor extends React.Component {
     isMultiSelected: false,
     isColorButtonSelected: false,
     hasKeymap: false,
-    hasColormap: false
+    hasColormap: false,
+    loading: true
   };
   keymapDB = new KeymapDB();
 
@@ -404,7 +406,10 @@ class Editor extends React.Component {
         }
       }
 
-      this.setState({ currentLayer: initialLayer });
+      this.setState({
+        currentLayer: initialLayer,
+        loading: false
+      });
     });
   }
 
@@ -658,8 +663,13 @@ class Editor extends React.Component {
       hasKeymap,
       hasColormap,
       colorMap,
-      mode
+      mode,
+      loading
     } = this.state;
+
+    if (loading) {
+      return <LoadingScreen />;
+    }
 
     let focus = new Focus();
     const Layer = focus.device.components.keymap;


### PR DESCRIPTION
When communicating with the keyboard, and we expect that it might take a while, try showing a loading animation instead of just a partial render. This should result in a considerably nicer user experience.

The component is currently only used by the Editor screen, but we may want to use it elsewhere too.

![Screenshot from 2020-08-05 13-52-24](https://user-images.githubusercontent.com/17243/89409801-eb042a00-d722-11ea-9844-1d1d100342d5.png)

The logo is animated, and is spinning slowly.