### PR TITLE
[Fix regression] Larger  key legends for single characters

### DIFF
--- a/src/api/hardware-keyboardio-atreus2/components/Keymap.js
+++ b/src/api/hardware-keyboardio-atreus2/components/Keymap.js
@@ -101,7 +101,9 @@ class Keymap extends React.Component {
       let textColor = "#ffffff";
       const buttonColor = "transparent";
 
-      let legendClass;
+      let legendClass = "";
+      if (key && (db.format(key).main || "").length <= 1)
+        legendClass = "shortLegend";
       if (key && key.code == 0) textColor = "#888888";
 
       return (


### PR DESCRIPTION
Fixes #669.

There was a regression when the new UI code was implemented and a piece of
code that applied conditional formatting went missing.

# Before
![image](https://user-images.githubusercontent.com/6189778/109877374-3c51a900-7c73-11eb-9c90-43855c37909d.png)

# After

# How it looked on version 0.2.9
![image](https://user-images.githubusercontent.com/6189778/109877352-33f96e00-7c73-11eb-902a-9ce97460727f.png)

Signed-off-by: RodrigoRoaRodriguez <rodrigoroarod@gmail.com>