### PR TITLE
Rather than needing to pass accessor and mutator for darkmode around,

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -123,11 +123,17 @@ const App = (props) => {
       );
     };
   });
-  const toggleDarkMode = async () => {
-    const nextDarkModeState = !darkMode;
-    setDarkMode(nextDarkModeState);
-    await settings.set("ui.darkMode", nextDarkModeState);
-  };
+
+  useEffect(() => {
+    const darkmode_toggle_channel = new BroadcastChannel("ui.darkMode");
+    darkmode_toggle_channel.onmessage = (event) => {
+      setDarkMode(event.data);
+    };
+
+    return function cleanup() {
+      darkmode_toggle_channel.close();
+    };
+  });
 
   const toggleFlashing = async () => {
     flashing = !flashing;
@@ -276,8 +282,6 @@ const App = (props) => {
                   connected={connected}
                   path="/preferences"
                   titleElement={() => document.querySelector("#page-title")}
-                  darkMode={darkMode}
-                  toggleDarkMode={toggleDarkMode}
                   startContext={startContext}
                   cancelContext={cancelContext}
                   inContext={contextBar}

--- a/src/renderer/screens/Preferences/Basic.js
+++ b/src/renderer/screens/Preferences/Basic.js
@@ -28,14 +28,20 @@ import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 
 import i18n from "../../i18n";
-
 const Store = require("electron-store");
 const settings = new Store();
 
 function BasicPreferences(props) {
   const [language, setLanguage] = useState(i18n.language);
-  const darkMode = props.darkMode;
-  const toggleDarkMode = props.toggleDarkMode;
+  const [darkMode, setDarkMode] = useState(settings.get("ui.darkMode"));
+
+  const darkmode_toggle_channel = new BroadcastChannel("ui.darkMode");
+
+  const toggleDarkMode = async () => {
+    darkmode_toggle_channel.postMessage(!darkMode);
+    settings.set("ui.darkMode", !darkMode);
+    setDarkMode(!darkMode);
+  };
 
   const updateLanguage = async (event) => {
     i18n.changeLanguage(event.target.value);


### PR DESCRIPTION
use a BrowserChannel to do in-renderer IPC. This helps make different
bits of code a bit more independent.

Also, now change the preference from within the prefs screen, rather
than over in the apps screen