### PR TITLE
New screen: Storage & Sharing

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -44,6 +44,7 @@ import Preferences from "./screens/Preferences";
 import Welcome from "./screens/Welcome";
 import SystemInfo from "./screens/SystemInfo";
 import ChangeLog from "./screens/ChangeLog";
+import StorageAndSharing from "./screens/StorageAndSharing";
 import i18n from "./i18n";
 
 import Header from "./components/Header";
@@ -268,6 +269,16 @@ class App extends React.Component {
                 />
                 <Editor
                   path="/editor"
+                  onDisconnect={this.onKeyboardDisconnect}
+                  startContext={this.startContext}
+                  cancelContext={this.cancelContext}
+                  inContext={this.state.contextBar}
+                  titleElement={() => document.querySelector("#page-title")}
+                  appBarElement={() => document.querySelector("#appbar")}
+                />
+                <StorageAndSharing
+                  connected={connected}
+                  path="/storage-and-sharing"
                   onDisconnect={this.onKeyboardDisconnect}
                   startContext={this.startContext}
                   cancelContext={this.cancelContext}

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -43,6 +43,7 @@ import KeyboardMenuItem from "./KeyboardSelectMenuItem";
 import PreferencesMenuItem from "./PreferencesMenuItem";
 import UpgradeMenuItem from "./UpgradeMenuItem";
 import ChangeLogMenuItem from "./ChangeLogMenuItem";
+import StorageAndSharingMenuItem from "./StorageAndSharingMenuItem";
 import openURL from "../../utils/openURL";
 
 import { history } from "../../routerHistory";
@@ -123,6 +124,13 @@ function MainMenu({ open, closeMenu, classes, connected, pages }) {
               />
             </Link>
           )}
+          <Link to="/storage-and-sharing" className={classes.link}>
+            <StorageAndSharingMenuItem
+              selected={currentPage == "/storage-and-sharing"}
+              className={classes.menuItem}
+              onClick={() => setCurrentPage("/storage-and-sharing")}
+            />
+          </Link>
           <Link to="/firmware-update" className={classes.link}>
             <FlashMenuItem
               selected={currentPage == "/firmware-update"}

