### PR TITLE
Rename and simplify the context bar undo manager just a little bit.

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -37,7 +37,6 @@ import {
   StyledEngineProvider,
   createTheme,
 } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
 
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -52,9 +51,8 @@ import ChangeLog from "./screens/ChangeLog";
 import i18n from "@renderer/i18n";
 
 import Header from "./components/Header";
-import ConfirmationDialog from "./components/ConfirmationDialog";
 import { history, navigate } from "./routerHistory";
-
+import { hideContextBar } from "./components/ContextBar";
 import { isDevelopment } from "./config";
 
 let focus = new Focus();
@@ -72,8 +70,6 @@ const App = (props) => {
   const [connected, setConnected] = useState(false);
   const [device, setDevice] = useState(null);
   const [pages, setPages] = useState({});
-  const [contextBar, setContextBar] = useState(false);
-  const [cancelPendingOpen, setCancelPendingOpen] = useState(false);
 
   localStorage.clear();
 
@@ -102,8 +98,8 @@ const App = (props) => {
     }
 
     await focus.close();
-    setContextBar(false);
-    setCancelPendingOpen(false);
+    hideContextBar();
+
     setConnected(false);
     setDevice(null);
     setPages({});
@@ -203,26 +199,9 @@ const App = (props) => {
     await navigate("/keyboard-select");
   };
 
-  const cancelContext = (dirty) => {
-    if (dirty) {
-      setCancelPendingOpen(true);
-    } else {
-      doCancelContext();
-    }
-  };
-  const doCancelContext = () => {
-    setContextBar(false);
-    setCancelPendingOpen(false);
-  };
-  const cancelContextCancellation = () => {
-    setCancelPendingOpen(false);
-  };
-  const startContext = () => {
-    setContextBar(true);
-  };
-
   let focus = new Focus();
   const deviceInfo = focus?.device?.info || device?.info;
+
   const theme = createTheme({
     palette: {
       mode: darkMode ? "dark" : "light",
@@ -241,13 +220,7 @@ const App = (props) => {
         <div sx={{ display: "flex", flexDirection: "column" }}>
           <LocationProvider history={history}>
             <CssBaseline />
-            <Header
-              contextBar={contextBar}
-              connected={connected}
-              pages={pages}
-              device={deviceInfo}
-              cancelContext={cancelContext}
-            />
+            <Header connected={connected} pages={pages} device={deviceInfo} />
             <main sx={{ flexGrow: 1, overflow: "auto" }}>
               <Router>
                 <Welcome
@@ -265,9 +238,6 @@ const App = (props) => {
                 <Editor
                   path="/editor"
                   onDisconnect={onKeyboardDisconnect}
-                  startContext={startContext}
-                  cancelContext={cancelContext}
-                  inContext={contextBar}
                   titleElement={() => document.querySelector("#page-title")}
                   appBarElement={() => document.querySelector("#appbar")}
                 />
@@ -282,9 +252,6 @@ const App = (props) => {
                   connected={connected}
                   path="/preferences"
                   titleElement={() => document.querySelector("#page-title")}
-                  startContext={startContext}
-                  cancelContext={cancelContext}
-                  inContext={contextBar}
                 />
                 <SystemInfo
                   path="/system-info"
@@ -297,14 +264,6 @@ const App = (props) => {
               </Router>
             </main>
           </LocationProvider>
-          <ConfirmationDialog
-            title={i18n.t("app.cancelPending.title")}
-            open={cancelPendingOpen}
-            onConfirm={doCancelContext}
-            onCancel={cancelContextCancellation}
-          >
-            {i18n.t("app.cancelPending.content")}
-          </ConfirmationDialog>
         </div>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -287,12 +287,10 @@ const App = (props) => {
                   inContext={contextBar}
                 />
                 <SystemInfo
-                  connected={connected}
                   path="/system-info"
                   titleElement={() => document.querySelector("#page-title")}
                 />
                 <ChangeLog
-                  connected={connected}
                   path="/changelog"
                   titleElement={() => document.querySelector("#page-title")}
                 />

--- a/src/renderer/components/ContextBar.js
+++ b/src/renderer/components/ContextBar.js
@@ -1,0 +1,14 @@
+const context_bar_channel = new BroadcastChannel("context_bar");
+
+export const showContextBar = () => {
+  context_bar_channel.postMessage("show");
+};
+
+export const hideContextBar = () => {
+  context_bar_channel.postMessage("cancel");
+};
+
+export const contextBarChangesDiscarded = () => {
+  console.log("posting a changes-discarded message");
+  context_bar_channel.postMessage("changes-discarded");
+};

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -39,7 +39,13 @@ import i18n from "../../i18n";
 import LoadingScreen from "../../components/LoadingScreen";
 import OnlyCustomScreen from "./components/OnlyCustomScreen";
 
+import {
+  showContextBar,
+  hideContextBar,
+} from "@renderer/components/ContextBar";
+
 const db = new KeymapDB();
+const context_bar_channel = new BroadcastChannel("context_bar");
 
 class Editor extends React.Component {
   state = {
@@ -124,7 +130,7 @@ class Editor extends React.Component {
         keymap: newKeymap,
       };
     });
-    this.props.startContext();
+    showContextBar();
   };
 
   onLedChange = (index) => {
@@ -138,7 +144,7 @@ class Editor extends React.Component {
       };
     });
 
-    this.props.startContext();
+    showContextBar();
   };
 
   onPaletteChange = (newPalette) => {
@@ -152,7 +158,7 @@ class Editor extends React.Component {
       };
     });
 
-    this.props.startContext();
+    showContextBar();
   };
 
   onKeymapChange = (newKeymap) => {
@@ -168,7 +174,7 @@ class Editor extends React.Component {
       };
     });
 
-    this.props.startContext();
+    showContextBar();
   };
 
   onColormapChange = (newColormap) => {
@@ -182,7 +188,7 @@ class Editor extends React.Component {
       };
     });
 
-    this.props.startContext();
+    showContextBar();
   };
 
   scanKeyboard = async () => {
@@ -233,6 +239,8 @@ class Editor extends React.Component {
   };
 
   async componentDidMount() {
+    this.context_bar_channel = new BroadcastChannel("context_bar");
+
     const layoutSetting = await settings.get("keyboard.layout", "English (US)");
     db.setLayout(layoutSetting);
 
@@ -244,17 +252,17 @@ class Editor extends React.Component {
       loading: false,
       layout: layoutSetting,
     });
-  }
+    context_bar_channel.onmessage = (event) => {
+      if (event.data === "changes-discarded") {
+        this.componentDidMount();
 
-  UNSAFE_componentWillReceiveProps = (nextProps) => {
-    if (this.props.inContext && !nextProps.inContext) {
-      this.scanKeyboard();
-      this.setState({ modified: false });
-    }
-    if (!this.state.keymap.onlyCustom) {
-      this.scanKeyboard();
-    }
-  };
+        this.setState({ modified: false });
+      }
+    };
+  }
+  async componentWillUnmount() {
+    this.context_bar_channel.close();
+  }
 
   onApply = async () => {
     this.setState({ saving: true });
@@ -273,7 +281,7 @@ class Editor extends React.Component {
       saving: false,
     });
     logger.log("Changes saved.");
-    this.props.cancelContext();
+    hideContextBar();
   };
 
   migrateLegacy = async () => {
@@ -293,7 +301,7 @@ class Editor extends React.Component {
     let logger = new Log();
     logger.log("Legacy keycodes migrated to new ones.");
 
-    this.props.startContext();
+    showContextBar();
   };
 
   render() {

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -128,18 +128,10 @@ function Preferences(props) {
         </TabPanel>
 
         <TabPanel value={value} index={1}>
-          <KeyboardSettings
-            startContext={props.startContext}
-            cancelContext={props.cancelContext}
-            inContext={props.inContext}
-          />
+          <KeyboardSettings inContext={props.inContext} />
         </TabPanel>
         <TabPanel value={value} index={2}>
-          <AdvancedKeyboardSettings
-            startContext={props.startContext}
-            cancelContext={props.cancelContext}
-            inContext={props.inContext}
-          />
+          <AdvancedKeyboardSettings inContext={props.inContext} />
         </TabPanel>
         <TabPanel value={value} index={3}>
           <DevtoolsPreferences />


### PR DESCRIPTION
I'm not thrilled with this implementation, but I believe it to be better encapsulated than what we had before. I think we ought to be able to use global state to do the exact same thing, but nicer and simpler. But one step at a time.