### PR TITLE
api/focus: Do not send unknown requests

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -21,26 +21,9 @@ import { truncate } from "original-fs";
 export function ActiveDevice() {
   this.port = undefined;
   this.connected = false;
-  this.commands = undefined;
   this.focusConnection = undefined;
 
-  this.availableFocusCommands = undefined;
-
   this.focus = new Focus();
-
-  this.focusCommands = async () => {
-    if (this.commands === undefined) {
-      this._probeFocusCommands();
-    }
-    return this.commands;
-  };
-  this._probeFocusCommands = () => {
-    try {
-      this.commands = this.focus.probe();
-    } catch (e) {
-      this.commands = [];
-    }
-  };
 
   this.focusDetected = async () => {
     if (this.hasCustomizableKeymaps() || this.hasCustomizableLEDMaps()) {
@@ -50,30 +33,28 @@ export function ActiveDevice() {
     }
   };
   this.hasCustomizableKeymaps = async () => {
-    this.focusCommands().then((commands) => {
-      if (
-        commands.includes("keymap.custom") > 0 ||
-        commands.includes("keymap.map") > 0
-      ) {
-        return true;
-      } else {
-        return false;
-      }
-    });
+    const commands = await this.focus.supported_commands();
+    if (
+      commands.includes("keymap.custom") > 0 ||
+      commands.includes("keymap.map") > 0
+    ) {
+      return true;
+    } else {
+      return false;
+    }
   };
 
-  this.hasCustomizableLEDMaps = () => {
-    this.focusCommands().then((commands) => {
-      if (
-        commands.includes("colormap.map") > 0 &&
-        commands.includes("palette") > 0
-      ) {
-        console.log("it has customizable LED maps");
-        console.log(commands);
-        return true;
-      } else {
-        return false;
-      }
-    });
+  this.hasCustomizableLEDMaps = async () => {
+    const commands = await this.focus.supported_commands();
+    if (
+      commands.includes("colormap.map") > 0 &&
+      commands.includes("palette") > 0
+    ) {
+      console.log("it has customizable LED maps");
+      console.log(commands);
+      return true;
+    } else {
+      return false;
+    }
   };
 }


### PR DESCRIPTION
Upon `probe()`, save the results of  `help`, so we have a list of commands. Clear it on `close()`. We'll use this list of supported commands in `request()` to see if the requested command is supported, and if it isn't, we simply return no data, without sending the request.

This reduces traffic between keyboard and host, and fixes #802.