### PR TITLE
Model100: Adjust the firmware update instructions

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -418,7 +418,7 @@ seconds.`,
         updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue holding it while you click the Update button. Once the keys start flashing red across the board, you can release the key.`,
       },
       Model100: {
-        updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue holding it while you click the Update button. Once the keys start flashing red across the board, please release the key, as holding it too long may prevent flashing from succeeding.`,
+        updateInstructions: `Hold down the key in the top left corner of the keyboard (in the default layout, this key is the PROG key). Continue holding it while you click the Update button. Once the keys start flashing green across the first column of the board, please release the key, as holding it too long may prevent flashing from succeeding.`,
       },
     },
     PJRC: {


### PR DESCRIPTION
The instructions were originally copied from the Model 01, but there are two subtle changes for the Model 100: the LEDs are lit up green instead of red, and they're restricted to the first column.

Fixes #850.
