### PR TITLE
FirmwareUpdate: Call out the update instructions more visibly

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -296,6 +296,7 @@ const English = {
     permissionErrorSuggestion: `Chrysalis can fix this by installing a udev rules file into /etc/udev/rules.d/.`,
   },
   firmwareUpdate: {
+    calloutTitle: "Important!",
     dialog: {
       selectFirmware: "Select a firmware",
       firmwareFiles: "Firmware files",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -20,6 +20,8 @@ import BuildIcon from "@mui/icons-material/Build";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import ExploreIcon from "@mui/icons-material/ExploreOutlined";
 import SettingsBackupRestoreIcon from "@mui/icons-material/SettingsBackupRestore";
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -379,9 +381,10 @@ const FirmwareUpdate = (props) => {
               Chrysalis-Firmware-Bundle
             </a>
           </Typography>
-          <Typography component="p" gutterBottom>
+          <Alert severity="info" sx={{ my: 2 }}>
+            <AlertTitle>{t("firmwareUpdate.calloutTitle")}</AlertTitle>
             {t("hardware.updateInstructions")}
-          </Typography>
+          </Alert>
           <Typography component="p" gutterBottom>
             {t("firmwareUpdate.postUpload")}
           </Typography>


### PR DESCRIPTION
The device specific flashing instructions were blending in with the rest too much, and people had a hard time noticing them. Lets make them stand out a little, by wrapping them in an informational alert.

Fixes #822.

![Screenshot from 2022-05-25 15-29-52](https://user-images.githubusercontent.com/17243/170273859-887949de-706e-474d-80f2-50a49e9db708.png)
