### PR TITLE
components/MainMenu: Fix the link colors

### DIFF
--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -60,7 +60,8 @@ const styles = theme => ({
     ...theme.mixins.toolbar
   },
   link: {
-    textDecoration: "none"
+    textDecoration: "none",
+    color: theme.palette.text.primary
   },
   menuItem: {
     paddingLeft: theme.spacing.unit * 4


### PR DESCRIPTION
When we upgraded to Material UI 4, link colors in the main menu turned from dark grey to blue. That wasn't intended, so this little change restores the proper color of the links.

Bug:
![Screenshot from 2020-10-08 01-10-21](https://user-images.githubusercontent.com/17243/95397368-52954c00-0903-11eb-9923-3479f0f0693a.png)

Fix:
![Screenshot from 2020-10-08 01-10-38](https://user-images.githubusercontent.com/17243/95397381-56c16980-0903-11eb-93ca-857affa56de6.png)
