### PR TITLE
Teach the sidebar to hide unavailable functionality by default

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -33,6 +33,7 @@ class Focus {
       this.debug = false;
       this.logger = new Log();
       this._supported_commands = [];
+      this._plugins = [];
     }
 
     return global.chrysalis_focus_instance;
@@ -130,7 +131,8 @@ class Focus {
       focusDeviceDescriptor.usb
     );
     await this.open(d.path, d);
-    return await this.supported_commands();
+    await this.supported_commands();
+    await this.plugins();
   }
 
   async find(...device_descriptors) {
@@ -232,6 +234,7 @@ class Focus {
     });
 
     this._supported_commands = [];
+    this._plugins = [];
     return this._port;
   }
 
@@ -242,6 +245,7 @@ class Focus {
     this._port = null;
     this.focusDeviceDescriptor = null;
     this._supported_commands = [];
+    this._plugins = [];
   }
 
   async isDeviceAccessible(port) {
@@ -274,6 +278,13 @@ class Focus {
       this._supported_commands = await this.request("help");
     }
     return this._supported_commands;
+  }
+
+  async plugins() {
+    if (this._plugins.length == 0) {
+      this._plugins = await this.request("plugins");
+    }
+    return this._plugins;
   }
 
   async _write_parts(request) {

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -28,6 +28,10 @@ export function ActiveDevice() {
     return this.focus._port?.settings.path;
   };
 
+  this.plugins = () => {
+    return this.focus.plugins();
+  };
+
   this.focusDetected = async () => {
     if (this.hasCustomizableKeymaps() || this.hasCustomizableLEDMaps()) {
       return true;

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -32,6 +32,10 @@ export function ActiveDevice() {
     return this.focus.plugins();
   };
 
+  this.supported_commands = () => {
+    return this.focus.supported_commands();
+  };
+
   this.focusDetected = async () => {
     if (this.hasCustomizableKeymaps() || this.hasCustomizableLEDMaps()) {
       return true;

--- a/src/renderer/hooks/usePluginVisibility.js
+++ b/src/renderer/hooks/usePluginVisibility.js
@@ -17,6 +17,9 @@
 import { useEffect, useContext, useState } from "react";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 
+const Store = require("electron-store");
+const settings = new Store();
+
 export default function usePluginVisibility(plugin) {
   const globalContext = useContext(GlobalContext);
   const [activeDevice, _] = globalContext.state.activeDevice;
@@ -25,7 +28,19 @@ export default function usePluginVisibility(plugin) {
   useEffect(() => {
     const fetchData = async () => {
       const plugins = await activeDevice.plugins();
-      setPluginSupported(plugins.includes(plugin));
+      const hideUnavailableFeatures = settings.get(
+        "ui.hideFeaturesNotAvailableInCurrentFirmware",
+        true
+      );
+      const commands = await activeDevice.supported_commands();
+
+      if (commands.includes("plugins")) {
+        setPluginSupported(
+          !hideUnavailableFeatures || plugins.includes(plugin)
+        );
+      } else {
+        setPluginSupported(true);
+      }
     };
     fetchData();
   }, [activeDevice, plugin]);

--- a/src/renderer/hooks/usePluginVisibility.js
+++ b/src/renderer/hooks/usePluginVisibility.js
@@ -1,0 +1,34 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useContext, useState } from "react";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
+export default function usePluginVisibility(plugin) {
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice, _] = globalContext.state.activeDevice;
+  const [pluginSupported, setPluginSupported] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const plugins = await activeDevice.plugins();
+      setPluginSupported(plugins.includes(plugin));
+    };
+    fetchData();
+  }, [activeDevice, plugin]);
+
+  return pluginSupported;
+}

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -246,6 +246,10 @@ const English = {
     darkMode: "Dark mode",
     coloredLayoutCards: "Show key colors on layout cards",
     verboseFocus: "Verbose logging",
+    hideUnavailableFeatures: {
+      label: "Hide features not supported by your keyboard's current firmware",
+      help: `When enabled, Chrysalis will hide configuration options for features that your keyboard's firmware doesn't support.`,
+    },
   },
   keyboardSettings: {
     advanced: "Advanced Tools & Preferences",

--- a/src/renderer/screens/Editor/Sidebar/LayerKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LayerKeys.js
@@ -21,6 +21,7 @@ import Input from "@mui/material/Input";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -30,6 +31,7 @@ const db = new KeymapDB();
 const LayerKeys = (props) => {
   const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation();
+  const oneShotVisible = usePluginVisibility("OneShot");
 
   const getMaxLayer = () => {
     const { keymap, selectedKey, layer } = props;
@@ -113,9 +115,11 @@ const LayerKeys = (props) => {
               <MenuItem value="movetolayer" selected={type == "movetolayer"}>
                 {t("editor.layerswitch.moveTo")}
               </MenuItem>
-              <MenuItem value="oneshot" selected={type == "oneshot"}>
-                {t("editor.layerswitch.oneshot")}
-              </MenuItem>
+              {oneShotVisible && (
+                <MenuItem value="oneshot" selected={type == "oneshot"}>
+                  {t("editor.layerswitch.oneshot")}
+                </MenuItem>
+              )}
               <MenuItem value="dualuse" selected={type == "dualuse"} disabled>
                 {t("editor.layerswitch.dualuse")}
               </MenuItem>

--- a/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LeaderKeys.js
@@ -17,11 +17,15 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import CategorySelector from "../components/CategorySelector";
 
 const LeaderKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("Leader");
+  if (!pluginVisible) return null;
+
   return (
     <CategorySelector
       title={t("editor.sidebar.leader.title")}

--- a/src/renderer/screens/Editor/Sidebar/MacroKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MacroKeys.js
@@ -17,11 +17,15 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import CategorySelector from "../components/CategorySelector";
 
 const MacroKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("Macros");
+  if (!pluginVisible) return null;
+
   return (
     <CategorySelector
       title={t("editor.sidebar.macros.title")}

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -24,6 +24,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import Switch from "@mui/material/Switch";
 import Tooltip from "@mui/material/Tooltip";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -32,6 +33,7 @@ const db = new KeymapDB();
 
 const KeyPicker = (props) => {
   const { t } = useTranslation();
+  const oneShotVisible = usePluginVisibility("OneShot");
 
   const isStandardKey = (props) => {
     const { selectedKey, keymap, layer } = props;
@@ -98,7 +100,7 @@ const KeyPicker = (props) => {
   const key = keymap.custom[layer][selectedKey];
 
   let oneShot;
-  if (db.isInCategory(key.baseCode || key.code, "modifier")) {
+  if (oneShotVisible && db.isInCategory(key.baseCode || key.code, "modifier")) {
     const osmControl = (
       <Switch
         checked={db.isInCategory(key, "oneshot")}

--- a/src/renderer/screens/Editor/Sidebar/MouseKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MouseKeys.js
@@ -18,6 +18,7 @@
 import { KeymapDB } from "@api/keymap";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -126,6 +127,9 @@ const MouseWarpKeys = (props) => {
 const MouseKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("MouseKeys");
+  if (!pluginVisible) return null;
+
   const key = keymap.custom[layer][selectedKey];
 
   const subWidgets = [

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -22,6 +22,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import FormHelperText from "@mui/material/FormHelperText";
 import Switch from "@mui/material/Switch";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -47,6 +48,9 @@ const OneShotKeys = (props) => {
       setEscCancel(escCancel);
     });
   }, []);
+
+  const pluginVisible = usePluginVisibility("OneShot");
+  if (!pluginVisible) return null;
 
   const { classes, keymap, selectedKey, layer, onKeyChange } = props;
   const key = keymap.custom[layer][selectedKey];

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -24,6 +24,7 @@ import Input from "@mui/material/Input";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -81,6 +82,9 @@ const SecondaryFunction = (props) => {
       db.isInCategory(key.code, "dualuse")
     );
   };
+
+  const pluginVisible = usePluginVisibility("Qukeys");
+  if (!pluginVisible) return null;
 
   const { classes, keymap, selectedKey, layer } = props;
   const key = keymap.custom[layer][selectedKey];

--- a/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/SpaceCadetKeys.js
@@ -17,11 +17,15 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import CategorySelector from "../components/CategorySelector";
 
 const SpaceCadetKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("SpaceCadet");
+  if (!pluginVisible) return null;
+
   return (
     <CategorySelector
       title={t("editor.sidebar.spacecadet.title")}

--- a/src/renderer/screens/Editor/Sidebar/StenoKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/StenoKeys.js
@@ -17,11 +17,15 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import CategorySelector from "../components/CategorySelector";
 
 const StenoKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("Steno");
+  if (!pluginVisible) return null;
+
   return (
     <CategorySelector
       title={t("editor.sidebar.steno.title")}

--- a/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
@@ -17,11 +17,15 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
+import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import CategorySelector from "../components/CategorySelector";
 
 const TapDanceKeys = (props) => {
   const { keymap, selectedKey, layer, onKeyChange } = props;
   const { t } = useTranslation();
+  const pluginVisible = usePluginVisibility("TapDance");
+  if (!pluginVisible) return null;
+
   return (
     <CategorySelector
       title={t("editor.sidebar.tapdance.title")}

--- a/src/renderer/screens/Preferences/UserInterface.js
+++ b/src/renderer/screens/Preferences/UserInterface.js
@@ -18,6 +18,7 @@
 import FilledInput from "@mui/material/FilledInput";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
+import FormHelperText from "@mui/material/FormHelperText";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
@@ -38,6 +39,7 @@ function UserInterfacePreferences(props) {
 
   const [darkMode, setDarkMode] = globalContext.state.darkMode;
   const [coloredLayoutCards, setColoredLayoutCards] = useState(false);
+  const [hideUnavailableFeatures, setHideUnavailableFeatures] = useState(true);
 
   const toggleDarkMode = async () => {
     settings.set("ui.darkMode", !darkMode);
@@ -47,6 +49,14 @@ function UserInterfacePreferences(props) {
   const toggleColoredLayoutCards = () => {
     settings.set("ui.layoutCards.colored", !coloredLayoutCards);
     setColoredLayoutCards(!coloredLayoutCards);
+  };
+
+  const toggleHideUnavailableFeatures = () => {
+    settings.set(
+      "ui.hideFeaturesNotAvailableInCurrentFirmware",
+      !hideUnavailableFeatures
+    );
+    setHideUnavailableFeatures(!hideUnavailableFeatures);
   };
 
   const updateLanguage = async (event) => {
@@ -60,6 +70,12 @@ function UserInterfacePreferences(props) {
 
   useEffect(() => {
     setColoredLayoutCards(settings.get("ui.layoutCards.colored"));
+
+    const hideUnavail = settings.get(
+      "ui.hideFeaturesNotAvailableInCurrentFirmware",
+      true
+    );
+    setHideUnavailableFeatures(hideUnavail);
   });
 
   const languages = Object.keys(i18n.options.resources).map((code) => {
@@ -110,6 +126,21 @@ function UserInterfacePreferences(props) {
         labelPlacement="end"
         label={t("preferences.coloredLayoutCards")}
       />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={hideUnavailableFeatures}
+            onChange={toggleHideUnavailableFeatures}
+            sx={{ mx: 3 }}
+          />
+        }
+        sx={{ display: "flex", marginRight: 2 }}
+        labelPlacement="end"
+        label={t("preferences.hideUnavailableFeatures.label")}
+      />
+      <FormHelperText sx={{ mx: 3 }}>
+        {t("preferences.hideUnavailableFeatures.help")}
+      </FormHelperText>
     </>
   );
 }


### PR DESCRIPTION
Recent firmware supports a `plugins` command, letting us query the list of available plugins. We can leverage this information to hide functionality from the sidebar for which firmware-side support does not exist - at least optionally. This pull request does just that.

The parts of the Sidebar which depend on firmware-side plugins will now check if they should make those functions visible. They do so via the new `usePluginVisibility()` hook that checks the available plugin list, and also consults the UI settings, which can override the default hiding behaviour.

The result is a considerably cleaner sidebar, with no fluff. With hiding functionality not supported by the firmware, we avoid surprises: a very frequently asked question on Discord is why "Secondary actions" don't work, and the answer is always: because the plugin is not enabled. With this PR, we simply won't show that section if `Qukeys` isn't enabled in the firmware.

For a very bare-bones firmware with only `EEPROMKeymap` and `Focus` enabled, the sidebar looks like this:

![Screenshot from 2022-05-27 11-42-59](https://user-images.githubusercontent.com/17243/170675871-58c4172c-ad25-4b9d-9102-7cba83ce6768.png)

We can, of course, disable this feature, and show all possible keys:

![Screenshot from 2022-05-27 11-42-49](https://user-images.githubusercontent.com/17243/170675971-66f96c9c-f65f-4cb2-92e0-5645ab830cd6.png)

If the `plugins` command is not supported by the firmware, we fall back to showing everything.