### PR TITLE
Update copyright years & make our @ imports more consistent

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -32,7 +32,8 @@
         "alias": {
           "@api": "/src/api",
           "@renderer": "/src/renderer",
-          "@main": "/src/main"
+          "@main": "/src/main",
+          "@root": "/"
         }
       }
     ]

--- a/electron-webpack.json
+++ b/electron-webpack.json
@@ -2,6 +2,9 @@
   "renderer": {
     "webpackConfig": "webpack.renderer.additions.js"
   },
+  "main": {
+    "webpackConfig": "webpack.main.additions.js"
+  },
 
   "title": "Chrysalis",
 

--- a/src/api/colormap/index.js
+++ b/src/api/colormap/index.js
@@ -14,7 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Focus from "../focus";
+import Focus from "@api/focus";
 
 global.chrysalis_colormap_instance = null;
 

--- a/src/api/colormap/index.js
+++ b/src/api/colormap/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-colormap -- Chrysalis colormap library
- * Copyright (C) 2018-2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -22,9 +22,9 @@ import sudo from "sudo-prompt";
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
 
-import Log from "../log";
+import Log from "@api/log";
 
-import { getStaticPath } from "../../renderer/config";
+import { getStaticPath } from "@renderer/config";
 
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 

--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-flash -- Keyboard flash helpers for Chrysalis
- * Copyright (C) 2018-2021  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-focus -- Chrysalis Focus protocol library
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -19,7 +19,7 @@ const { SerialPort } = require("serialport");
 const { DelimiterParser } = require("@serialport/parser-delimiter");
 import fs from "fs";
 
-import Log from "../log";
+import Log from "@api/log";
 
 global.chrysalis_focus_instance = null;
 

--- a/src/api/hardware-ez-ergodox/components/Keymap.js
+++ b/src/api/hardware-ez-ergodox/components/Keymap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-hardware-ez-ergodox -- Chrysalis ErgoDox support
- * Copyright (C) 2019-2020  Keyboardio, Inc.
+ * Copyright (C) 2019-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-ez-ergodox/components/Keymap.js
+++ b/src/api/hardware-ez-ergodox/components/Keymap.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { KeymapDB } from "../../keymap";
+import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();
 

--- a/src/api/hardware-ez-ergodox/index.js
+++ b/src/api/hardware-ez-ergodox/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-hardware-ez-ergodox -- Chrysalis ErgoDox support
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-ez-ergodox/index.js
+++ b/src/api/hardware-ez-ergodox/index.js
@@ -15,7 +15,7 @@
  */
 
 import Keymap from "./components/Keymap";
