### PR TITLE
KeyboardSelect: Pre-select the active device (if any)

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -24,6 +24,10 @@ export function ActiveDevice() {
 
   this.focus = new Focus();
 
+  this.devicePath = async () => {
+    return this.focus._port?.settings.path;
+  };
+
   this.focusDetected = async () => {
     if (this.hasCustomizableKeymaps() || this.hasCustomizableLEDMaps()) {
       return true;


### PR DESCRIPTION
When we arrive on the KeyboardSelect screen, we want to show the currently active device as the initially selected device. To do that, we perform an initial scan, and iterate through the device list returned to see if we're connected to any of them. If we are, we simply set the selected port index accordingly. We do this only once per mount.

The periodic device scans have been changed from `useIntervalImmediate` to `userInterval`, because we handle the initial scan via `useEffectOnce`, which does the scanning too.

Fixes #809.

Signed-off-by: Gergely Nagy <algernon@keyboard.io>