### PR TITLE
Editor: Improve the host layout selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "archiver": "^5.0.2",
     "avrgirl-arduino": "^4.2.2",
     "classnames": "^2.2.6",
+    "cldr": "^5.8.0",
     "electron-devtools-installer": "^3.1.1",
     "electron-settings": "^4.0.2",
     "electron-window-state": "^5.0.3",

--- a/src/api/keymap/db.js
+++ b/src/api/keymap/db.js
@@ -17,6 +17,8 @@
 import { Base } from "./db/base";
 import { USQwerty } from "./db/us/qwerty";
 import cldr from "./cldr";
+import cldr_ from "cldr";
+import i18n from "i18next";
 
 global.chrysalis_keymapdb_instance = null;
 
@@ -42,6 +44,11 @@ class KeymapDB {
       this._layouts,
       await cldr.loadAllKeymaps()
     );
+  };
+
+  getLayoutLanguage = layout => {
+    const languageCode = this._layouts[layout].group;
+    return cldr_.extractLanguageDisplayNames(i18n.language)[languageCode];
   };
 
   getSupportedLayouts() {

--- a/src/api/keymap/db.js
+++ b/src/api/keymap/db.js
@@ -50,8 +50,20 @@ class KeymapDB {
       layouts.push(layout[0]);
     }
     layouts.sort((a, b) => {
-      const n1 = a.toUpperCase();
-      const n2 = b.toUpperCase();
+      const l1 = this._layouts[a];
+      const l2 = this._layouts[b];
+
+      // Sort on group first
+      if (l1.group < l2.group) return -1;
+      if (l1.group > l2.group) return 1;
+
+      // If in the same group, sort the default one higher
+      if (l1.default) return -1;
+      if (l2.default) return 1;
+
+      // If neither is the default, sort on name.
+      const n1 = l1.name.toUpperCase();
+      const n2 = l2.name.toUpperCase();
 
       if (n1 < n2) return -1;
       if (n1 > n2) return 1;

--- a/src/api/keymap/db/us/qwerty.js
+++ b/src/api/keymap/db/us/qwerty.js
@@ -372,6 +372,8 @@ const keyCodeTable = [
 
 const USQwerty = {
   name: "English (US)",
+  default: true,
+  group: "en",
   codetable: withModifiers(keyCodeTable)
 };
 

--- a/src/renderer/screens/Editor/Sidebar/KeyPicker.js
+++ b/src/renderer/screens/Editor/Sidebar/KeyPicker.js
@@ -41,6 +41,7 @@ import {
   removeModifier
 } from "../../../../api/keymap/db/modifiers";
 import { GuiLabel } from "../../../../api/keymap/db/base/gui";
+import LayoutSelect from "./KeyPicker/LayoutSelect";
 
 const db = new KeymapDB();
 
@@ -144,30 +145,9 @@ class KeyPickerBase extends React.Component {
     );
   };
 
-  setLayout = event => {
-    const layout = event.target.value || this.props.layout;
-    this.props.setLayout(layout);
-  };
-
   render() {
-    const { classes, keymap, selectedKey, layer, layout } = this.props;
+    const { classes, keymap, selectedKey, layer } = this.props;
     const key = keymap.custom[layer][selectedKey];
-
-    const layoutMenu = db.getSupportedLayouts().map((layout, index) => {
-      const menuKey = "layout-menu-" + index.toString();
-      return (
-        <MenuItem value={layout} key={menuKey}>
-          <ListItemText primary={layout} />
-        </MenuItem>
-      );
-    });
-
-    const platforms = {
-      linux: "Linux",
-      win32: "Windows",
-      darwin: "macOS"
-    };
-    const hostos = platforms[process.platform];
 
     let oneShot;
     if (db.isInCategory(key.baseCode || key.code, "modifier")) {
@@ -251,21 +231,11 @@ class KeyPickerBase extends React.Component {
             {oneShot}
           </div>
           <Divider />
-          <div className={classes.layout}>
-            <FormControl>
-              <InputLabel>
-                {i18n.t("editor.sidebar.keypicker.hostLayout", {
-                  hostos: hostos
-                })}
-              </InputLabel>
-              <Select value={layout} onClick={this.setLayout} autoWidth>
-                {layoutMenu}
-              </Select>
-              <FormHelperText>
-                {i18n.t("editor.sidebar.keypicker.hostHelp")}
-              </FormHelperText>
-            </FormControl>
-          </div>
+          <LayoutSelect
+            className={classes.layout}
+            layout={this.props.layout}
+            setLayout={this.props.setLayout}
+          />
         </Collapsible>
         <Dialog
           open={this.state.pickerOpen}

--- a/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
+++ b/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
@@ -18,12 +18,11 @@
 import React from "react";
 import i18n from "i18next";
 
+import Autocomplete from "@material-ui/lab/Autocomplete";
 import FormControl from "@material-ui/core/FormControl";
 import FormHelperText from "@material-ui/core/FormHelperText";
-import InputLabel from "@material-ui/core/InputLabel";
-import ListItemText from "@material-ui/core/ListItemText";
-import MenuItem from "@material-ui/core/MenuItem";
 import Select from "@material-ui/core/Select";
+import TextField from "@material-ui/core/TextField";
 import { withStyles } from "@material-ui/core/styles";
 
 import { KeymapDB } from "../../../../../api/keymap";
@@ -33,22 +32,13 @@ const db = new KeymapDB();
 const styles = () => ({});
 
 class LayoutSelectBase extends React.Component {
-  setLayout = event => {
-    const layout = event.target.value || this.props.layout;
+  setLayout = (_, value) => {
+    const layout = value || this.props.layout;
     this.props.setLayout(layout);
   };
 
   render() {
-    const { className, layout, setLayout } = this.props;
-
-    const layoutMenu = db.getSupportedLayouts().map((layout, index) => {
-      const menuKey = "layout-menu-" + index.toString();
-      return (
-        <MenuItem value={layout} key={menuKey}>
-          <ListItemText primary={layout} />
-        </MenuItem>
-      );
-    });
+    const { className, layout } = this.props;
 
     const platforms = {
       linux: "Linux",
@@ -57,17 +47,23 @@ class LayoutSelectBase extends React.Component {
     };
     const hostos = platforms[process.platform];
 
+    const label = i18n.t("editor.sidebar.keypicker.hostLayout", {
+      hostos: hostos
+    });
+
     return (
       <div className={className}>
         <FormControl>
-          <InputLabel>
-            {i18n.t("editor.sidebar.keypicker.hostLayout", {
-              hostos: hostos
-            })}
-          </InputLabel>
-          <Select value={layout} onClick={this.setLayout} autoWidth>
-            {layoutMenu}
-          </Select>
+          <Autocomplete
+            value={layout}
+            onChange={this.setLayout}
+            options={db.getSupportedLayouts()}
+            getOptionLabel={option => option}
+            disableClearable
+            renderInput={params => (
+              <TextField {...params} label={label} variant="outlined" />
+            )}
+          />
           <FormHelperText>
             {i18n.t("editor.sidebar.keypicker.hostHelp")}
           </FormHelperText>

--- a/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
+++ b/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
@@ -1,0 +1,81 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import i18n from "i18next";
+
+import FormControl from "@material-ui/core/FormControl";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import InputLabel from "@material-ui/core/InputLabel";
+import ListItemText from "@material-ui/core/ListItemText";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+import { withStyles } from "@material-ui/core/styles";
+
+import { KeymapDB } from "../../../../../api/keymap";
+
+const db = new KeymapDB();
+
+const styles = () => ({});
+
+class LayoutSelectBase extends React.Component {
+  setLayout = event => {
+    const layout = event.target.value || this.props.layout;
+    this.props.setLayout(layout);
+  };
+
+  render() {
+    const { className, layout, setLayout } = this.props;
+
+    const layoutMenu = db.getSupportedLayouts().map((layout, index) => {
+      const menuKey = "layout-menu-" + index.toString();
+      return (
+        <MenuItem value={layout} key={menuKey}>
+          <ListItemText primary={layout} />
+        </MenuItem>
+      );
+    });
+
+    const platforms = {
+      linux: "Linux",
+      win32: "Windows",
+      darwin: "macOS"
+    };
+    const hostos = platforms[process.platform];
+
+    return (
+      <div className={className}>
+        <FormControl>
+          <InputLabel>
+            {i18n.t("editor.sidebar.keypicker.hostLayout", {
+              hostos: hostos
+            })}
+          </InputLabel>
+          <Select value={layout} onClick={this.setLayout} autoWidth>
+            {layoutMenu}
+          </Select>
+          <FormHelperText>
+            {i18n.t("editor.sidebar.keypicker.hostHelp")}
+          </FormHelperText>
+        </FormControl>
+      </div>
+    );
+  }
+}
+const LayoutSelect = withStyles(styles, { withTheme: true })(LayoutSelectBase);
+
+export { LayoutSelect as default };

--- a/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
+++ b/src/renderer/screens/Editor/Sidebar/KeyPicker/LayoutSelect.js
@@ -56,6 +56,7 @@ class LayoutSelectBase extends React.Component {
         <FormControl>
           <Autocomplete
             value={layout}
+            groupBy={option => db.getLayoutLanguage(option)}
             onChange={this.setLayout}
             options={db.getSupportedLayouts()}
             getOptionLabel={option => option}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,6 +3794,13 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
 
+"chainsaw@>=0.0.7 <0.1":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.0.9.tgz#11a05102d1c4c785b6d0415d336d5a3a1612913e"
+  integrity sha1-EaBRAtHEx4W20EFdM21aOhYSkT4=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
+
 chalk@^1.0.0, chalk@^1.1.3, chalk@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -3974,6 +3981,21 @@ classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+cldr@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/cldr/-/cldr-5.8.0.tgz#f8d4c0e82376a25efa9e1dabd1d6e2cda459c49b"
+  integrity sha512-w0L5FX4X3txDX5G/YSbDAQuneVSFPSKjOXB2ehWh/J6BN7RJ+IUEVNG9hIGjuJoyYJcVGE2AoL0W0VSjirQPIg==
+  dependencies:
+    escodegen "^2.0.0"
+    esprima "^4.0.1"
+    memoizeasync "^1.1.0"
+    passerror "^1.1.1"
+    pegjs "^0.10.0"
+    seq "^0.3.5"
+    unicoderegexp "^0.4.1"
+    xmldom "^0.4.0"
+    xpath "^0.0.32"
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -5553,6 +5575,18 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-prettier@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
@@ -5746,7 +5780,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6845,6 +6879,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+"hashish@>=0.0.2 <0.1":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/hashish/-/hashish-0.0.4.tgz#6d60bc6ffaf711b6afd60e426d077988014e6554"
+  integrity sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=
+  dependencies:
+    traverse ">=0.2.4"
 
 he@^1.2.0:
   version "1.2.0"
@@ -9093,6 +9134,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.5.0.tgz#d82388ae9c960becbea0c73bb9eb79b6c6ce9aeb"
+  integrity sha1-2COIrpyWC+y+oMc7uet5tsbOmus=
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -9235,6 +9281,14 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
+
+memoizeasync@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/memoizeasync/-/memoizeasync-1.1.0.tgz#9d7028a6f266deb733510bb7dbba5f51878c561e"
+  integrity sha1-nXAopvJm3rczUQu327pfUYeMVh4=
+  dependencies:
+    lru-cache "2.5.0"
+    passerror "1.1.1"
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -10459,6 +10513,11 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+passerror@1.1.1, passerror@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/passerror/-/passerror-1.1.1.tgz#a25b88dbdd910a29603aec7dcb96e9a7a97687b4"
+  integrity sha1-oluI292RCilgOux9y5bpp6l2h7Q=
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -10531,6 +10590,11 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+  integrity sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=
 
 pend@~1.2.0:
   version "1.2.0"
@@ -11973,6 +12037,14 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+seq@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/seq/-/seq-0.3.5.tgz#ae02af3a424793d8ccbf212d69174e0c54dffe38"
+  integrity sha1-rgKvOkJHk9jMvyEtaRdODFTf/jg=
+  dependencies:
+    chainsaw ">=0.0.7 <0.1"
+    hashish ">=0.0.2 <0.1"
+
 serialize-error@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-5.0.0.tgz#a7ebbcdb03a5d71a6ed8461ffe0fc1a1afed62ac"
@@ -13201,6 +13273,16 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+traverse@>=0.2.4:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
 trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
@@ -13377,6 +13459,11 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
   integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
+
+unicoderegexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/unicoderegexp/-/unicoderegexp-0.4.1.tgz#afb10e4ef1eeddc711417bbb652bc885da9d4171"
+  integrity sha1-r7EOTvHu3ccRQXu7ZSvIhdqdQXE=
 
 unified@^7.0.0:
   version "7.1.0"
@@ -14212,6 +14299,16 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmldom@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.4.0.tgz#8771e482a333af44587e30ce026f0998c23f3830"
+  integrity sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==
+
+xpath@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.32.tgz#1b73d3351af736e17ec078d6da4b8175405c48af"
+  integrity sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==
 
 xpipe@*:
   version "1.0.5"


### PR DESCRIPTION
There are three major things done here: first, the layout selector was changed from a simple dropdown to an autocomplete-able input. Second, we now load _all_ layouts from CLDR, and third, we group them by language.

The result is, in my opinion, quite pleasing:

![Screenshot from 2021-01-19 23-24-52](https://user-images.githubusercontent.com/17243/105100611-cff95c80-5aad-11eb-8727-6036427c7355.png)

Turning the selector into an autocomplete-able input also has the advantage that when one starts to type in it, it takes the whole typed string into account.

Fixes #633.