### PR TITLE
Right now the color selector always defaults to open. It should not. …

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -64,6 +64,7 @@ class ColormapBase extends React.Component {
       <Collapsible
         title={i18n.t("editor.sidebar.colors.title")}
         help={i18n.t("editor.sidebar.colors.help")}
+        expanded={false}
       >
         <PalettePicker
           color={colorIndex}


### PR DESCRIPTION
… This fixes that