### PR TITLE
Add support for Escape Oneshot

### DIFF
--- a/src/api/keymap/db/base/oneshot.js
+++ b/src/api/keymap/db/base/oneshot.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -78,7 +78,19 @@ const oneshot = [
   osl(4),
   osl(5),
   osl(6),
-  osl(7)
+  osl(7),
+
+  {
+    code: 53630,
+    label: {
+      hint: {
+        full: "OneShot",
+        "1u": "OS"
+      },
+      base: "Cancel"
+    },
+    categories: ["oneshot"]
+  }
 ];
 
 export { oneshot };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -160,6 +160,14 @@ const English = {
       leader: {
         title: "Leader",
         help: `Assign Leader keys. To configure this feature, you can use the Arduino IDE to customize the Kaleidoscope 'Sketch' file for your keyboard.`
+      },
+      oneshot: {
+        title: "One-shot",
+        help: `Click button below to choose a dedicated key to cancel one-shot keys.`,
+        configuration: {
+          help: `When enabled, "Escape" will cancel one-shot keys.`,
+          escCancelLabel: "Escape cancels one-shot keys"
+        }
       },
       ledcontrol: {
         title: "LED control",

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2021  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -32,6 +32,7 @@ import LeaderKeys from "./Sidebar/LeaderKeys";
 import LEDKeys from "./Sidebar/LEDKeys";
 import MacroKeys from "./Sidebar/MacroKeys";
 import MouseKeys from "./Sidebar/MouseKeys";
+import OneShotKeys from "./Sidebar/OneShotKeys";
 import SpaceCadetKeys from "./Sidebar/SpaceCadetKeys";
 import StenoKeys from "./Sidebar/StenoKeys";
 import TapDanceKeys from "./Sidebar/TapDanceKeys";
@@ -76,6 +77,7 @@ class Sidebar extends React.Component {
       LEDKeys,
       MacroKeys,
       TapDanceKeys,
+      OneShotKeys,
       SpaceCadetKeys,
       LeaderKeys,
       StenoKeys,

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -1,0 +1,125 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2021  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import i18n from "i18next";
+
+import FormGroup from "@material-ui/core/FormGroup";
+import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import InputLabel from "@material-ui/core/InputLabel";
+import Switch from "@material-ui/core/Switch";
+
+import { withStyles } from "@material-ui/core/styles";
+
+import Collapsible from "../components/Collapsible";
+import KeyButton from "../components/KeyButton";
+
+import Focus from "../../../../api/focus";
+import { KeymapDB } from "../../../../api/keymap";
+
+const db = new KeymapDB();
+
+const styles = theme => ({
+  cancelContainer: {
+    margin: `${theme.spacing(2)}px 0`
+  }
+});
+
+const cancelKeyCode = 53630;
+
+class OneShotKeysBase extends React.Component {
+  state = {
+    escCancel: true
+  };
+
+  async componentDidMount() {
+    const focus = new Focus();
+
+    let escCancel = await focus.command("escape_oneshot.cancel_key");
+    if (escCancel.length == 0) {
+      escCancel = false;
+    } else {
+      escCancel = parseInt(escCancel) == cancelKeyCode;
+    }
+
+    this.setState({
+      escCacnel: escCancel
+    });
+  }
+
+  render() {
+    const { classes, keymap, selectedKey, layer, onKeyChange } = this.props;
+    const key = keymap.custom[layer][selectedKey];
+
+    const toggleEscapeCancel = async event => {
+      const focus = new Focus();
+      const escCancel = event.target.checked;
+      let newCancelKeyCode = cancelKeyCode;
+
+      if (escCancel) {
+        newCancelKeyCode = 41; // Esc
+      }
+
+      await focus.command("escape_oneshot.cancel_key", newCancelKeyCode);
+      this.setState({ escCancel: escCancel });
+    };
+
+    const escCancelWidget = (
+      <Switch
+        checked={this.state.escCancel}
+        color="primary"
+        onChange={toggleEscapeCancel}
+      />
+    );
+
+    return (
+      <React.Fragment>
+        <Collapsible
+          expanded={key.code == cancelKeyCode || key.code == 41}
+          title={i18n.t("editor.sidebar.oneshot.title")}
+          help={i18n.t("editor.sidebar.oneshot.help")}
+        >
+          <KeyButton
+            keyObj={db.lookup(cancelKeyCode)}
+            onKeyChange={onKeyChange}
+          />
+
+          <div className={classes.cancelContainer}>
+            <FormControl component="fieldset" className={classes.mods}>
+              <FormGroup row>
+                <FormControlLabel
+                  control={escCancelWidget}
+                  label={i18n.t(
+                    "editor.sidebar.oneshot.configuration.escCancelLabel"
+                  )}
+                />
+              </FormGroup>
+              <FormHelperText>
+                {i18n.t("editor.sidebar.oneshot.configuration.help")}
+              </FormHelperText>
+            </FormControl>
+          </div>
+        </Collapsible>
+      </React.Fragment>
+    );
+  }
+}
+const OneShotKeys = withStyles(styles, { withTheme: true })(OneShotKeysBase);
+
+export { OneShotKeys as default };


### PR DESCRIPTION
This depends on keyboardio/Kaleidoscope#1089, and adds support for both the dedicated one-shot cancel key, and for toggling the functionality on and off to begin with.

I feel the wording of the help text, and the labels could be improved, help on that would be most appreciated.

### Screenshot

![Screenshot from 2021-11-18 20-54-01](https://user-images.githubusercontent.com/17243/142487856-e940cf00-c477-4b1a-aa34-1298dc4e43df.png)
