### PR TITLE
First pass at exporting full layouts

### DIFF
--- a/src/api/keymap/chrysalis-keymap.js
+++ b/src/api/keymap/chrysalis-keymap.js
@@ -59,13 +59,13 @@ class Keymap {
 
       if (this.legacyInterface) {
         const args = flatten(keymap.default.concat(keymap.custom)).map(k =>
-          this.db.serialize(k)
+          this.db.toKeycode(k)
         );
 
         return await s.request("keymap.map", ...args);
       }
 
-      const args = flatten(keymap.custom).map(k => this.db.serialize(k));
+      const args = flatten(keymap.custom).map(k => this.db.toKeycode(k));
 
       await s.request("keymap.onlyCustom", keymap.onlyCustom ? "1" : "0");
       return await s.request("keymap.custom", ...args);

--- a/src/api/keymap/db.js
+++ b/src/api/keymap/db.js
@@ -119,7 +119,7 @@ class KeymapDB {
     }
   }
 
-  parse(keyCode) {
+  fromKeycode(keyCode) {
     let key;
 
     if (!keyCode) keyCode = 0;
@@ -145,8 +145,27 @@ class KeymapDB {
     };
   }
 
-  serialize(key) {
+  toKeycode(key) {
     return key.keyCode;
+  }
+
+  serialize(key) {
+    // TODO when possible reduce down into a named key string like "q" or an object with a named key like {key: "q", modifiers: ["alt"]}, otherwise just use the raw db entry
+    return key;
+  }
+
+  parse(input) {
+    if (typeof input === "number") {
+      return this.fromKeycode(input);
+    } else if (typeof input === "string") {
+      // TODO handle named keys like "q", "á", "Á" and "Consumer_Brightness_Up"
+    } else if (input && input.keyCode !== undefined) {
+      // already a raw db entry, just copy it
+      return { ...input, parsed: true };
+    } else if (input && typeof input.key) {
+      // TODO handle an object with a named key and possibly modifiers, labels, etc
+    }
+    return null;
   }
 }
 

--- a/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
+++ b/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
@@ -27,9 +27,13 @@ import { toast } from "react-toastify";
 import React, { useState } from "react";
 import i18n from "../../../i18n";
 import LoadDefaultKeymap from "./LoadDefaultKeymap";
+import { KeymapDB } from "../../../../api/keymap";
+
 const { clipboard } = require("electron");
 const fs = require("fs");
 const jsonStringify = require("json-stringify-pretty-compact");
+
+const keymapDB = new KeymapDB();
 
 export const ImportExportDialog = props => {
   const { toCloseImportExportDialog } = props;
@@ -46,9 +50,14 @@ export const ImportExportDialog = props => {
     dataState != undefined
       ? dataState
       : jsonStringify({
-          keymap: props.keymap,
-          colormap: props.colormap,
-          palette: props.palette
+          configVersion: 1,
+          device: props.deviceInfo,
+          palette: props.palette,
+          defaultLayer: props.defaultLayer,
+          layers: props.keymap.custom.map((m, i) => ({
+            keymap: m.map(k => keymapDB.serialize(k)),
+            colormap: props.colormap[i]
+          }))
         });
 
   function onConfirm() {


### PR DESCRIPTION
This is a bare minimum pass at implementing #562. The format is pretty verbose, but should be easy to iterate on later since it includes a version tag. Also, expanding `db.parse` and `db.serialize` should allow for reworking the representation of keys in a backwards compatible way.

Starting as a draft since I think it still needs some testing (don't have a keyboard with colormap support handy) as well as some discussion on the serialization format. Also have some placeholder code in db based on discussions about some upcoming changes, but these need to be discussed as well.

Current format looks like this:
```js
{
  "configVersion": 1,
  "device": {
    "vendor": "Keyboardio",
    "product": "Atreus",
    "displayName": "Keyboardio Atreus",
    "urls": [{"name": "Homepage", "url": "https://atreus.technomancy.us/"}]
  },
  "palette": [
    {"r": 255, "g": 0, "b": 0, "rgb": "rgb(255, 0, 0)"},
    ...
  ],
  "defaultLayer": 0,
  "layers": [
    {
      "keymap": [
        {"keyCode": 20, "label": "Q"},
       ...
      ],
      "colormap": [0, ...]
    },
    ...
  ]
}
```

Including device info in there at the moment as it seems useful to know what you are looking at a config for (and for metadta if someone wanted to create something to manage sharing these configs). Also probably makes sense to sanity check the device matches the currently active device when importing (though I haven't done this yet). Could probably limit it down to just a product ID, but just grabbing the whole info object for now.

An example config for my currently layout (note the layout itself is pretty wonky, just got me Atreus today so still messing with it): https://gist.github.com/netpro2k/216489815889c492b68b0433d6771efa

Seems likely we want to do something with empty layers, but layer numbering needs to be preserved.