### PR TITLE
Editor/SideBar: Add a small margin at the bottom

### DIFF
--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -100,7 +100,7 @@ const Sidebar = (props) => {
       }}
     >
       <Toolbar />
-      <Box sx={{ px: 1 }}>
+      <Box sx={{ px: 1, mb: 2 }}>
         <Overview
           keymap={keymap}
           colormap={colormap}


### PR DESCRIPTION
Our last Collapsible hitting the very border of a window looked a bit awkward. Adding a small margin makes it look nicer.

Fixes #823.
