### PR TITLE
Editor: Prevent opening the macro editor if we don't support macros

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -74,6 +74,11 @@ const Editor = (props) => {
 
   const { t } = useTranslation();
 
+  const maybeOpenMacroEditor = (state) => {
+    if (macros.storageSize == 0) return;
+    setOpenMacroEditor(state);
+  };
+
   const onMacroChange = async (id, macro) => {
     const newMacros = {
       storageSize: macros.storageSize,
@@ -160,7 +165,7 @@ const Editor = (props) => {
       const macroId = newKey.code - newKey.rangeStart;
 
       setCurrentMacroId(macroId);
-      setOpenMacroEditor(true);
+      maybeOpenMacroEditor(true);
     }
   };
 
@@ -420,7 +425,7 @@ const Editor = (props) => {
         onColormapChange={onColormapChange}
         onPaletteChange={onPaletteChange}
         onLedChange={onLedChange}
-        setOpenMacroEditor={setOpenMacroEditor}
+        setOpenMacroEditor={maybeOpenMacroEditor}
         currentKey={currentKey}
       />
       <FloatingKeyPicker


### PR DESCRIPTION
The macro editor depends on having macro support, so we should not try to open it when we do not support dynamic macros. We can't guard against it within the Macro Editor itself, because the best we can do there is not render - but the Editor will still consider us open then.

So if our macro storage space is zero (either DynamicMacros is not enabled, or not configured), we simply don't open the editor.

This fixes an exception when trying to assign a dynamic macro to a key on keyboards that do not support them. Assigning a dynamic macro always tried to open the editor before, and thus, bombed out. Now we assign the key, but don't try to open the editor, and all is well.