### PR TITLE
Assorted focus fixes

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -57,7 +57,7 @@ function FocusCommands(options) {
     };
 
     // Attempt calling device.reset first, if present.
-    const commands = await focus.command("help");
+    const commands = await focus.supported_commands();
     if (commands.includes("device.reset")) {
       try {
         await focus.request("device.reset");

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -220,7 +220,7 @@ class Focus {
 
         this.result = "";
         if (resolve) {
-          resolve(result);
+          resolve(result.trim());
         }
       } else {
         if (this.result.length == 0) {

--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -129,7 +129,8 @@ class Focus {
       focusDeviceDescriptor,
       focusDeviceDescriptor.usb
     );
-    return await this.open(d.path, d);
+    await this.open(d.path, d);
+    return await this.supported_commands();
   }
 
   async find(...device_descriptors) {


### PR DESCRIPTION
These are a couple of small fixes around `@api/focus`:

- A tiny one to use `focus.supported_commands()` in `FlashCommands.reboot()`, instead of requesting a `help` again. This is inconsequential, but makes the code more expressive, and avoids unnecessary trafic.
- Slightly bigger impact is explicitly calling `supported_commands()` after a reconnect, to cache available commands. This lets us avoid sending unknown commands during EEPROM restore, and thus fixes #817.
- Trim the data we return from a requests, mostly as a workaround for keyboardio/Kaleidoscope#1178.