### PR TITLE
Keyboard scanning and disconnecting improvements

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -103,17 +103,19 @@ class App extends React.Component {
         this.props.enqueueSnackbar(i18n.t("errors.deviceDisconnected"), {
           variant: "warning"
         });
-        focus.close();
-        this.setState({
-          contextBar: false,
-          cancelPendingOpen: false,
-          connected: false,
-          device: null,
-          pages: {}
-        });
-        // Second call to `navigate` will actually render the proper route
-        await navigate("/keyboard-select");
       }
+
+      await focus.close();
+      await this.setState({
+        contextBar: false,
+        cancelPendingOpen: false,
+        connected: false,
+        device: null,
+        pages: {}
+      });
+
+      // Second call to `navigate` will actually render the proper route
+      await navigate("/keyboard-select");
     });
   }
 

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -114,7 +114,8 @@ class KeyboardSelect extends React.Component {
     selectedPortIndex: 0,
     opening: false,
     devices: null,
-    loading: false
+    loading: false,
+    scanForKeyboards: false
   };
 
   findNonSerialKeyboards = deviceList => {
@@ -161,6 +162,7 @@ class KeyboardSelect extends React.Component {
           const list = this.findNonSerialKeyboards(supported_devices);
           this.setState({
             loading: false,
+            scanForKeyboards: false,
             devices: list
           });
           resolve(list.length > 0);
@@ -169,6 +171,7 @@ class KeyboardSelect extends React.Component {
           const list = this.findNonSerialKeyboards([]);
           this.setState({
             loading: false,
+            scanForKeyboards: false,
             devices: list
           });
           resolve(list.length > 0);
@@ -185,8 +188,14 @@ class KeyboardSelect extends React.Component {
   };
 
   componentDidMount() {
+    setInterval(() => {
+      if (this.state.scanForKeyboards) {
+        this.findKeyboards();
+      }
+    }, 10000);
+
     this.finder = () => {
-      this.findKeyboards();
+      this.setState({ scanForKeyboards: true });
     };
     usb.on("attach", this.finder);
     usb.on("detach", this.finder);


### PR DESCRIPTION
These patches do a number of things, that I hope, will improve both the automatic keyboard scanning system, and the way we handle connected keyboards detaching.

First of all, we no longer scan for new keyboards _immediately_ when we receive an USB attach or detach event: we merely take a note that said event happend. Then, every 10 seconds or so, we do the automatic scan, but only if we had an event since the last scan attempt. The aim of this is to reduce the spammyness of scanning, and to give time for the attached hardware to settle.

Secondly, when handling the detachment of a connected keyboard, we _always_ navigate to the keyboard selection screen at the end of the handler, not only when the port was half-closed. On some operating systems, we may get a detach event sooner than the port's open state is updated, in which case, we'd be stuck on a blank screen, doing who knows what.

Fixes #522.