### PR TITLE
Assorted Firmware Upgrade UX fixes

### DIFF
--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -150,15 +150,14 @@ const FirmwareUpdate = (props) => {
         });
       }
 
-      setActiveStep(activeStep + 1);
+      setActiveStep(
+        Math.min(activeStep + 1, focusDeviceDescriptor.flashSteps.length)
+      );
       focusDeviceDescriptor.flashSteps.forEach((step, index) => {
         if (step == desiredState) {
           setActiveStep(index);
         }
       });
-      return {
-        activeStep: activeStep,
-      };
     };
 
     const preferExternalFlasher =

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -179,7 +179,7 @@ const FirmwareUpdate = (props) => {
 
     try {
       await _flash();
-      await setActiveStep(activeStep + 1);
+      await setActiveStep(flashSteps.length);
     } catch (e) {
       console.error(e);
       setActiveStep(-1);

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -73,6 +73,17 @@ const FirmwareUpdate = (props) => {
     props.focusDeviceDescriptor || focus.focusDeviceDescriptor;
 
   useEffectOnce(() => {
+    // We're caching the device-specific flashSteps here, because during the
+    // flashing process, we will reboot and reconnect to the keyboard, which can
+    // - and often does - turn `focusDeviceDescriptor` into null, at least
+    // temporarily.
+    //
+    // We do not want to fall back to the default `["flash"]` step list, not
+    // even temporarily.
+    //
+    // As such, we cache the steps on mount. We can do that, because the steps
+    // are device-specific, but static, and when this component gets first
+    // mounted, `props.focusDeviceDescriptor` *will* be available.
     setFlashSteps(focusDeviceDescriptor.flashSteps);
   });
 

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -191,7 +191,9 @@ const FirmwareUpdate = (props) => {
 
     return new Promise((resolve) => {
       setTimeout(() => {
-        toast.success(t("firmwareUpdate.flashing.success"));
+        toast.success(t("firmwareUpdate.flashing.success"), {
+          autoHideDuration: 10000,
+        });
 
         props.toggleFlashing();
         props.onDisconnect();


### PR DESCRIPTION
The major part of this pull request is fixing #811, which looked very weird, out of place, and not very professional, to say the least.

We do this by caching the available flash steps on mount, so that they don't accidentally become unavailable during a reboot or reconnect operation. This way we avoid the default "flash" step kicking in.

On top of that, once we're done flashing, successfully, we mark the last step as completed before returning to the keyboard selection screen.

And as an extra improvement, after a successful flash, the success notification no longer stays up indefinitely, but closes automatically after 10 seconds. The idea behind this is that after a flash, the user may likely want to connect to the keyboard - or might even get automatically reconnected -, and in that case a persistent notification they have to close manually is not a good experience. So it auto-closes now after a short duration.

The error message after a failed flash stays indefinitely, because that does require human attention.