### PR TITLE
Enable hot module reload, dramatically improving developer UX

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -50,6 +50,9 @@ const webusb = new WebUSB({
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 
+// Enable Hot Module Reload in dev
+if (module.hot) module.hot.accept();
+
 let mainWindow;
 let windows = [];
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -26,6 +26,9 @@ import "../styles/keymap.css";
 import i18n from "./i18n";
 import { I18nextProvider } from "react-i18next";
 
+// Enable Hot Module Reload in dev
+if (module.hot) module.hot.accept();
+
 try {
   ReactDOM.render(
     <I18nextProvider i18n={i18n}>


### PR DESCRIPTION
We were missing the mandatory configuration for hot module reload to work in dev

Signed-off-by: Jesse Vincent <jesse@keyboard.io>