### PR TITLE
Add support for Linux/arm64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jobs:
   include:
     - os: linux
       dist: xenial
+    - os: linux
+      dist: xenial
+      arch: arm64
     - os: osx
       osx_image: "xcode11.6"
     - os: windows
@@ -36,4 +39,3 @@ script:
 after_script:
   - yarn add --dev aws-sdk
   - tools/s3-upload.js
-

--- a/README.md
+++ b/README.md
@@ -9,14 +9,17 @@ You can download pre-built binaries for the three major operating systems below:
 
 Development builds:
 
-[![Latest Linux build][badge:appimage]][build:appimage]
+[![Latest Linux x64 build][badge:appimage-x64]][build:appimage-x64]
+[![Latest Linux amd64 build][badge:appimage-arm64]][build:appimage-arm64]
 [![Latest macOS build][badge:dmg]][build:dmg]
 [![Latest Windows build][badge:exe]][build:exe]
 
- [badge:appimage]: https://img.shields.io/badge/AppImage-latest-blue.svg?logo=linux&style=for-the-badge&logoColor=ffffff
+ [badge:appimage-x64]: https://img.shields.io/badge/AppImage%20x64-latest-blue.svg?logo=linux&style=for-the-badge&logoColor=ffffff
+ [badge:appimage-arm64]: https://img.shields.io/badge/AppImage%20arm64-latest-blue.svg?logo=linux&style=for-the-badge&logoColor=ffffff
  [badge:dmg]: https://img.shields.io/badge/dmg-latest-blue.svg?logo=apple&style=for-the-badge&logoColor=ffffff
  [badge:exe]: https://img.shields.io/badge/exe-latest-blue.svg?logo=windows&style=for-the-badge&logoColor=ffffff
- [build:appimage]: http://kaleidoscope-builds.s3-website-us-west-2.amazonaws.com/Chrysalis/latest/Chrysalis.AppImage
+ [build:appimage-x64]: http://kaleidoscope-builds.s3-website-us-west-2.amazonaws.com/Chrysalis/latest/Chrysalis.amd64.AppImage
+[build:appimage-arm64]: http://kaleidoscope-builds.s3-website-us-west-2.amazonaws.com/Chrysalis/latest/Chrysalis.arm64.AppImage
  [build:dmg]: http://kaleidoscope-builds.s3-website-us-west-2.amazonaws.com/Chrysalis/latest/Chrysalis.dmg
  [build:exe]: http://kaleidoscope-builds.s3-website-us-west-2.amazonaws.com/Chrysalis/latest/Chrysalis.exe
 

--- a/tools/get-artifact
+++ b/tools/get-artifact
@@ -20,7 +20,7 @@ else
 fi
 echo "${BUILD_NUMBER}"
 
-EXTENSION="${2:-AppImage}"
+EXTENSION="${2:-amd64.AppImage}"
 
 echo -n "Fetching the version number... "
 VERSION="$(curl -s -f https://kaleidoscope-builds.s3.amazonaws.com/Chrysalis/${BUILD_NUMBER}/version.txt)"


### PR DESCRIPTION
Travis has a Linux/arm64 environment, Chrysalis builds there fine, and works well on arm64, too. As such, adjust our Travis config to build it, and the artifact upload/download tools to support multiple architectures for Linux.

Fixes #524.

For build logs, see [here](https://travis-ci.org/github/keyboardio/Chrysalis/builds/734290991).