### PR TITLE
Show a prompt screen instead of an alert when encountering mixed layers

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -67,7 +67,8 @@ const English = {
     cancelPending: {
       title: "Discard pending changes?",
       content: "You have unsaved changes. If you proceed, they will be lost."
-    }
+    },
+    actionRequired: "Action required"
   },
   editor: {
     keyType: "Key type",
@@ -213,8 +214,8 @@ const English = {
     pasteFromClipboard: "Paste from clipboard",
     pasteSuccess: "Pasted!",
     onlyCustom: {
-      warning: `Chrysalis no longer supports configurations containing a mix of hardcoded and EEPROM layers. If this is a feature you need, we'd love to hear more about your use case.`,
-      fixItButton: "Fix it",
+      warning: `Chrysalis no longer supports configurations containing a mix of hardcoded and EEPROM layers. If this is a feature you need, we'd love to hear more about your use case. In most cases, however, we would advise switching to custom layers only, which Chrysalis can do for you. When doing the switch, hardcoded layers will not be used, and the default layer set - if any - will be layer zero.`,
+      fixItButton: "Switch to custom layers only",
       openFR: "Open a feature request"
     }
   },

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -201,6 +201,7 @@ class Editor extends React.Component {
         for (let i = 0; i < keymap.default.length; i++) {
           keymap.custom[i] = keymap.default[i].slice();
         }
+        keymap.onlyCustom = true;
         await focus.command("keymap", keymap);
       }
 

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -18,11 +18,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Alert from "@material-ui/lab/Alert";
-import Box from "@material-ui/core/Box";
-import Button from "@material-ui/core/Button";
 import Portal from "@material-ui/core/Portal";
-import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 
 import { toast } from "react-toastify";
@@ -30,7 +26,6 @@ import settings from "electron-settings";
 
 import Focus from "../../../api/focus";
 import Log from "../../../api/log";
-import openURL from "../../utils/openURL";
 import { KeymapDB } from "../../../api/keymap";
 
 import Sidebar, { sidebarWidth } from "./Sidebar";
@@ -38,6 +33,7 @@ import Sidebar, { sidebarWidth } from "./Sidebar";
 import SaveChangesButton from "../../components/SaveChangesButton";
 import i18n from "../../i18n";
 import LoadingScreen from "../../components/LoadingScreen";
+import OnlyCustomScreen from "./components/OnlyCustomScreen";
 
 const db = new KeymapDB();
 
@@ -247,26 +243,9 @@ class Editor extends React.Component {
       this.scanKeyboard();
       this.setState({ modified: false });
     }
-  };
-
-  enableOnlyCustom = async () => {
-    let focus = new Focus();
-    await focus.command("keymap.onlyCustom", true);
-    this.setState(state => ({
-      keymap: {
-        custom: state.keymap.custom,
-        default: state.keymap.default,
-        onlyCustom: true
-      }
-    }));
-  };
-
-  openFeatureRequest = async () => {
-    const url =
-      "https://github.com/keyboardio/Chrysalis/issues/new?labels=enhancement&template=feature_request.md";
-    const opener = openURL(url);
-
-    await opener();
+    if (!this.state.keymap.onlyCustom) {
+      this.scanKeyboard();
+    }
   };
 
   onApply = async () => {
@@ -304,33 +283,8 @@ class Editor extends React.Component {
       return <LoadingScreen />;
     }
 
-    let onlyCustomWarning;
     if (!this.state.keymap.onlyCustom) {
-      const fixitButton = (
-        <React.Fragment>
-          <Box component="span" mr={1}>
-            <Button color="primary" onClick={this.openFeatureRequest}>
-              {i18n.t("editor.onlyCustom.openFR")}
-            </Button>
-          </Box>
-
-          <Button onClick={this.enableOnlyCustom} color="primary">
-            {i18n.t("editor.onlyCustom.fixItButton")}
-          </Button>
-        </React.Fragment>
-      );
-
-      onlyCustomWarning = (
-        <Alert
-          severity="error"
-          action={fixitButton}
-          className={classes.warning}
-        >
-          <Typography component="p">
-            {i18n.t("editor.onlyCustom.warning")}
-          </Typography>
-        </Alert>
-      );
+      return <OnlyCustomScreen titleElement={this.props.titleElement} />;
     }
 
     const layerData = keymap.custom && keymap.custom[currentLayer];
@@ -363,7 +317,6 @@ class Editor extends React.Component {
     return (
       <React.Fragment>
         <Portal container={this.props.titleElement}>{title}</Portal>
-        {onlyCustomWarning}
         <main className={classes.content}>{keymapWidget}</main>
         <Sidebar
           keymap={keymap}

--- a/src/renderer/screens/Editor/components/OnlyCustomScreen.js
+++ b/src/renderer/screens/Editor/components/OnlyCustomScreen.js
@@ -1,0 +1,105 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2021  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import Box from "@material-ui/core/Box";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import Divider from "@material-ui/core/Divider";
+import Portal from "@material-ui/core/Portal";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+
+import Focus from "../../../../api/focus";
+import openURL from "../../../utils/openURL";
+import i18n from "../../../i18n";
+import { navigate } from "../../../routerHistory";
+
+const styles = theme => ({
+  root: {
+    display: "flex",
+    justifyContent: "center"
+  },
+  card: {
+    margin: theme.spacing(4),
+    maxWidth: "50%"
+  },
+  grow: {
+    flexGrow: 1
+  }
+});
+
+class OnlyCustomScreen extends React.Component {
+  enableOnlyCustom = async () => {
+    let focus = new Focus();
+    await focus.command("keymap.onlyCustom", true);
+    await focus.command("settings.defaultLayer", 0);
+    await navigate("/editor");
+  };
+
+  openFeatureRequest = async () => {
+    const url =
+      "https://github.com/keyboardio/Chrysalis/issues/new?labels=enhancement&template=feature_request.md";
+    const opener = openURL(url);
+
+    await opener();
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <div className={classes.root}>
+        <Portal container={this.props.titleElement}>
+          {i18n.t("app.actionRequired")}
+        </Portal>
+        <Card className={classes.card}>
+          <CardContent>
+            <Typography component="p" gutterBottom>
+              {i18n.t("editor.onlyCustom.warning")}
+            </Typography>
+          </CardContent>
+          <Divider variant="middle" />
+          <CardActions>
+            <Box component="span" mr={1}>
+              <Button
+                color="default"
+                onClick={this.openFeatureRequest}
+                variant="outlined"
+              >
+                {i18n.t("editor.onlyCustom.openFR")}
+              </Button>
+            </Box>
+            <div className={classes.grow} />
+            <Button
+              onClick={this.enableOnlyCustom}
+              color="primary"
+              variant="outlined"
+            >
+              {i18n.t("editor.onlyCustom.fixItButton")}
+            </Button>
+          </CardActions>
+        </Card>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(OnlyCustomScreen);


### PR DESCRIPTION
Chrysalis no longer supports mixing hardcoded and custom layers, because they were confusing. However, showing an alert below the toolbar, but otherwise letting the user to continue also led to surprising behaviour, such as disabling the keyboard in some cases when pressing the "Fix it" button.

To combat these issues, these changes turn the alert into a separate screen, where the case, and the suggested solution is better explained. This prevents the user from editing the keymap and wondering why it doesn't work the way it should, and the "fix it" button is better explained too (and renamed, to `Switch to custom layers only`).

![Screenshot from 2021-03-22 18-18-30](https://user-images.githubusercontent.com/17243/112031298-778d1c80-8b3b-11eb-80c6-fe7f51b94a1e.png)

Additionally, when Chrysalis decides to copy the default layers to eeprom, it will also tell the keyboard to use custom layers only. This way, anyone plugging in a keyboard with an empty eeprom will not see the prompt, but will end up on the proper Editor screen instead.

Fixes #658.