### PR TITLE
Fix SpaceCadet enable and disable key values

### DIFF
--- a/src/api/keymap/db/base/spacecadet.js
+++ b/src/api/keymap/db/base/spacecadet.js
@@ -20,7 +20,7 @@ const spacecadet = addCategories(
   ["spacecadet"],
   [
     {
-      code: 53591,
+      code: 53592,
       label: {
         hint: {
           full: "SpaceCadet",
@@ -33,7 +33,7 @@ const spacecadet = addCategories(
       }
     },
     {
-      code: 53592,
+      code: 53593,
       label: {
         hint: {
           full: "SpaceCadet",


### PR DESCRIPTION
The keycode values for the SpaceCadet enable and disable keys were off by one, such that the "disable" key was actually the _enable_ key, and the "enable" key was in the Steno range.

Fixes #697