--- a/src/renderer/components/MainMenu/StorageAndSharingMenuItem.js
+++ b/src/renderer/components/MainMenu/StorageAndSharingMenuItem.js
@@ -1,0 +1,43 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2021  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+import ShareIcon from "@material-ui/icons/Share";
+import i18n from "../../i18n";
+
+export default function StorageAndSharingMenuItem({
+  selected,
+  onClick,
+  className
+}) {
+  return (
+    <ListItem
+      button
+      selected={selected}
+      onClick={onClick}
+      className={className}
+    >
+      <ListItemIcon>
+        <ShareIcon />
+      </ListItemIcon>
+      <ListItemText primary={i18n.t("app.menu.storageAndSharing")} />
+    </ListItem>
+  );
+}

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -58,7 +58,8 @@ const English = {
       chrysalisSection: "Chrysalis",
       miscSection: "Miscellaneous",
       upgradeAvailable: "An upgrade is available!",
-      changelog: "Changelog"
+      changelog: "Changelog",
+      storageAndSharing: "Storage & Sharing"
     },
     deviceMenu: {
       Homepage: "Homepage",
@@ -73,6 +74,20 @@ const English = {
   },
   changelog: {
     title: "Changelog"
+  },
+  storageAndSharing: {
+    sharing: {
+      title: "Sharing",
+      button: "Layout sharing",
+      description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+    },
+    eeprom: {
+      title: "Storage",
+      save: "Save",
+      restore: "Restore",
+      clear: "Restore factory settings",
+      description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+    }
   },
   editor: {
     keyType: "Key type",

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -32,7 +32,6 @@ import TableFooter from "@material-ui/core/TableFooter";
 import TableRow from "@material-ui/core/TableRow";
 import { withStyles } from "@material-ui/core/styles";
 
-import LayoutSharing from "./Overview/LayoutSharing";
 import { KeymapDB } from "../../../../api/keymap";
 
 const styles = theme => ({
@@ -56,20 +55,11 @@ const styles = theme => ({
 
 class OverviewBase extends React.Component {
   state = {
-    showAll: false,
-    dialogOpen: false
+    showAll: false
   };
 
   selectLayer = index => () => {
     this.props.setLayer(index);
-  };
-
-  closeDialog = () => {
-    this.setState({ dialogOpen: false });
-  };
-
-  openDialog = () => {
-    this.setState({ dialogOpen: true });
   };
 
   findLastUsedLayer = () => {
@@ -104,7 +94,7 @@ class OverviewBase extends React.Component {
       layer,
       colormap
     } = this.props;
-    const { showAll, dialogOpen } = this.state;
+    const { showAll } = this.state;
     const db = new KeymapDB();
 
     const lastUsedLayer = this.findLastUsedLayer();
@@ -202,19 +192,6 @@ class OverviewBase extends React.Component {
             {footer}
           </Table>
         </TableContainer>
-        <Button onClick={this.openDialog} color="secondary" variant="outlined">
-          {i18n.t("editor.sidebar.overview.sharing")}
-        </Button>
-        <LayoutSharing
-          open={dialogOpen}
-          onClose={this.closeDialog}
-          keymap={keymap}
-          colormap={colormap}
-          layer={layer}
-          onKeymapChange={this.props.onKeymapChange}
-          onPaletteChange={this.props.onPaletteChange}
-          onColormapChange={this.props.onColormapChange}
-        />
       </div>
     );
   }

--- a/src/renderer/screens/StorageAndSharing.js
+++ b/src/renderer/screens/StorageAndSharing.js
@@ -1,0 +1,148 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2021  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import Electron from "electron";
+
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import Divider from "@material-ui/core/Divider";
+import Portal from "@material-ui/core/Portal";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+
+import LayoutSharing from "./StorageAndSharing/LayoutSharing";
+import i18n from "../i18n";
+
+import Focus from "../../api/focus";
+
+const styles = theme => ({
+  root: {
+    ...theme.mixins.gutters(),
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+    margin: `0px ${theme.spacing(8)}px`
+  },
+  grow: {
+    flexGrow: 1
+  },
+  title: {
+    marginTop: theme.spacing(4),
+    marginBottom: theme.spacing(1)
+  }
+});
+
+class StorageAndSharing extends React.Component {
+  state = {
+    dialogOpen: false
+  };
+
+  closeDialog = () => {
+    this.setState({ dialogOpen: false });
+  };
+
+  openDialog = () => {
+    this.setState({ dialogOpen: true });
+  };
+
+  render() {
+    const { classes, keymap, layer, colormap } = this.props;
+    const { dialogOpen } = this.state;
+
+    return (
+      <div className={classes.root}>
+        <Portal container={this.props.titleElement}>
+          {i18n.t("app.menu.storageAndSharing")}
+        </Portal>
+        <Typography
+          variant="subtitle1"
+          component="h2"
+          className={classes.title}
+        >
+          {i18n.t("storageAndSharing.sharing.title")}
+        </Typography>
+        <Card>
+          <CardContent>
+            <Typography component="p" gutterBottom>
+              {i18n.t("storageAndSharing.sharing.description")}
+            </Typography>
+          </CardContent>
+          <Divider variant="middle" />
+          <CardActions>
+            <div className={classes.grow} />
+            <Button
+              onClick={this.openDialog}
+              color="secondary"
+              variant="outlined"
+            >
+              {i18n.t("storageAndSharing.sharing.button")}
+            </Button>
+          </CardActions>
+        </Card>
+        <Typography
+          variant="subtitle1"
+          component="h2"
+          className={classes.title}
+        >
+          {i18n.t("storageAndSharing.eeprom.title")}
+        </Typography>
+        <Card>
+          <CardContent>
+            <Typography component="p" gutterBottom>
+              {i18n.t("storageAndSharing.eeprom.description")}
+            </Typography>
+          </CardContent>
+          <Divider variant="middle" />
+          <CardActions>
+            <Button color="default" variant="text">
+              {i18n.t("storageAndSharing.eeprom.clear")}
+            </Button>
+            <div className={classes.grow} />
+            <Button color="secondary" variant="outlined">
+              {i18n.t("storageAndSharing.eeprom.save")}
+            </Button>
+            <Button color="secondary" variant="outlined">
+              {i18n.t("storageAndSharing.eeprom.restore")}
+            </Button>
+          </CardActions>
+        </Card>
+      </div>
+    );
+  }
+}
+
+/*
+  <LayoutSharing
+  open={dialogOpen}
+  onClose={this.closeDialog}
+  keymap={keymap}
+  colormap={colormap}
+  layer={layer}
+  onKeymapChange={this.props.onKeymapChange}
+  onPaletteChange={this.props.onPaletteChange}
+  onColormapChange={this.props.onColormapChange}
+  />
+*/
+
+StorageAndSharing.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(StorageAndSharing);

--- a/src/renderer/screens/StorageAndSharing/LayoutSharing.js
+++ b/src/renderer/screens/StorageAndSharing/LayoutSharing.js
@@ -35,12 +35,12 @@ import MenuList from "@material-ui/core/MenuList";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 
-import ConfirmationDialog from "../../../../components/ConfirmationDialog";
+import ConfirmationDialog from "../../components/ConfirmationDialog";
 
-import Focus from "../../../../../api/focus";
-import Log from "../../../../../api/log";
-import { KeymapDB } from "../../../../../api/keymap";
-import { getStaticPath } from "../../../../config";
+import Focus from "../../../api/focus";
+import Log from "../../../api/log";
+import { KeymapDB } from "../../../api/keymap";
+import { getStaticPath } from "../../config";
 
 const db = new KeymapDB();
 


### PR DESCRIPTION
There are a number of storage and sharing related features, that are currently scattered around Chrysalis: layout sharing is on the Editor sidebar, EEPROM reset is on the Preferences screen, hidden behind an advanced settings collapsible. To make it all more discoverable, and add new features, this (draft) PR introduces a new screen: Storage & Sharing, and will eventually move both of these to the new screen, and implement full EEPROM save & restore as well.

As of this writing, this is only partially done, and none of it functions just yet. Nevertheless, I'm opening this draft in the hopes of getting feedback on the proposed feature and its UX.

![Screenshot from 2021-12-13 12-10-30](https://user-images.githubusercontent.com/17243/145802818-f89ef514-4732-41fc-9cf5-7fb29ac7ae6b.png)

At first, there will be some code duplication, and a bit of inefficiency: both this screen, and Editor will have to deal with reading and updating the keymap, the palette, and the colormap, and we have no global state to reduce the amount of traffic between keyboard and host. Fixing that is out of scope for this particular feature.