### PR TITLE
Editor: Add an "Open Feature Request" button to the onlyCustom warning

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -114,8 +114,9 @@ const English = {
     pasteFromClipboard: "Paste from clipboard",
     pasteSuccess: "Pasted!",
     onlyCustom: {
-      warning: `Chrysalis no longer supports configurations containing a mix of hardcoded and EEPROM layers. If this is a feature you need, we'd love to hear more about your use case. Please open a feature request.`,
-      fixItButton: "Fix it"
+      warning: `Chrysalis no longer supports configurations containing a mix of hardcoded and EEPROM layers. If this is a feature you need, we'd love to hear more about your use case.`,
+      fixItButton: "Fix it",
+      openFR: "Open a feature request"
     }
   },
   preferences: {

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -114,8 +114,9 @@ const Hungarian = {
     pasteFromClipboard: "Beillesztés a vágólapról",
     pasteSuccess: "Beillesztve!",
     onlyCustom: {
-      warning: `A Chrysalis többé már nem támogatja a beépített- és EEPROM rétegek kevert használatát. Amennyiben erre mégis szüksége lenne, kiváncsiak lennénk miként használja őket keverve. Kérjük, nyisson egy hibajegyet!`,
-      fixItButton: "Javítás"
+      warning: `A Chrysalis többé már nem támogatja a beépített- és EEPROM rétegek kevert használatát. Amennyiben erre mégis szüksége lenne, kiváncsiak lennénk miként használja őket keverve.`,
+      fixItButton: "Javítás",
+      openFR: "Hibajegy nyitás"
     }
   },
   preferences: {

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -19,6 +19,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import Alert from "@material-ui/lab/Alert";
+import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Fade from "@material-ui/core/Fade";
 import FileCopyIcon from "@material-ui/icons/FileCopy";
@@ -45,6 +46,7 @@ import { toast } from "react-toastify";
 
 import Focus from "../../../api/focus";
 import Log from "../../../api/log";
+import openURL from "../../utils/openURL";
 import { KeymapDB } from "../../../api/keymap";
 
 import ColorPalette from "../../components/ColorPalette";
@@ -610,6 +612,14 @@ class Editor extends React.Component {
     }));
   };
 
+  openFeatureRequest = async () => {
+    const url =
+      "https://github.com/keyboardio/Chrysalis/issues/new?labels=enhancement&template=feature_request.md";
+    const opener = openURL(url);
+
+    await opener();
+  };
+
   render() {
     const { classes } = this.props;
     const {
@@ -710,13 +720,17 @@ class Editor extends React.Component {
     let onlyCustomWarning;
     if (!this.state.keymap.onlyCustom) {
       const fixitButton = (
-        <Button
-          variant="outlined"
-          color="primary"
-          onClick={this.enableOnlyCustom}
-        >
-          {i18n.t("editor.onlyCustom.fixItButton")}
-        </Button>
+        <React.Fragment>
+          <Box component="span" mr={1}>
+            <Button color="primary" onClick={this.openFeatureRequest}>
+              {i18n.t("editor.onlyCustom.openFR")}
+            </Button>
+          </Box>
+
+          <Button onClick={this.enableOnlyCustom} color="primary">
+            {i18n.t("editor.onlyCustom.fixItButton")}
+          </Button>
+        </React.Fragment>
       );
 
       onlyCustomWarning = (


### PR DESCRIPTION
When we're warning the user about using mixed hardcoded & custom layers, instead of directing them to open a feature request in text, provide a button instead.

![Screenshot from 2020-10-10 11-17-00](https://user-images.githubusercontent.com/17243/95651354-225bd200-0aea-11eb-9ea5-e49efeecf8ef.png)
