### PR TITLE
KeyboardSelect: When there's only one keyboard present, auto-connect

### DIFF
--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -130,7 +130,12 @@ class KeyboardSelect extends React.Component {
 
     this.findKeyboards().then(() => {
       let focus = new Focus();
-      if (!focus._port) return;
+      if (!focus._port) {
+        if (this.state.devices.length != 1) return;
+
+        // We have a single device in the list, try to connect
+        this.onKeyboardConnect();
+      }
       for (let device of this.state.devices) {
         if (!device.path) continue;
 


### PR DESCRIPTION
When there's only one keyboard detected, attempt to auto-connect. We only do this when the component mounts and we aren't already connected.

If there are multiple devices, or if we're connected already, or we disconnect from the same screen, we will not auto-connect.

Fixes #595.
