### PR TITLE
api/focus: Document the macOS workaround

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -237,6 +237,15 @@ class Focus {
     request += "\n";
 
     if (process.platform == "darwin") {
+      /*
+       * On macOS, we need to stagger writes, otherwise we seem to overwhelm the
+       * system, and the host will receive garbage. If we send in smaller
+       * chunks, with a slight delay between them, we can avoid this problem.
+       *
+       * We may be able to do this smarter, if we figure out the rough chunk
+       * size that is safe to send. That'd speed up writes on macOS. Until then,
+       * we split at each space, and send tiny chunks.
+       */
       let parts = request.split(" ");
       return new Promise(resolve => {
         setTimeout(async () => {


### PR DESCRIPTION
This documents why we have the workaround for writes in `api/focus` on macOS: because without splitting the data into smaller chunks, we seem to overwhelm the system, and the host will receive garbage. Also noted a possible improvement there.

~~This removes the macOS-specific workarounds from `api/focus`, which should speed up Chrysalis on mac considerably.~~

~~I'm setting this as a draft, because we had a reason for the workaround, which, I believe, we fixed, and it WorksForMe™, but I'm not 100% sure what the cause of the original problem was, and as such, I'm not certain that the fix we have (ie, setting `clocal` on the serial port) is enough.~~