### PR TITLE
Editor: Legacy code migration

### DIFF
--- a/src/api/keymap/chrysalis-keymap.js
+++ b/src/api/keymap/chrysalis-keymap.js
@@ -1,5 +1,5 @@
 /* chrysalis-keymap -- Chrysalis keymap library
- * Copyright (C) 2018-2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -49,6 +49,31 @@ class Keymap {
     for (var i = 0; i < a.length; i += chunkSize)
       R.push(a.slice(i, i + chunkSize));
     return R;
+  }
+
+  hasLegacyCodes(keymap) {
+    for (let layer of keymap) {
+      for (let key of layer) {
+        if (this.db.lookupLegacy(key.code)) return true;
+      }
+    }
+    return false;
+  }
+
+  migrateLegacyCodes(keymap) {
+    let newKeymap = [];
+    for (let layer of keymap) {
+      let newLayer = [];
+      for (let key of layer) {
+        const legacyKey = this.db.lookupLegacy(key.code);
+        if (legacyKey) {
+          key = this.db.lookup(legacyKey.code);
+        }
+        newLayer.push(key);
+      }
+      newKeymap.push(newLayer);
+    }
+    return newKeymap;
   }
 
   async focus(s, keymap) {

--- a/src/api/keymap/db.js
+++ b/src/api/keymap/db.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -167,6 +167,12 @@ class KeymapDB {
 
   _lookupByKeycode(keyCode) {
     return this._codetable[keyCode];
+  }
+
+  lookupLegacy(keyCode) {
+    for (const key of this._codetable) {
+      if (key && key.legacyCode == keyCode) return key;
+    }
   }
 
   _lookupObject(key) {

--- a/src/api/keymap/db/base/consumer.js
+++ b/src/api/keymap/db/base/consumer.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -25,12 +25,14 @@ const consumer = addCategories(
   [
     {
       code: makeConsumer(0xe2),
+      legacyCode: 19682,
       label: {
         base: "Mute"
       }
     },
     {
       code: makeConsumer(0xb5),
+      legacyCode: 22709,
       label: {
         base: {
           full: "Next track",
@@ -40,6 +42,7 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0xb6),
+      legacyCode: 22710,
       label: {
         base: {
           full: "Previous track",
@@ -49,12 +52,14 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0xb7),
+      legacyCode: 22711,
       label: {
         base: "Stop"
       }
     },
     {
       code: makeConsumer(0xcd),
+      legacyCode: 22733,
       label: {
         base: {
           full: "Play / pause",
@@ -64,6 +69,7 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0xe9),
+      legacyCode: 23785,
       label: {
         hint: {
           full: "Volume",
@@ -77,6 +83,7 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0xea),
+      legacyCode: 23786,
       label: {
         hint: {
           full: "Volume",
@@ -90,6 +97,7 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0x6f),
+      legacyCode: 23663,
       label: {
         hint: {
           full: "Brightness",
@@ -103,6 +111,7 @@ const consumer = addCategories(
     },
     {
       code: makeConsumer(0x70),
+      legacyCode: 23664,
       label: {
         hint: {
           full: "Brightness",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -73,6 +73,10 @@ const English = {
   editor: {
     keyType: "Key type",
     keyCode: "Key code",
+    legacy: {
+      migrate: "Migrate",
+      warning: `We found legacy keys on the keymap that are no longer valid. To migrate to the new codes, please press the Migrate button.`
+    },
     sharing: {
       title: "Layout sharing",
       loadFromLibrary: "Load from library",


### PR DESCRIPTION
This implements a check on the Editor screen, that displays a warning when we find a keymap with legacy keycodes on it, and offer to migrate to new ones. Right now, the only such keycodes are the old Consumer Control keys (see #680, #677, and #678), but the migration code is generic, and it's trivial to migrate any keycode: all we need is a `legacyCode` property on the key, and Chrysalis will do the right thing.

Migrating does _not_ save the result to the keyboard, to allow users to review any changes, and make sure they're correct.

The warning looks like this:

![Screenshot from 2021-04-04 13-02-40](https://user-images.githubusercontent.com/17243/113506770-14da4e80-9547-11eb-9624-146cfa0b305d.png)

And after migration:

![Screenshot from 2021-04-04 13-02-52](https://user-images.githubusercontent.com/17243/113506775-215ea700-9547-11eb-9c51-aa125d60034e.png)
