### PR TITLE
flashing: Clarify the flashing instructions for Keyboardio devices

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -351,10 +351,10 @@ seconds.`
     },
     Keyboardio: {
       Atreus: {
-        updateInstructions: `Hold down the ESC key (in the lower left corner of the keyboard), and continue holding it while you click the Update button.`
+        updateInstructions: `Hold down the key in the bottom left corner of the keyboard (in the default layout, this key is the ESC key). Continue holding it down while you click the Update button.`
       },
       Model01: {
-        updateInstructions: `Hold down the PROG key (in the upper left corner of the keyboard), and continue holding it while you click the Update button. Once the keys start flashing red across the board, you can release the PROG key.`
+        updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue hulding it while you click the Update button. Once the keys start flashing red across the board, you can release the key.`
       }
     },
     PJRC: {


### PR DESCRIPTION
To make it clearer that the key needing to be held is tied to a position, not to a mapping, reword the update instructions to mention the position first, and the mapping as a comment. Also clarify that the mapping mentioned is according to the default layout.

Fixes #701.
