### PR TITLE
backups: Make automatic EEPROM backups device-type specific

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -112,8 +112,12 @@ function FocusCommands(options) {
     );
     sessionStorage.setItem(key, json_dump);
 
-    const r = ipcRenderer.sendSync("eeprom-backup", Date.now(), json_dump);
-    console.debug("eeprom-backup", r);
+    const r = ipcRenderer.sendSync(
+      "backups.save-file",
+      focus.focusDeviceDescriptor.info,
+      Date.now(),
+      json_dump
+    );
 
     return key;
   };

--- a/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
@@ -44,6 +44,7 @@ import { KeymapDB } from "@api/keymap";
 import { getStaticPath } from "../../../../config";
 
 const db = new KeymapDB();
+const focus = new Focus();
 
 const sidebarWidth = 300;
 
@@ -161,7 +162,6 @@ class LibraryImportBase extends React.Component {
   };
 
   loadFromLibrary = (layoutName) => {
-    const focus = new Focus();
     const { vendor, product } = focus.focusDeviceDescriptor.info;
     const cVendor = vendor.replace("/", "");
     const cProduct = product.replace("/", "");
@@ -214,7 +214,8 @@ class BackupImportBase extends React.Component {
 
   selectBackupItem = (item) => () => {
     const [layoutFileData, error] = ipcRenderer.sendSync(
-      "backups.load-backup",
+      "backups.load-file",
+      focus.focusDeviceDescriptor.info,
       item
     );
 
@@ -229,7 +230,10 @@ class BackupImportBase extends React.Component {
   };
 
   componentDidMount() {
-    const library = ipcRenderer.sendSync("backups.list-library");
+    const library = ipcRenderer.sendSync(
+      "backups.list-library",
+      focus.focusDeviceDescriptor.info
+    );
 
     this.setState({ library: library });
   }
@@ -354,8 +358,6 @@ class LayoutSharingBase extends React.Component {
   constructor(props) {
     super(props);
 
-    const focus = new Focus();
-
     const { vendor, product } = focus.focusDeviceDescriptor.info;
     const cVendor = vendor.replace("/", "");
     const cProduct = product.replace("/", "");
@@ -430,7 +432,6 @@ class LayoutSharingBase extends React.Component {
       this.props;
     const { layout, layoutName, library } = this.state;
 
-    const focus = new Focus();
     const Keymap = focus.focusDeviceDescriptor.components.keymap;
     const previewLayout = layout.keymaps ? layout.keymaps[0] : keymap.custom[0];
     const palette = layout.palette || colormap.palette;


### PR DESCRIPTION
We do not want to offer backups made from a Model01 when on an Atreus. To this end, save backups in a vendor/product subdir, and load the library from that directory too.

While there, renamed the IPC functions to be more consistent, too.

Fixes #804, and also fixes #806.