### PR TITLE
~[Export Layers] Add a default name to the exported file

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
@@ -237,6 +237,7 @@ class ExportToFileBase extends React.Component {
   exportToFile = () => {
     const files = Electron.remote.dialog.showSaveDialog({
       title: i18n.t("editor.sharing.selectExportFile"),
+      defaultPath: "Layout.json",
       filters: [
         {
           name: i18n.t("editor.sharing.dialog.layoutFiles"),


### PR DESCRIPTION
When saving the keyboard layout to a file, having a default filename is
friendlier than nothing, and it's even better with the json extension.

resolve #663

Signed-off-by: Romain Heller <Rom1deTroyes@users.noreply.github.com>