### PR TITLE
FirmwareUpdate: Let the user know when they can release PROG

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -307,6 +307,7 @@ const English = {
     },
     flashing: {
       error: "Error flashing the firmware",
+      releasePROG: `Bootloader detected. If you're holding a key down, please release it.`,
       troubleshooting: "Troubleshooting",
       success: "Firmware flashed successfully!",
       button: "Update",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -142,6 +142,13 @@ const FirmwareUpdate = (props) => {
     }
 
     const nextStep = async (desiredState) => {
+      if (desiredState == "bootloaderWait") {
+        toast.info(t("firmwareUpdate.flashing.releasePROG"), {
+          autoClose: 5000,
+          closeOnClick: true,
+        });
+      }
+
       setActiveStep(activeStep + 1);
       focusDeviceDescriptor.flashSteps.forEach((step, index) => {
         if (step == desiredState) {


### PR DESCRIPTION
When we reach the waiting-for-bootloader step of the firmware flashing process, it is safe to release the PROG key (or its equivalent). Pop up a toast letting the user know.

We do this when we start to wait for the bootloader, rather than after, to give enough time for the user to react. If we do it at the start of `flash` (the usual next step), we only have a couple of seconds to react before flashing finishes. Doing it at this time gives us a few more.

![Screenshot from 2022-05-24 23-16-19](https://user-images.githubusercontent.com/17243/170134237-4cf0f0c1-2d7c-4c4f-bb57-ba8f8b9526ab.png)
