### PR TITLE
Our macos 'delay' logic was badly flawed. 

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -259,7 +259,9 @@ class Focus {
     }
 
     let part = parts.shift();
-    part += " ";
+    if (parts.length > 0) {
+      part += " ";
+    }
     this._port.write(part);
     this._port.drain(async () => {
       await this._write_parts(parts, cb);

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -300,13 +300,9 @@ class Focus {
        * size that is safe to send. That'd speed up writes on macOS. Until then,
        * we split at each space, and send tiny chunks.
        */
-      let parts = request.split(" ");
       return new Promise((resolve) => {
-        setTimeout(async () => {
-          await this._port.flush();
-          this.callbacks.push(resolve);
-          await this._write_parts(parts, () => {});
-        }, 500);
+        this.callbacks.push(resolve);
+        this._write_parts(request.split(" "), () => {});
       });
     } else {
       return new Promise((resolve) => {

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -263,9 +263,9 @@ class Focus {
       part += " ";
     }
     this._port.write(part);
-    this._port.drain(async () => {
-      await this._write_parts(parts, cb);
-    });
+    await new Promise((timeout) => setTimeout(timeout, 50));
+    this._port.drain();
+    await this._write_parts(parts, cb);
   }
 
   request(cmd, ...args) {


### PR DESCRIPTION
This PR changes the logic of how we speak focus to darwin devices. After these changes, I've stopped being able to make Chrysalis fail to talk to an Atreus from a mac, something that was otherwise a regular occurrence.