### PR TITLE
Remove duplicate 'modifier' word in OneShot sticky tooltip

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -150,7 +150,7 @@ const English = {
         hostHelp: "Select the key layout you use on your computer",
         oneshot: {
           label: "Sticky",
-          tooltip: `Tap to activate for next keypress, hold to act like a regular modifier modifier, double tap to toggle modifier.`
+          tooltip: `Tap to activate for next keypress, hold to act like a regular modifier, double tap to toggle modifier.`
         }
       },
       layer: {


### PR DESCRIPTION
Just a minor double word cleanup on a tooltip in the english translation file.