### PR TITLE
Preferences: Move the EscapeOneShot preferences here

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -171,10 +171,6 @@ const English = {
       oneshot: {
         title: "One-shot",
         help: `Click button below to choose a dedicated key to cancel one-shot keys.`,
-        configuration: {
-          help: `When enabled, "Escape" will cancel one-shot keys.`,
-          escCancelLabel: "Escape cancels one-shot keys",
-        },
       },
       ledcontrol: {
         title: "LED control",
@@ -366,6 +362,13 @@ const English = {
         brightness: {
           label: "LED Brightness",
           help: "Adjust the brightness of the LEDs on the keyboard.",
+        },
+      },
+      plugins: {
+        label: "Plugin preferences",
+        escOneShot: {
+          label: `Let Escape cancel one-shot keys`,
+          help: `When enabled, "Escape" will cancel one-shot keys, otherwise a dedicated cancel key can do so.`,
         },
       },
     },

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -14,14 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import Focus from "@api/focus";
+
 import KeymapDB from "@api/focus/keymap/db";
-import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import FormGroup from "@mui/material/FormGroup";
-import FormHelperText from "@mui/material/FormHelperText";
-import Switch from "@mui/material/Switch";
 import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,43 +27,13 @@ const db = new KeymapDB();
 const cancelKeyCode = 53630;
 
 const OneShotKeys = (props) => {
-  const [escCancel, setEscCancel] = useState(true);
   const { t } = useTranslation();
-
-  useEffect(() => {
-    const focus = new Focus();
-    focus.command("escape_oneshot.cancel_key").then((escCancel) => {
-      if (escCancel.length == 0) {
-        escCancel = false;
-      } else {
-        escCancel = parseInt(escCancel) == cancelKeyCode;
-      }
-
-      setEscCancel(escCancel);
-    });
-  }, []);
 
   const pluginVisible = usePluginVisibility("OneShot");
   if (!pluginVisible) return null;
 
   const { currentKey: key } = props;
 
-  const toggleEscapeCancel = async (event) => {
-    const focus = new Focus();
-    const escCancel = event.target.checked;
-    let newCancelKeyCode = cancelKeyCode;
-
-    if (escCancel) {
-      newCancelKeyCode = 41; // Esc
-    }
-
-    await focus.command("escape_oneshot.cancel_key", newCancelKeyCode);
-    setEscCancel(escCancel);
-  };
-
-  const escCancelWidget = (
-    <Switch checked={escCancel} color="primary" onChange={toggleEscapeCancel} />
-  );
   return (
     <React.Fragment>
       <Collapsible
@@ -81,24 +45,6 @@ const OneShotKeys = (props) => {
           keyObj={db.lookup(cancelKeyCode)}
           onKeyChange={props.onKeyChange}
         />
-
-        <Box
-          sx={{
-            m: "2 0",
-          }}
-        >
-          <FormControl component="fieldset">
-            <FormGroup row>
-              <FormControlLabel
-                control={escCancelWidget}
-                label={t("editor.sidebar.oneshot.configuration.escCancelLabel")}
-              />
-            </FormGroup>
-            <FormHelperText>
-              {t("editor.sidebar.oneshot.configuration.help")}
-            </FormHelperText>
-          </FormControl>
-        </Box>
       </Collapsible>
     </React.Fragment>
   );

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -28,12 +28,17 @@ import { useTranslation } from "react-i18next";
 import AdvancedKeyboardPreferences from "./keyboard/AdvancedKeyboardPreferences";
 import KeyboardLayerPreferences from "./keyboard/KeyboardLayerPreferences";
 import KeyboardLEDPreferences from "./keyboard/KeyboardLEDPreferences";
+import PluginPreferences from "./keyboard/PluginPreferences";
 
 const MyKeyboardPreferences = (props) => {
+  const oneShotCancelKeyCode = 53630;
+  const escKeyCode = 41;
+
   const [modified, setModified] = useState(false);
   const [defaultLayer, setDefaultLayer] = useState(126);
   const [ledBrightness, setLedBrightness] = useState(255);
   const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
+  const [escOneShot, setEscOneShot] = useState(true);
 
   const { t } = useTranslation();
   const globalContext = useContext(GlobalContext);
@@ -43,6 +48,10 @@ const MyKeyboardPreferences = (props) => {
     await activeDevice.focus.command("settings.defaultLayer", defaultLayer);
     await activeDevice.focus.command("led.brightness", ledBrightness);
     await activeDevice.focus.command("idleleds.time_limit", ledIdleTimeLimit);
+    await activeDevice.focus.command(
+      "escape_oneshot.cancel_key",
+      escOneShot ? escKeyCode : oneShotCancelKeyCode
+    );
 
     await setModified(false);
     await hideContextBar();
@@ -62,6 +71,11 @@ const MyKeyboardPreferences = (props) => {
         setLedBrightness={setLedBrightness}
         ledIdleTimeLimit={ledIdleTimeLimit}
         setLedIdleTimeLimit={setLedIdleTimeLimit}
+      />
+      <PluginPreferences
+        setModified={setModified}
+        escOneShot={escOneShot}
+        setEscOneShot={setEscOneShot}
       />
       <AdvancedKeyboardPreferences />
 

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -1,0 +1,111 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Skeleton from "@mui/material/Skeleton";
+import { showContextBar } from "@renderer/components/ContextBar";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+import React, { useEffect, useState, useContext } from "react";
+import { useTranslation } from "react-i18next";
+
+import PreferenceSection from "../components/PreferenceSection";
+import EscapeOneShotPreferences from "./plugins/EscapeOneShot";
+
+const PluginPreferences = (props) => {
+  const escKeyCode = 41;
+
+  const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
+
+  const [loaded, setLoaded] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [hasEscOneShot, setHasEscOneShot] = useState(false);
+
+  const { setModified, escOneShot, setEscOneShot } = props;
+
+  // Initialize: check for plugins
+  useEffect(() => {
+    const initialize = async () => {
+      const plugins = await activeDevice.plugins();
+
+      if (plugins.includes("EscapeOneShot")) {
+        setHasEscOneShot(true);
+      }
+
+      setInitialized(true);
+    };
+
+    if (!initialized) initialize();
+  }, [activeDevice, initialized]);
+
+  const doesEscCancelOneShot = (value) => {
+    if (value.length == 0) {
+      return false;
+    }
+
+    return parseInt(value) == escKeyCode;
+  };
+
+  // Fetch data, after initialization
+  useEffect(() => {
+    const fetchData = async () => {
+      const key = await activeDevice.focus.command("escape_oneshot.cancel_key");
+      setEscOneShot(doesEscCancelOneShot(key));
+
+      setLoaded(true);
+    };
+
+    const context_bar_channel = new BroadcastChannel("context_bar");
+    context_bar_channel.onmessage = async (event) => {
+      if (event.data === "changes-discarded") {
+        await fetchData();
+        setModified(false);
+      }
+    };
+
+    if (initialized) fetchData();
+
+    return () => {
+      context_bar_channel.close();
+    };
+  }, [activeDevice, setEscOneShot, setModified, setLoaded, initialized]);
+
+  const toggleEscOneShot = (event) => {
+    setEscOneShot(event.target.checked);
+
+    setModified(true);
+    showContextBar();
+  };
+
+  if (initialized && !hasEscOneShot) return null;
+
+  return (
+    <PreferenceSection name="keyboard.plugins">
+      {loaded ? (
+        <EscapeOneShotPreferences
+          value={escOneShot}
+          onChange={toggleEscOneShot}
+          visible={hasEscOneShot}
+        />
+      ) : (
+        <Skeleton variant="text" width="100%" height={56} />
+      )}
+    </PreferenceSection>
+  );
+};
+
+export { PluginPreferences as default };

--- a/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
@@ -1,0 +1,43 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FormControl from "@mui/material/FormControl";
+import FormHelperText from "@mui/material/FormHelperText";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
+
+import PreferenceSwitch from "../../components/PreferenceSwitch";
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+const EscapeOneShotPreferences = (props) => {
+  const { t } = useTranslation();
+  const { value, onChange, visible } = props;
+
+  if (!visible) return null;
+
+  return (
+    <PreferenceSwitch
+      option="keyboard.plugins.escOneShot"
+      checked={value}
+      onChange={onChange}
+    />
+  );
+};
+
+export { EscapeOneShotPreferences as default };


### PR DESCRIPTION
Instead of having the EscapeOneShot cancel key configuration on the sidebar, move it to the Preferences screen, under My Keyboard.

As it doesn't fit any of the existing sub-sections, a new one ("Plugin preferences") was created for it.

![Screenshot from 2022-05-30 19-07-51](https://user-images.githubusercontent.com/17243/171036424-f7ee0c75-e6bf-41fa-8212-548146f25b85.png)

Fixes #866.