### PR TITLE
Bump our Electron dependency to 17.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "app-builder-lib": "^23.0.3",
     "babel-plugin-module-resolver": "^4.1.0",
     "core-js": "^3.21.1",
-    "electron": "^17.1.2",
+    "electron": "^17.4.6",
     "electron-builder": "^23.0.3",
     "electron-builder-notarize": "^1.2.0",
     "electron-webpack": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,10 +4906,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^17.1.2:
-  version "17.4.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.5.tgz#a1d9c22fc7acfeced4f56caef68bb53988aceb97"
-  integrity sha512-OuJH+cVko69/o/zxsQXpjoLaIEQLZ/yVSd82bShRBdKc3JVfVo2cCejjpeizq/Q4VjWyT494BodDSS2hz/47cQ==
+electron@^17.4.6:
+  version "17.4.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.6.tgz#4837b3adb2636992a33da734a77794dd932fb05c"
+  integrity sha512-9aPjlyWoVxchD/iw5KcbQ7ZaC5ezxsObBrMbGjpdMmDL5dktI0EkT6x2l2CYPZCi4rQG/6qlPfTZJeVPIIwI2Q==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
This is the latest in the 17.x series, and fixes a few Wayland-related issues people were having. Might even render --disable-gpu obsolete, but lets try with that still in use first.
