### PR TITLE
Enable eslint plugin:jsx-a11y/recommended and fix existing violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:jest/recommended",
-    // 'plugin:jsx-a11y/recommended', // Don't uncomment until you're ready to fix some stuff
+    "plugin:jsx-a11y/recommended",
     "plugin:prettier/recommended"
   ],
   parser: "babel-eslint",

--- a/src/renderer/components/LoadingScreen.js
+++ b/src/renderer/components/LoadingScreen.js
@@ -48,7 +48,7 @@ function LoadingScreen(props) {
   return (
     <div className={props.classes.wrapper}>
       <div className={props.classes.logo}>
-        <img src={logoPath} />
+        <img src={logoPath} alt={i18n.t("components.logo.altText")} />
       </div>
       <Typography component="h2" variant="h2">
         {i18n.t("components.loading")}

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -91,7 +91,7 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
       <div className={classes.toolbarIcon}>
         <Link to={homePage}>
           <IconButton onClick={() => setCurrentPage(homePage)}>
-            <img src={logo} alt={i18n.t("component.logo.altText")} />
+            <img src={logo} alt={i18n.t("components.logo.altText")} />
           </IconButton>
         </Link>
       </div>

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -70,8 +70,15 @@ const styles = theme => ({
 });
 
 function MainMenu({ open, closeMenu, classes, connected, pages }) {
-  const currentPage = history.location.pathname,
-    setCurrentPage = history.navigate;
+  const currentPage = history.location.pathname;
+  const setCurrentPage = page => {
+    history.navigate(page);
+    closeMenu();
+  };
+  const openExternalPage = page => {
+    openURL(page)();
+    closeMenu();
+  };
 
   const homePage = connected
     ? pages.keymap
@@ -81,123 +88,119 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
 
   return (
     <Drawer open={open} onClose={closeMenu}>
-      <div onClick={closeMenu} role="button" onKeyDown={closeMenu}>
-        <div className={classes.toolbarIcon}>
-          <Link to={homePage}>
-            <IconButton
-              onClick={() => {
-                setCurrentPage(homePage);
-              }}
-            >
-              <img src={logo} />
-            </IconButton>
-          </Link>
-        </div>
-        {connected && (
-          <List
-            className={classes.drawer}
-            subheader={
-              <ListSubheader disableSticky>
-                {i18n.t("app.menu.keyboardSection")}
-              </ListSubheader>
-            }
-          >
-            {!pages.keymap && !pages.colormap && (
-              <Link to="/welcome" className={classes.link}>
-                <WelcomeMenu
-                  selected={currentPage == "/welcome"}
-                  className={classes.menuItem}
-                  onClick={() => setCurrentPage("/welcome")}
-                />
-              </Link>
-            )}
-            {pages.keymap && (
-              <Link to="/editor" className={classes.link}>
-                <EditorMenuItem
-                  selected={currentPage == "/editor"}
-                  className={classes.menuItem}
-                  onClick={() => setCurrentPage("/editor")}
-                />
-              </Link>
-            )}
-            <Link to="/firmware-update" className={classes.link}>
-              <FlashMenuItem
-                selected={currentPage == "/firmware-update"}
+      <div className={classes.toolbarIcon}>
+        <Link to={homePage}>
+          <IconButton onClick={() => setCurrentPage(homePage)}>
+            <img src={logo} alt={i18n.t("component.logo.altText")} />
+          </IconButton>
+        </Link>
+      </div>
+      {connected && (
+        <List
+          className={classes.drawer}
+          subheader={
+            <ListSubheader disableSticky>
+              {i18n.t("app.menu.keyboardSection")}
+            </ListSubheader>
+          }
+        >
+          {!pages.keymap && !pages.colormap && (
+            <Link to="/welcome" className={classes.link}>
+              <WelcomeMenu
+                selected={currentPage == "/welcome"}
                 className={classes.menuItem}
-                onClick={() => setCurrentPage("/firmware-update")}
+                onClick={() => setCurrentPage("/welcome")}
               />
             </Link>
-          </List>
-        )}
-        {connected && <Divider />}
-        <List
-          className={classes.drawer}
-          subheader={
-            <ListSubheader disableSticky>
-              {i18n.t("app.menu.chrysalisSection")}
-            </ListSubheader>
+          )}
+          {pages.keymap && (
+            <Link to="/editor" className={classes.link}>
+              <EditorMenuItem
+                selected={currentPage == "/editor"}
+                className={classes.menuItem}
+                onClick={() => setCurrentPage("/editor")}
+              />
+            </Link>
+          )}
+          <Link to="/firmware-update" className={classes.link}>
+            <FlashMenuItem
+              selected={currentPage == "/firmware-update"}
+              className={classes.menuItem}
+              onClick={() => setCurrentPage("/firmware-update")}
+            />
+          </Link>
+        </List>
+      )}
+      {connected && <Divider />}
+      <List
+        className={classes.drawer}
+        subheader={
+          <ListSubheader disableSticky>
+            {i18n.t("app.menu.chrysalisSection")}
+          </ListSubheader>
+        }
+      >
+        <Link to="/keyboard-select" className={classes.link}>
+          <KeyboardMenuItem
+            className={classes.menuItem}
+            keyboardSelectText={
+              connected
+                ? i18n.t("app.menu.selectAnotherKeyboard")
+                : i18n.t("app.menu.selectAKeyboard")
+            }
+            selected={currentPage == "/keyboard-select"}
+            onClick={() => setCurrentPage("/keyboard-select")}
+          />
+        </Link>
+        <Link to="/preferences" className={classes.link}>
+          <PreferencesMenuItem
+            className={classes.menuItem}
+            selected={currentPage == "/preferences"}
+            onClick={() => setCurrentPage("/preferences")}
+          />
+        </Link>
+      </List>
+      <Divider />
+      <List
+        className={classes.drawer}
+        subheader={
+          <ListSubheader disableSticky>
+            {i18n.t("app.menu.miscSection")}
+          </ListSubheader>
+        }
+      >
+        <ChatMenuItem
+          className={classes.menuItem}
+          onClick={() => openExternalPage("https://keyboard.io/discord-invite")}
+        />
+        <FeedbackMenuItem
+          className={classes.menuItem}
+          onClick={() =>
+            openExternalPage("https://github.com/keyboardio/Chrysalis/issues")
           }
-        >
-          <Link to="/keyboard-select" className={classes.link}>
-            <KeyboardMenuItem
-              className={classes.menuItem}
-              keyboardSelectText={
-                connected
-                  ? i18n.t("app.menu.selectAnotherKeyboard")
-                  : i18n.t("app.menu.selectAKeyboard")
-              }
-              selected={currentPage == "/keyboard-select"}
-              onClick={() => setCurrentPage("/keyboard-select")}
-            />
-          </Link>
-          <Link to="/preferences" className={classes.link}>
-            <PreferencesMenuItem
-              className={classes.menuItem}
-              selected={currentPage == "/preferences"}
-              onClick={() => setCurrentPage("/preferences")}
-            />
-          </Link>
-        </List>
-        <Divider />
-        <List
-          className={classes.drawer}
-          subheader={
-            <ListSubheader disableSticky>
-              {i18n.t("app.menu.miscSection")}
-            </ListSubheader>
-          }
-        >
-          <ChatMenuItem
+        />
+        <Link to="/system-info" className={classes.link}>
+          <SystemInfoMenuItem
             className={classes.menuItem}
-            onClick={openURL("https://keyboard.io/discord-invite")}
+            selected={currentPage == "/system-info"}
+            onClick={() => setCurrentPage("/system-info")}
           />
-          <FeedbackMenuItem
-            className={classes.menuItem}
-            onClick={openURL("https://github.com/keyboardio/Chrysalis/issues")}
+        </Link>
+        <ExitMenuItem
+          className={classes.menuItem}
+          onClick={() => Electron.remote.app.exit(0)}
+        />
+      </List>
+      <Divider />
+      <List>
+        <ListItem disabled>
+          <ListItemText
+            primary={`Chrysalis ${version}`}
+            className={classes.version}
           />
-          <Link to="/system-info" className={classes.link}>
-            <SystemInfoMenuItem
-              className={classes.menuItem}
-              selected={currentPage == "/system-info"}
-              onClick={() => setCurrentPage("/system-info")}
-            />
-          </Link>
-          <ExitMenuItem
-            className={classes.menuItem}
-            onClick={() => Electron.remote.app.exit(0)}
-          />
-        </List>
-        <Divider />
-        <List>
-          <ListItem disabled>
-            <ListItemText
-              primary={`Chrysalis ${version}`}
-              className={classes.version}
-            />
-          </ListItem>
-          <UpgradeMenuItem />
-        </List>
-      </div>
+        </ListItem>
+        <UpgradeMenuItem />
+      </List>
     </Drawer>
   );
 }

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -30,7 +30,10 @@ const English = {
       saveChanges: "Save Changes"
     },
     pickerColorButton: "Change color",
-    loading: "Reading data from device..."
+    loading: "Reading data from device...",
+    logo: {
+      altText: "Chrysalis logo"
+    }
   },
   dialog: {
     ok: "Ok",

--- a/src/renderer/i18n/hu.js
+++ b/src/renderer/i18n/hu.js
@@ -26,7 +26,10 @@ const Hungarian = {
       success: "Elmentve!",
       saveChanges: "Mentés"
     },
-    loading: "Adatok olvasása az eszközről..."
+    loading: "Adatok olvasása az eszközről...",
+    logo: {
+      altText: "Chrysalis logó"
+    }
   },
   dialog: {
     ok: "Ok",

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -239,7 +239,7 @@ class SystemInfo extends React.Component {
         </Portal>
         <Card className={classes.card}>
           <CardHeader
-            avatar={<img src={logo} alt={i18n.t("component.logo.altText")} />}
+            avatar={<img src={logo} alt={i18n.t("components.logo.altText")} />}
             title="Chrysalis"
             subheader={version}
           />

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -239,7 +239,7 @@ class SystemInfo extends React.Component {
         </Portal>
         <Card className={classes.card}>
           <CardHeader
-            avatar={<img src={logo} />}
+            avatar={<img src={logo} alt={i18n.t("component.logo.altText")} />}
             title="Chrysalis"
             subheader={version}
           />


### PR DESCRIPTION
This PR adds `plugin:jsx-a11y/recommended` to eslint settings and fixes all pre-existing violations.

The violations fall into 2 categories:
* `<img>` elements representing the Chrysalis logo with no alt text. These were fixed by adding alt text "Chrysalis logo"
* A `role="button"` element in `MainMenu` which did not appear in tab order. This element was an invisible wrapper around all the menu items which gets "clicked" via fall-through when a menu item is clicked (or when a particular subset of the empty space in the menu was clicked) which dismissed the menu. I removed this element entirely and instead added `closeMenu` calls to the handlers for the menu items; this results in a flatter DOM structure and avoids closing the menu when clicking on the empty parts of its top.

Note that GitHub appears to be having trouble rendering a reasonable diff for MainMenu.js; it'll probably be easier to review with a different diff tool.