-import { teensy } from "../flash";
+import { teensy } from "@api/flash";
 
 const ErgoDox = {
   info: {

--- a/src/api/hardware-keyboardio-atreus2/components/Keymap.js
+++ b/src/api/hardware-keyboardio-atreus2/components/Keymap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-hardware-keyboardio-atreus2 -- Chrysalis Atreus2 support
- * Copyright (C) 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2019-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-keyboardio-atreus2/components/Keymap.js
+++ b/src/api/hardware-keyboardio-atreus2/components/Keymap.js
@@ -21,7 +21,7 @@ import classNames from "classnames";
 import Atreus from "../data/atreus.png";
 import Box from "@mui/material/Box";
 
-import { KeymapDB } from "../../keymap";
+import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();
 

--- a/src/api/hardware-keyboardio-atreus2/index.js
+++ b/src/api/hardware-keyboardio-atreus2/index.js
@@ -15,7 +15,7 @@
  */
 
 import Keymap from "./components/Keymap";
-import { Avr109, Avr109Bootloader } from "../flash";
+import { Avr109, Avr109Bootloader } from "@api/flash";
 
 const Atreus2 = {
   info: {

--- a/src/api/hardware-keyboardio-atreus2/index.js
+++ b/src/api/hardware-keyboardio-atreus2/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-hardware-keyboardio-atreus2 -- Chrysalis Atreus2 support
- * Copyright (C) 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2019-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-keyboardio-model01/components/Keymap.js
+++ b/src/api/hardware-keyboardio-model01/components/Keymap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
- * Copyright (C) 2018-2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  * Copyright (C) 2017, 2018  Simon-Claudius Wystrach
  *
  * Based on the SVG done by Simon-Claudius for the previous incarnation of

--- a/src/api/hardware-keyboardio-model01/components/keymap/Key.js
+++ b/src/api/hardware-keyboardio-model01/components/keymap/Key.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { KeymapDB } from "../../../keymap";
+import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();
 

--- a/src/api/hardware-keyboardio-model01/components/keymap/Key.js
+++ b/src/api/hardware-keyboardio-model01/components/keymap/Key.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
- * Copyright (C) 2018  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-keyboardio-model01/index.js
+++ b/src/api/hardware-keyboardio-model01/index.js
@@ -15,7 +15,12 @@
  */
 
 import Keymap from "./components/Keymap";
-import { Avr109, Avr109Bootloader, DFUUtil, DFUUtilBootloader } from "../flash";
+import {
+  Avr109,
+  Avr109Bootloader,
+  DFUUtil,
+  DFUUtilBootloader,
+} from "@api/flash";
 
 const Model01 = {
   info: {

--- a/src/api/hardware-keyboardio-model01/index.js
+++ b/src/api/hardware-keyboardio-model01/index.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018-2021  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-softhruf-splitography/components/Keymap.js
+++ b/src/api/hardware-softhruf-splitography/components/Keymap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-hardware-softhruf-splitography -- Chrysalis SOFT/HRUF Splitography library
- * Copyright (C) 2019-2020  Keyboard.io, Inc.
+ * Copyright (C) 2019-2022  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-softhruf-splitography/components/Keymap.js
+++ b/src/api/hardware-softhruf-splitography/components/Keymap.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { KeymapDB } from "../../keymap";
+import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();
 

--- a/src/api/hardware-softhruf-splitography/index.js
+++ b/src/api/hardware-softhruf-splitography/index.js
@@ -15,7 +15,7 @@
  */
 
 import Keymap from "./components/Keymap";
-import { DFUProgrammer } from "../flash";
+import { DFUProgrammer } from "@api/flash";
 
 const Splitography = {
   info: {

--- a/src/api/hardware-softhruf-splitography/index.js
+++ b/src/api/hardware-softhruf-splitography/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-hardware-softhruf-splitography -- Chrysalis SOFT/HRUF Splitography library
- * Copyright (C) 2019, 2020  Keyboard.io, Inc.
+ * Copyright (C) 2019-2022  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-technomancy-atreus/components/Keymap.js
+++ b/src/api/hardware-technomancy-atreus/components/Keymap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
- * Copyright (C) 2018-2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-technomancy-atreus/components/keymap/Key.js
+++ b/src/api/hardware-technomancy-atreus/components/keymap/Key.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
- * Copyright (C) 2018-2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware-technomancy-atreus/components/keymap/Key.js
+++ b/src/api/hardware-technomancy-atreus/components/keymap/Key.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { KeymapDB } from "../../../keymap";
+import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();
 

--- a/src/api/hardware-technomancy-atreus/index.js
+++ b/src/api/hardware-technomancy-atreus/index.js
@@ -15,7 +15,7 @@
  */
 
 import Keymap from "./components/Keymap";
-import { teensy } from "../flash";
+import { teensy } from "@api/flash";
 
 const Atreus = {
   info: {

--- a/src/api/hardware-technomancy-atreus/index.js
+++ b/src/api/hardware-technomancy-atreus/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-hardware-technomancy-Atreus -- Chrysalis Atreus support
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/hardware/index.js
+++ b/src/api/hardware/index.js
@@ -18,16 +18,16 @@ import {
   Model01,
   Model100,
   Model100Bootloader,
-} from "../hardware-keyboardio-model01";
-import { Atreus } from "../hardware-technomancy-atreus";
-import { Atreus2 } from "../hardware-keyboardio-atreus2";
-import { Raise_ANSI } from "../hardware-dygma-raise-ansi";
-import { Raise_ISO } from "../hardware-dygma-raise-iso";
-import { ErgoDox } from "../hardware-ez-ergodox";
-import { Planck } from "../hardware-olkb-planck";
-import { KBD4x } from "../hardware-kbdfans-kbd4x";
-import { Splitography } from "../hardware-softhruf-splitography";
-import { GenericTeensy } from "../hardware-pjrc-teensy";
+} from "@api/hardware-keyboardio-model01";
+import { Atreus } from "@api/hardware-technomancy-atreus";
+import { Atreus2 } from "@api/hardware-keyboardio-atreus2";
+import { Raise_ANSI } from "@api/hardware-dygma-raise-ansi";
+import { Raise_ISO } from "@api/hardware-dygma-raise-iso";
+import { ErgoDox } from "@api/hardware-ez-ergodox";
+import { Planck } from "@api/hardware-olkb-planck";
+import { KBD4x } from "@api/hardware-kbdfans-kbd4x";
+import { Splitography } from "@api/hardware-softhruf-splitography";
+import { GenericTeensy } from "@api/hardware-pjrc-teensy";
 
 const Hardware = {
   serial: [

--- a/src/api/hardware/index.js
+++ b/src/api/hardware/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-hardware -- Chrysalis Hardware library collection
- * Copyright (C) 2019-2021  Keyboardio, Inc.
+ * Copyright (C) 2019-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/chrysalis-keymap.js
+++ b/src/api/keymap/chrysalis-keymap.js
@@ -1,5 +1,5 @@
 /* chrysalis-keymap -- Chrysalis keymap library
- * Copyright (C) 2018-2021  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/chrysalis-keymap.js
+++ b/src/api/keymap/chrysalis-keymap.js
@@ -14,7 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Focus from "../focus";
+import Focus from "@api/focus";
 
 import KeymapDB from "./db";
 

--- a/src/api/keymap/cldr.js
+++ b/src/api/keymap/cldr.js
@@ -18,7 +18,7 @@ import fs from "fs";
 import path from "path";
 import xml2js from "xml2js";
 import unraw from "unraw";
-import { getStaticPath } from "../../renderer/config";
+import { getStaticPath } from "@renderer/config";
 
 import { addModifier } from "./db/modifiers";
 

--- a/src/api/keymap/cldr.js
+++ b/src/api/keymap/cldr.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db.js
+++ b/src/api/keymap/db.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/addCategories.js
+++ b/src/api/keymap/db/addCategories.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/blanks.js
+++ b/src/api/keymap/db/base/blanks.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/consumer.js
+++ b/src/api/keymap/db/base/consumer.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/dualuse.js
+++ b/src/api/keymap/db/base/dualuse.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/fx.js
+++ b/src/api/keymap/db/base/fx.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/gui.js
+++ b/src/api/keymap/db/base/gui.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/index.js
+++ b/src/api/keymap/db/base/index.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020, 2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/layers.js
+++ b/src/api/keymap/db/base/layers.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/leader.js
+++ b/src/api/keymap/db/base/leader.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/ledkeys.js
+++ b/src/api/keymap/db/base/ledkeys.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/macros.js
+++ b/src/api/keymap/db/base/macros.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/misc.js
+++ b/src/api/keymap/db/base/misc.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/modifiers.js
+++ b/src/api/keymap/db/base/modifiers.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/mousekeys.js
+++ b/src/api/keymap/db/base/mousekeys.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/navigation.js
+++ b/src/api/keymap/db/base/navigation.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/numpad.js
+++ b/src/api/keymap/db/base/numpad.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/oneshot.js
+++ b/src/api/keymap/db/base/oneshot.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/spacecadet.js
+++ b/src/api/keymap/db/base/spacecadet.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/spacing.js
+++ b/src/api/keymap/db/base/spacing.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/steno.js
+++ b/src/api/keymap/db/base/steno.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/base/tapdance.js
+++ b/src/api/keymap/db/base/tapdance.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/modifiers.js
+++ b/src/api/keymap/db/modifiers.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/db/us/qwerty.js
+++ b/src/api/keymap/db/us/qwerty.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/keymap/index.js
+++ b/src/api/keymap/index.js
@@ -1,5 +1,5 @@
 /* chrysalis-keymap -- Chrysalis keymap library
- * Copyright (C) 2018  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/api/log/index.js
+++ b/src/api/log/index.js
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/dragons.js
+++ b/src/main/dragons.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -32,7 +32,7 @@ import windowStateKeeper from "electron-window-state";
 import installExtension, {
   REACT_DEVELOPER_TOOLS,
 } from "electron-devtools-installer";
-import { getStaticPath } from "../renderer/config";
+import { getStaticPath } from "@renderer/config";
 import { initialize, enable as enableRemote } from "@electron/remote/main";
 import {
   registerDeviceDiscoveryHandlers,

--- a/src/main/ipc_backups.js
+++ b/src/main/ipc_backups.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ipcMain, app } from "electron";
 import fs from "fs";
 import path from "path";

--- a/src/main/ipc_device_discovery.js
+++ b/src/main/ipc_device_discovery.js
@@ -18,8 +18,8 @@
 import { ipcMain, BrowserWindow } from "electron";
 import { findByIds, getDeviceList, WebUSB } from "usb";
 // Focus
-import Focus from "../api/focus";
-import Hardware from "../api/hardware";
+import Focus from "@api/focus";
+import Hardware from "@api/hardware";
 const focus = new Focus();
 
 const webusb = new WebUSB({

--- a/src/main/ipc_devtools.js
+++ b/src/main/ipc_devtools.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ipcMain } from "electron";
 
 export const registerDevtoolsHandlers = () => {

--- a/src/main/ipc_file_io.js
+++ b/src/main/ipc_file_io.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ipcMain, dialog } from "electron";
 import fs from "fs";
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { app, BrowserWindow, Menu } from "electron";
 
 const isMac = process.platform === "darwin";

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Focus from "@api/focus";
 import { truncate } from "original-fs";
 

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/Error.js
+++ b/src/renderer/Error.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/BoardMenu.js
+++ b/src/renderer/components/BoardMenu.js
@@ -21,7 +21,7 @@ import Electron from "electron";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Divider from "@mui/material/Divider";
-import i18n from "../i18n";
+import i18n from "@renderer/i18n";
 
 const openURL = (url, closeMenu) => {
   const shell = Electron.remote && Electron.remote.shell;

--- a/src/renderer/components/BoardMenu.js
+++ b/src/renderer/components/BoardMenu.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/ConfirmationDialog.js
+++ b/src/renderer/components/ConfirmationDialog.js
@@ -23,7 +23,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 
-import i18n from "../i18n";
+import i18n from "@renderer/i18n";
 
 const ConfirmationDialog = (props) => {
   return (

--- a/src/renderer/components/ConfirmationDialog.js
+++ b/src/renderer/components/ConfirmationDialog.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/ContextBar.js
+++ b/src/renderer/components/ContextBar.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 const context_bar_channel = new BroadcastChannel("context_bar");
 
 export const showContextBar = () => {

--- a/src/renderer/components/GlobalContext.js
+++ b/src/renderer/components/GlobalContext.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React, { useState, createContext } from "react";
 
 export const GlobalContext = createContext();

--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -17,8 +17,8 @@
 
 import React, { useState, useEffect, useContext } from "react";
 
-import "../../api/keymap";
-import "../../api/colormap";
+import "@api/keymap";
+import "@api/colormap";
 import "typeface-roboto/index.css";
 import "typeface-source-code-pro/index.css";
 

--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/KeyButton.js
+++ b/src/renderer/components/KeyButton.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/LoadingScreen.js
+++ b/src/renderer/components/LoadingScreen.js
@@ -19,9 +19,10 @@ import React from "react";
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import i18n from "../i18n";
-import { getStatic } from "../config";
 import { keyframes } from "@mui/system";
+
+import i18n from "@renderer/i18n";
+import { getStatic } from "@renderer/config";
 
 function LoadingScreen(props) {
   const logoPath = getStatic("/logo.png");

--- a/src/renderer/components/LoadingScreen.js
+++ b/src/renderer/components/LoadingScreen.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -27,13 +27,13 @@ import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import ListItemIcon from "@mui/material/ListItemIcon";
 
-import logo from "../../logo-small.png";
-import i18n from "../../i18n";
+import logo from "@renderer/logo-small.png";
+import i18n from "@renderer/i18n";
 
-import { version } from "../../../../package.json";
+import { version } from "@root/package.json";
 
 import UpgradeMenuItem from "./UpgradeMenuItem";
-import openURL from "../../utils/openURL";
+import openURL from "@renderer/utils/openURL";
 import ChatIcon from "@mui/icons-material/Chat";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import InfoIcon from "@mui/icons-material/Info";
@@ -43,9 +43,9 @@ import KeyboardIcon from "@mui/icons-material/Keyboard";
 
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 
-import { history } from "../../routerHistory";
+import { history } from "@renderer/routerHistory";
 
-import { GlobalContext } from "../GlobalContext";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 
 function MainMenu({ open, closeMenu, classes }) {
   const drawerWidth = 350;

--- a/src/renderer/components/MainMenu/UpgradeMenuItem.js
+++ b/src/renderer/components/MainMenu/UpgradeMenuItem.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/MainMenu/UpgradeMenuItem.js
+++ b/src/renderer/components/MainMenu/UpgradeMenuItem.js
@@ -21,9 +21,9 @@ import Divider from "@mui/material/Divider";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 
-import i18n from "../../i18n";
-import { version } from "../../../../package.json";
-import getLatestVersion from "../../utils/getLatestVersion";
+import { version } from "@root/package.json";
+import i18n from "@renderer/i18n";
+import getLatestVersion from "@renderer/utils/getLatestVersion";
 
 function UpgradeMenuItem() {
   const [latestVersion, setLatestVersion] = useState(null);

--- a/src/renderer/components/PageTitle.js
+++ b/src/renderer/components/PageTitle.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React from "react";
 import Portal from "@mui/material/Portal";
 

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -27,7 +27,7 @@ import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Tooltip from "@mui/material/Tooltip";
 import withStyles from "@mui/styles/withStyles";
 
-import i18n from "../i18n";
+import i18n from "@renderer/i18n";
 
 const styles = (theme) => ({
   root: {

--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/hooks/useWindowSize.js
+++ b/src/renderer/hooks/useWindowSize.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { useState, useEffect } from "react";
 
 // Hook from https://usehooks.com/useWindowSize/

--- a/src/renderer/i18n.js
+++ b/src/renderer/i18n.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018-2021  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/routerHistory.js
+++ b/src/renderer/routerHistory.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { createMemorySource, createHistory } from "@gatsbyjs/reach-router";
 
 const source = createMemorySource("/keyboard-select");

--- a/src/renderer/screens/ChangeLog.js
+++ b/src/renderer/screens/ChangeLog.js
@@ -26,16 +26,16 @@ import Typography from "@mui/material/Typography";
 
 import Electron from "electron";
 
-import logo from "../logo-small.png";
-import { version } from "../../../package.json";
+import { version } from "@root/package.json";
+import logo from "@renderer/logo-small.png";
 
 import fs from "fs";
 import path from "path";
 
-import { getStaticPath } from "../config";
-import i18n from "../i18n";
+import { getStaticPath } from "@renderer/config";
+import i18n from "@renderer/i18n";
 
-import { PageTitle } from "../components/PageTitle";
+import { PageTitle } from "@renderer/components/PageTitle";
 
 const ChangeLog = (props) => {
   const { classes } = props;

--- a/src/renderer/screens/ChangeLog.js
+++ b/src/renderer/screens/ChangeLog.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2021  Keyboardio, Inc.
+ * Copyright (C) 2021-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -1,7 +1,7 @@
 import { LegacyAlert } from "./components/LegacyAlert";
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -1,4 +1,3 @@
-import { LegacyAlert } from "./components/LegacyAlert";
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
  * Copyright (C) 2020-2022  Keyboardio, Inc.
@@ -25,16 +24,17 @@ import { toast } from "react-toastify";
 const Store = require("electron-store");
 const settings = new Store();
 
-import Focus from "../../../api/focus";
-import Log from "../../../api/log";
+import Focus from "@api/focus";
+import Log from "@api/log";
 import { KeymapDB, default as Keymap } from "@api/keymap";
 
 import Sidebar, { sidebarWidth } from "./Sidebar";
 
-import SaveChangesButton from "../../components/SaveChangesButton";
-import { PageTitle } from "../../components/PageTitle";
-import i18n from "../../i18n";
-import LoadingScreen from "../../components/LoadingScreen";
+import { LegacyAlert } from "./components/LegacyAlert";
+import SaveChangesButton from "@renderer/components/SaveChangesButton";
+import { PageTitle } from "@renderer/components/PageTitle";
+import i18n from "@renderer/i18n";
+import LoadingScreen from "@renderer/components/LoadingScreen";
 import OnlyCustomScreen from "./components/OnlyCustomScreen";
 import { FloatingKeyPicker } from "./components/FloatingKeyPicker";
 import {

--- a/src/renderer/screens/Editor/Keyboard104.js
+++ b/src/renderer/screens/Editor/Keyboard104.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2019, 2020, 2021  Keyboardio, Inc.
+ * Copyright (C) 2019-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/BlankKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/BlankKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/BrightnessKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/BrightnessKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/Colormap/PalettePicker.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap/PalettePicker.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/CustomKey.js
+++ b/src/renderer/screens/Editor/Sidebar/CustomKey.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/LEDKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LEDKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/LEDKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LEDKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const LEDKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange, colormap } = props;

--- a/src/renderer/screens/Editor/Sidebar/LayerKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LayerKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const LeaderKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;

--- a/src/renderer/screens/Editor/Sidebar/LogicalLayout.js
+++ b/src/renderer/screens/Editor/Sidebar/LogicalLayout.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/LogicalLayout/LayoutSelect.js
+++ b/src/renderer/screens/Editor/Sidebar/LogicalLayout/LayoutSelect.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/MacroKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MacroKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const MacroKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;

--- a/src/renderer/screens/Editor/Sidebar/MacroKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MacroKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/MediaKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MediaKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/MouseKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MouseKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -27,7 +27,7 @@ import Switch from "@mui/material/Switch";
 import Collapsible from "../components/Collapsible";
 import KeyButton from "../components/KeyButton";
 
-import Focus from "../../../../api/focus";
+import Focus from "@api/focus";
 import { KeymapDB } from "@api/keymap";
 
 const db = new KeymapDB();

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview/LayoutSharing.js
@@ -36,12 +36,12 @@ import MenuList from "@mui/material/MenuList";
 import Typography from "@mui/material/Typography";
 import withStyles from "@mui/styles/withStyles";
 
-import ConfirmationDialog from "../../../../components/ConfirmationDialog";
+import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
 
-import Focus from "../../../../../api/focus";
-import Log from "../../../../../api/log";
+import Focus from "@api/focus";
+import Log from "@api/log";
 import { KeymapDB } from "@api/keymap";
-import { getStaticPath } from "../../../../config";
+import { getStaticPath } from "@renderer/config";
 
 const db = new KeymapDB();
 

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const SpaceCadetKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;

--- a/src/renderer/screens/Editor/Sidebar/StenoKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/StenoKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/StenoKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/StenoKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const StenoKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;

--- a/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
@@ -18,7 +18,7 @@
 import React from "react";
 import i18n from "i18next";
 
-import CategorySelector from "@renderer/screens/Editor/components/CategorySelector";
+import CategorySelector from "../components/CategorySelector";
 
 const TapDanceKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;

--- a/src/renderer/screens/Editor/Sidebar/VolumeKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/VolumeKeys.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/components/CategorySelector.js
+++ b/src/renderer/screens/Editor/components/CategorySelector.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/components/Collapsible.js
+++ b/src/renderer/screens/Editor/components/Collapsible.js
@@ -1,7 +1,6 @@
 // -*- mode: js-jsx -*-
-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/components/FloatingKeyPicker.js
+++ b/src/renderer/screens/Editor/components/FloatingKeyPicker.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Box from "@mui/material/Box";
 import useTheme from "@mui/material/styles/useTheme";
 import React, { useState } from "react";

--- a/src/renderer/screens/Editor/components/KeyButton.js
+++ b/src/renderer/screens/Editor/components/KeyButton.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/components/KeyButtonList.js
+++ b/src/renderer/screens/Editor/components/KeyButtonList.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/components/LegacyAlert.js
+++ b/src/renderer/screens/Editor/components/LegacyAlert.js
@@ -20,7 +20,7 @@ import Alert from "@mui/material/Alert";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 
-import i18n from "../../../i18n";
+import i18n from "@renderer/i18n";
 
 export const LegacyAlert = (migrateLegacy) => {
   return (

--- a/src/renderer/screens/Editor/components/LegacyAlert.js
+++ b/src/renderer/screens/Editor/components/LegacyAlert.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React from "react";
 import Alert from "@mui/material/Alert";
 import Button from "@mui/material/Button";

--- a/src/renderer/screens/Editor/components/OnlyCustomScreen.js
+++ b/src/renderer/screens/Editor/components/OnlyCustomScreen.js
@@ -25,11 +25,12 @@ import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 
-import Focus from "../../../../api/focus";
-import openURL from "../../../utils/openURL";
-import i18n from "../../../i18n";
-import { navigate } from "../../../routerHistory";
-import { PageTitle } from "../../../components/PageTitle";
+import Focus from "@api/focus";
+import openURL from "@renderer/utils/openURL";
+import i18n from "@renderer/i18n";
+import { navigate } from "@renderer/routerHistory";
+import { PageTitle } from "@renderer/components/PageTitle";
+
 const OnlyCustomScreen = (props) => {
   const enableOnlyCustom = async () => {
     let focus = new Focus();

--- a/src/renderer/screens/Editor/components/OnlyCustomScreen.js
+++ b/src/renderer/screens/Editor/components/OnlyCustomScreen.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2021  Keyboardio, Inc.
+ * Copyright (C) 2021-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Editor/index.js
+++ b/src/renderer/screens/Editor/index.js
@@ -1,3 +1,20 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Editor from "./Editor";
 
 export default Editor;

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -19,9 +19,9 @@ import React, { useState } from "react";
 import { Electron, ipcRenderer } from "electron";
 import path from "path";
 import fs from "fs";
-import { version } from "../../../package.json";
+import { version } from "@root/package.json";
 
-import Focus from "../../api/focus";
+import Focus from "@api/focus";
 
 import Box from "@mui/material/Box";
 import BuildIcon from "@mui/icons-material/Build";
@@ -51,14 +51,14 @@ import { toast } from "react-toastify";
 const Store = require("electron-store");
 const settings = new Store();
 
-import { getStaticPath } from "../config";
-import ConfirmationDialog from "../components/ConfirmationDialog";
-import SaveChangesButton from "../components/SaveChangesButton";
-import i18n from "../i18n";
+import { getStaticPath } from "@renderer/config";
+import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
+import SaveChangesButton from "@renderer/components/SaveChangesButton";
+import i18n from "@renderer/i18n";
 
-import clearEEPROM from "../utils/clearEEPROM";
-import checkExternalFlasher from "../utils/checkExternalFlasher";
-import { PageTitle } from "../components/PageTitle";
+import clearEEPROM from "@renderer/utils/clearEEPROM";
+import checkExternalFlasher from "@renderer/utils/checkExternalFlasher";
+import { PageTitle } from "@renderer/components/PageTitle";
 
 const FirmwareUpdate = (props) => {
   let focus = new Focus();

--- a/src/renderer/screens/FocusNotDetected.js
+++ b/src/renderer/screens/FocusNotDetected.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/FocusNotDetected.js
+++ b/src/renderer/screens/FocusNotDetected.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import Focus from "../../api/focus";
+import Focus from "@api/focus";
 
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
@@ -31,9 +31,9 @@ import Typography from "@mui/material/Typography";
 
 import { toast } from "react-toastify";
 
-import i18n from "../i18n";
-import { navigate } from "../routerHistory";
-import { PageTitle } from "../components/PageTitle";
+import i18n from "@renderer/i18n";
+import { navigate } from "@renderer/routerHistory";
+import { PageTitle } from "@renderer/components/PageTitle";
 
 const FocusNotDetected = (props) => {
   let focus = new Focus();

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -1,4 +1,3 @@
-import { PageTitle } from "./../components/PageTitle";
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
  * Copyright (C) 2018-2022  Keyboardio, Inc.
@@ -24,18 +23,20 @@ import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import LinearProgress from "@mui/material/LinearProgress";
 import React, { useState, useEffect } from "react";
+const { ipcRenderer } = require("electron");
 import { toast } from "react-toastify";
-import Focus from "../../api/focus";
-import i18n from "../i18n";
-import logo from "../logo-small.png";
 
-import { useIntervalImmediate } from "../utils/useInterval";
+import Focus from "@api/focus";
+import i18n from "@renderer/i18n";
+import logo from "@renderer/logo-small.png";
+import { useIntervalImmediate } from "@renderer/utils/useInterval";
+import { findKeyboards } from "@renderer/utils/findKeyboards";
+import { PageTitle } from "@renderer/components/PageTitle";
+
 import { ConnectionButton } from "./KeyboardSelect/ConnectionButton";
 import { LinuxPermissionsWarning } from "./KeyboardSelect/LinuxPermissionsWarning";
 import { KeyboardPortSelector } from "./KeyboardSelect/KeyboardPortSelector";
 import { DeviceImage } from "./KeyboardSelect/DeviceImage";
-const { ipcRenderer } = require("electron");
-import { findKeyboards } from "../utils/findKeyboards";
 
 const KeyboardSelect = (props) => {
   const [selectedPortIndex, setSelectedPortIndex] = useState(0);

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -1,7 +1,7 @@
 import { PageTitle } from "./../components/PageTitle";
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/KeyboardSelect/ConnectionButton.js
+++ b/src/renderer/screens/KeyboardSelect/ConnectionButton.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/KeyboardSelect/ConnectionButton.js
+++ b/src/renderer/screens/KeyboardSelect/ConnectionButton.js
@@ -19,7 +19,7 @@ import { autocompleteClasses } from "@mui/material";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import React from "react";
-import i18n from "../../i18n";
+import i18n from "@renderer/i18n";
 
 export const ConnectionButton = (props) => {
   const disabled = props.disabled;

--- a/src/renderer/screens/KeyboardSelect/DeviceImage.js
+++ b/src/renderer/screens/KeyboardSelect/DeviceImage.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/KeyboardSelect/KeyboardPortSelector.js
+++ b/src/renderer/screens/KeyboardSelect/KeyboardPortSelector.js
@@ -24,7 +24,8 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import i18n from "../../i18n";
+import i18n from "@renderer/i18n";
+
 export const KeyboardPortSelector = (props) => {
   const devices = props.devices;
   const selectedPortIndex = props.selectedPortIndex;

--- a/src/renderer/screens/KeyboardSelect/KeyboardPortSelector.js
+++ b/src/renderer/screens/KeyboardSelect/KeyboardPortSelector.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/KeyboardSelect/LinuxPermissionsWarning.js
+++ b/src/renderer/screens/KeyboardSelect/LinuxPermissionsWarning.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/KeyboardSelect/LinuxPermissionsWarning.js
+++ b/src/renderer/screens/KeyboardSelect/LinuxPermissionsWarning.js
@@ -20,8 +20,8 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { toast } from "react-toastify";
-import i18n from "../../i18n";
-import { installUdevRules } from "../../utils/installUdevRules";
+import i18n from "@renderer/i18n";
+import { installUdevRules } from "@renderer/utils/installUdevRules";
 
 export const LinuxPermissionsWarning = (props) => {
   const selectedDevicePort = props.selectedDevicePort;

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020-2021  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -18,6 +18,7 @@
 import React, { useState, useEffect } from "react";
 
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 
 import { toast } from "react-toastify";
 
@@ -27,10 +28,9 @@ const settings = new Store();
 import Focus from "@api/focus";
 import { KeymapDB, default as Keymap } from "@api/keymap";
 
-import { PageTitle } from "../components/PageTitle";
-import i18n from "../i18n";
-import LoadingScreen from "../components/LoadingScreen";
-import Typography from "@mui/material/Typography";
+import { PageTitle } from "@renderer/components/PageTitle";
+import i18n from "@renderer/i18n";
+import LoadingScreen from "@renderer/components/LoadingScreen";
 
 const db = new KeymapDB();
 const focus = new Focus();

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -23,15 +23,15 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import PropTypes from "prop-types";
 
-import { PageTitle } from "../components/PageTitle";
+import { PageTitle } from "@renderer/components/PageTitle";
 import {
   KeyboardSettings,
   AdvancedKeyboardSettings,
 } from "./Preferences/KeyboardSettings";
 import { BasicPreferences } from "./Preferences/Basic";
 import { DevtoolsPreferences } from "./Preferences/Devtools";
-import i18n from "../i18n";
-import { GlobalContext } from "../components/GlobalContext";
+import i18n from "@renderer/i18n";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 
 TabPanel.propTypes = {
   children: PropTypes.node,

--- a/src/renderer/screens/Preferences/Basic.js
+++ b/src/renderer/screens/Preferences/Basic.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Preferences/Basic.js
+++ b/src/renderer/screens/Preferences/Basic.js
@@ -16,7 +16,7 @@
  */
 
 import React, { useState } from "react";
-import { GlobalContext } from "../../components/GlobalContext";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -29,7 +29,8 @@ import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 
-import i18n from "../../i18n";
+import i18n from "@renderer/i18n";
+
 const Store = require("electron-store");
 const settings = new Store();
 

--- a/src/renderer/screens/Preferences/Devtools.js
+++ b/src/renderer/screens/Preferences/Devtools.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/Preferences/Devtools.js
+++ b/src/renderer/screens/Preferences/Devtools.js
@@ -24,9 +24,9 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 
-import i18n from "../../i18n";
+import i18n from "@renderer/i18n";
 
-import Focus from "../../../api/focus";
+import Focus from "@api/focus";
 
 const Store = require("electron-store");
 

--- a/src/renderer/screens/Preferences/KeyboardSettings.js
+++ b/src/renderer/screens/Preferences/KeyboardSettings.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019, 2020  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  * Copyright (C) 2020  DygmaLab SE.
  *
  * This program is free software: you can redistribute it and/or modify it under

--- a/src/renderer/screens/Preferences/KeyboardSettings.js
+++ b/src/renderer/screens/Preferences/KeyboardSettings.js
@@ -34,14 +34,14 @@ import Slider from "@mui/material/Slider";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 
-import Focus from "../../../api/focus";
+import Focus from "@api/focus";
 import { FocusCommands } from "@api/flash";
 
-import ConfirmationDialog from "../../components/ConfirmationDialog";
-import SaveChangesButton from "../../components/SaveChangesButton";
-import i18n from "../../i18n";
-import clearEEPROM from "../../utils/clearEEPROM";
-import checkExternalFlasher from "../../utils/checkExternalFlasher";
+import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
+import SaveChangesButton from "@renderer/components/SaveChangesButton";
+import i18n from "@renderer/i18n";
+import clearEEPROM from "@renderer/utils/clearEEPROM";
+import checkExternalFlasher from "@renderer/utils/checkExternalFlasher";
 
 import {
   showContextBar,

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -17,8 +17,8 @@
 
 import React, { useState } from "react";
 
-import Focus from "../../api/focus";
-import Log from "../../api/log";
+import Focus from "@api/focus";
+import Log from "@api/log";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -41,16 +41,16 @@ import { ipcRenderer, Electron } from "electron";
 
 import { toast } from "react-toastify";
 
-import logo from "../logo-small.png";
-import { version } from "../../../package.json";
+import { version } from "@root/package.json";
+import logo from "@renderer/logo-small.png";
 
 import si from "systeminformation";
 import archiver from "archiver";
 import fs from "fs";
 import jsonStringify from "json-stringify-pretty-compact";
 import { v4 as uuidv4 } from "uuid";
-import { PageTitle } from "../components/PageTitle";
-import i18n from "../i18n";
+import { PageTitle } from "@renderer/components/PageTitle";
+import i18n from "@renderer/i18n";
 
 function SystemInfo(props) {
   const [collecting, setCollecting] = useState(false);

--- a/src/renderer/utils/checkExternalFlasher.js
+++ b/src/renderer/utils/checkExternalFlasher.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/utils/checkExternalFlasher.js
+++ b/src/renderer/utils/checkExternalFlasher.js
@@ -18,7 +18,7 @@
 import fs from "fs";
 import path from "path";
 
-import { getStaticPath } from "../config";
+import { getStaticPath } from "@renderer/config";
 
 const checkExternalFlasher = async (device) => {
   if (!device.externalFlasher) return false;

--- a/src/renderer/utils/clearEEPROM.js
+++ b/src/renderer/utils/clearEEPROM.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/utils/clearEEPROM.js
+++ b/src/renderer/utils/clearEEPROM.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Focus from "../../api/focus";
+import Focus from "@api/focus";
 
 const clearEEPROM = async () => {
   const focus = new Focus();

--- a/src/renderer/utils/findKeyboards.js
+++ b/src/renderer/utils/findKeyboards.js
@@ -15,8 +15,8 @@
  */
 
 import { ipcRenderer } from "electron";
-import Hardware from "../../api/hardware";
-import Focus from "../../api/focus";
+import Hardware from "@api/hardware";
+import Focus from "@api/focus";
 
 const findNonSerialKeyboards = async (deviceList) => {
   return ipcRenderer.invoke("usb-scan-for-devices").then((devicesConnected) => {

--- a/src/renderer/utils/findKeyboards.js
+++ b/src/renderer/utils/findKeyboards.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { ipcRenderer } from "electron";
 import Hardware from "../../api/hardware";
 import Focus from "../../api/focus";

--- a/src/renderer/utils/getLatestVersion.js
+++ b/src/renderer/utils/getLatestVersion.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/utils/getLatestVersion.js
+++ b/src/renderer/utils/getLatestVersion.js
@@ -16,7 +16,7 @@
  */
 
 import https from "https";
-import { version } from "../../../package.json";
+import { version } from "@root/package.json";
 
 let __latestVersion;
 

--- a/src/renderer/utils/installUdevRules.js
+++ b/src/renderer/utils/installUdevRules.js
@@ -19,9 +19,9 @@ import sudo from "sudo-prompt";
 import path from "path";
 import tmp from "tmp";
 import { spawn } from "child_process";
-import { getStaticPath } from "../config";
 
-import Log from "../../api/log";
+import { getStaticPath } from "@renderer/config";
+import Log from "@api/log";
 
 const installUdevRules = async (devicePath) => {
   const rules = path.join(getStaticPath(), "udev", "60-kaleidoscope.rules");

--- a/src/renderer/utils/installUdevRules.js
+++ b/src/renderer/utils/installUdevRules.js
@@ -1,6 +1,6 @@
 // -*- mode: js-jsx -*-
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2020  Keyboardio, Inc.
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/renderer/utils/openURL.js
+++ b/src/renderer/utils/openURL.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Electron from "electron";
 
 export default function openURL(url) {

--- a/src/renderer/utils/useInterval.js
+++ b/src/renderer/utils/useInterval.js
@@ -1,3 +1,19 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // From https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 
 import React, { useState, useEffect, useRef } from "react";

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -1,5 +1,5 @@
 /* Chrysalis -- Kaleidoscope Command Center
- * Copyright (C) 2018, 2019  Keyboardio, Inc.
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webpack.main.additions.js
+++ b/webpack.main.additions.js
@@ -14,7 +14,6 @@ module.exports = {
       "@api": path.resolve(__dirname, "src/api"),
       "@renderer": path.resolve(__dirname, "src/renderer"),
       "@main": path.resolve(__dirname, "src/main"),
-      "@root": path.resolve(__dirname)
     },
   },
 };


### PR DESCRIPTION
This has two parts: the first updates all the copyright years, and adds the copyright header to files that were missing it.

The more interesting one is the second part, which changes a whole lot of imports to use `@api`, `@main` or `@renderer` instead of relative imports. There are a few cases where I changed an existing `@renderer` import to a relative one, because the guiding principle was that stuff that will move together, stuff that forms a logical unit, should use relative imports when importing things from the same unit. When importing from outside the logical unit, then we use the aliases.