### PR TITLE
LayoutCard: Use the colormap too when rendering, if available

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -244,6 +244,7 @@ const English = {
     interface: "User Interface",
     advanced: "Advanced",
     darkMode: "Dark mode",
+    coloredLayoutCards: "Show key colors on layout cards",
     verboseFocus: "Verbose logging",
   },
   keyboardSettings: {

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -37,6 +37,10 @@ const LayoutCard = (props) => {
     default: [],
     onlyCustom: false,
   });
+  const [colormap, setColormap] = useState({
+    palette: [],
+    colorMap: [],
+  });
 
   const [layout, _setLayout] = useState("English (US)");
   const [loading, setLoading] = useState(true);
@@ -51,8 +55,10 @@ const LayoutCard = (props) => {
   const scanKeyboard = async () => {
     try {
       const deviceKeymap = await focus.command("keymap");
+      const deviceColormap = await focus.command("colormap");
 
       setKeymap(deviceKeymap);
+      setColormap(deviceColormap);
     } catch (e) {
       toast.error(e);
       props.onDisconnect();
@@ -93,7 +99,13 @@ const LayoutCard = (props) => {
             >
               {t("components.layer", { index: i })}
             </Typography>
-            <KeymapSVG className="layer" index={i} keymap={keymap?.custom[i]} />
+            <KeymapSVG
+              className="layer"
+              index={i}
+              keymap={keymap?.custom[i]}
+              colormap={colormap?.colorMap[i]}
+              palette={colormap?.palette}
+            />
           </Box>
         );
 

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -55,10 +55,12 @@ const LayoutCard = (props) => {
   const scanKeyboard = async () => {
     try {
       const deviceKeymap = await focus.command("keymap");
-      const deviceColormap = await focus.command("colormap");
-
       setKeymap(deviceKeymap);
-      setColormap(deviceColormap);
+
+      if (settings.get("ui.layoutCards.colored")) {
+        const deviceColormap = await focus.command("colormap");
+        setColormap(deviceColormap);
+      }
     } catch (e) {
       toast.error(e);
       props.onDisconnect();

--- a/src/renderer/screens/Preferences/UserInterface.js
+++ b/src/renderer/screens/Preferences/UserInterface.js
@@ -23,7 +23,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
 import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 const Store = require("electron-store");
@@ -37,10 +37,16 @@ function UserInterfacePreferences(props) {
   const globalContext = React.useContext(GlobalContext);
 
   const [darkMode, setDarkMode] = globalContext.state.darkMode;
+  const [coloredLayoutCards, setColoredLayoutCards] = useState(false);
 
   const toggleDarkMode = async () => {
     settings.set("ui.darkMode", !darkMode);
     setDarkMode(!darkMode);
+  };
+
+  const toggleColoredLayoutCards = () => {
+    settings.set("ui.layoutCards.colored", !coloredLayoutCards);
+    setColoredLayoutCards(!coloredLayoutCards);
   };
 
   const updateLanguage = async (event) => {
@@ -51,6 +57,10 @@ function UserInterfacePreferences(props) {
       setLanguage(event.target.value);
     }
   };
+
+  useEffect(() => {
+    setColoredLayoutCards(settings.get("ui.layoutCards.colored"));
+  });
 
   const languages = Object.keys(i18n.options.resources).map((code) => {
     const t = i18n.getFixedT(code);
@@ -87,6 +97,18 @@ function UserInterfacePreferences(props) {
         sx={{ display: "flex", marginRight: 2 }}
         labelPlacement="end"
         label={t("preferences.darkMode")}
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={coloredLayoutCards}
+            onChange={toggleColoredLayoutCards}
+            sx={{ mx: 3 }}
+          />
+        }
+        sx={{ display: "flex", marginRight: 2 }}
+        labelPlacement="end"
+        label={t("preferences.coloredLayoutCards")}
       />
     </>
   );


### PR DESCRIPTION
If we're connected to a keyboard that has Colormap support, render the layers with the colormap applied, too.

![Screenshot from 2022-05-26 13-16-19](https://user-images.githubusercontent.com/17243/170477612-34d754ab-df62-40f5-9dc8-8aca3eb7eff8.png)
