### PR TITLE
Typo in Model01 Flashing Instructions

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -354,7 +354,7 @@ seconds.`
         updateInstructions: `Hold down the key in the bottom left corner of the keyboard (in the default layout, this key is the ESC key). Continue holding it down while you click the Update button.`
       },
       Model01: {
-        updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue hulding it while you click the Update button. Once the keys start flashing red across the board, you can release the key.`
+        updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue holding it while you click the Update button. Once the keys start flashing red across the board, you can release the key.`
       }
     },
     PJRC: {


### PR DESCRIPTION
Changes "hulding" to "holding" in the flashing instructions for the Model01.