### PR TITLE
Editor: Hide parts of the sidebar when the macro editor is open

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -387,6 +387,7 @@ const Editor = (props) => {
         {mainWidget}
       </Box>
       <Sidebar
+        macroEditorOpen={openMacroEditor}
         macros={macros}
         keymap={keymap}
         colormap={colormap}

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -42,7 +42,8 @@ import VolumeKeys from "./Sidebar/VolumeKeys";
 const sidebarWidth = 360;
 
 const Sidebar = (props) => {
-  const { keymap, selectedKey, selectedLed, layer, colormap } = props;
+  const { keymap, selectedKey, selectedLed, layer, colormap, macroEditorOpen } =
+    props;
 
   const widgets = [
     KeyPicker,
@@ -68,6 +69,7 @@ const Sidebar = (props) => {
     return (
       <Widget
         key={`sidebar-category-${index}`}
+        macroEditorOpen={macroEditorOpen}
         keymap={keymap}
         colormap={colormap}
         selectedKey={selectedKey}
@@ -103,6 +105,7 @@ const Sidebar = (props) => {
       <Toolbar />
       <Box sx={{ px: 1, mb: 2 }}>
         <Overview
+          macroEditorOpen={macroEditorOpen}
           keymap={keymap}
           colormap={colormap}
           selectedKey={selectedKey}

--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -48,6 +48,7 @@ const Colormap = (props) => {
   const { selectedLed, layer, colormap } = props;
 
   if (!colormap || colormap.palette.length == 0) return null;
+  if (props.macroEditorOpen) return null;
 
   const colorIndex = colormap.colorMap[layer][selectedLed];
   const color = colormap.palette[colorIndex];

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -64,6 +64,8 @@ const Overview = (props) => {
     setShowAll(!showAll);
   };
 
+  if (props.macroEditorOpen) return null;
+
   const { keymap, selectedKey, selectedLed, layer, colormap } = props;
   const db = new KeymapDB();
 

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -80,6 +80,7 @@ const SecondaryFunction = (props) => {
 
   const pluginVisible = usePluginVisibility("Qukeys");
   if (!pluginVisible) return null;
+  if (props.macroEditorOpen) return null;
 
   const { currentKey: key, keymap } = props;
   const maxLayer = Math.min(keymap.custom.length, 7);

--- a/src/renderer/screens/Editor/Sidebar/StenoKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/StenoKeys.js
@@ -24,6 +24,7 @@ const StenoKeys = (props) => {
   const { t } = useTranslation();
   const pluginVisible = usePluginVisibility("Steno");
   if (!pluginVisible) return null;
+  if (props.macroEditorOpen) return null;
 
   return (
     <CategorySelector

--- a/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/TapDanceKeys.js
@@ -24,6 +24,7 @@ const TapDanceKeys = (props) => {
   const { t } = useTranslation();
   const pluginVisible = usePluginVisibility("TapDance");
   if (!pluginVisible) return null;
+  if (props.macroEditorOpen) return null;
 
   return (
     <CategorySelector


### PR DESCRIPTION
Certain elements of the sidebar do not make sense in the context of the macro editor, so hide them to reduce unnecessary clutter, and avoid confusion.

The hidden parts are:

- The overview, because switching layers during macro editing is a strange and confusing experience.
- The colormap section, because that's irrelevant in context of the macro editor.
- Steno and TapDance keys, for the same reason.
- The Secondary Function section, likewise.

![Screenshot from 2022-05-30 19-24-25](https://user-images.githubusercontent.com/17243/171038141-267f828d-cf5d-4fc0-b80f-3b7d80b23394.png)

Fixes #867.
