### PR TITLE
Editor: Buttonize the layer keys

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/LayerKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LayerKeys.js
@@ -16,6 +16,8 @@
  */
 
 import KeymapDB from "@api/focus/keymap/db";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
@@ -50,16 +52,6 @@ const LayerKeys = (props) => {
     }
   };
 
-  const onKeyChange = (keyCode) => {
-    props.onKeyChange(keyCode);
-  };
-
-  const onTargetLayerChange = (event, max) => {
-    const target = Math.min(parseInt(event.target.value) || 0, max);
-
-    props.onKeyChange(props.currentKey.rangeStart + target);
-  };
-
   const onTypeChange = (event) => {
     const typeStarts = {
       locktolayer: 17408,
@@ -82,7 +74,20 @@ const LayerKeys = (props) => {
     targetLayer = key.target;
     type = key.categories[1];
   }
-  const max = getMaxLayer();
+
+  const layerKeys = [...Array(getMaxLayer())].map((x, i) => (
+    <Button
+      disabled={type == "none"}
+      key={`layerkey-${i.toString()}`}
+      variant="contained"
+      size="small"
+      sx={{ m: 1 }}
+      onClick={() => props.onKeyChange(props.currentKey.rangeStart + i)}
+    >
+      #{i}
+    </Button>
+  ));
+
   return (
     <React.Fragment>
       <Collapsible
@@ -91,7 +96,7 @@ const LayerKeys = (props) => {
         expanded={db.isInCategory(key.code, "layer")}
       >
         <div>
-          <FormControl>
+          <FormControl fullWidth>
             <InputLabel id="editor.layerswitch.type">
               {t("editor.layerswitch.type")}
             </InputLabel>
@@ -123,25 +128,7 @@ const LayerKeys = (props) => {
               </MenuItem>
             </Select>
           </FormControl>
-          <FormControl sx={{ mx: 1 }}>
-            <InputLabel id="editor.layerswitch.target">
-              {t("editor.layerswitch.target")}
-            </InputLabel>
-            <Select
-              labelId="editor.layerswitch.target"
-              value={targetLayer}
-              onChange={(event) => onTargetLayerChange(event, max)}
-              label={t("editor.layerswitch.target")}
-              disabled={targetLayer < 0}
-            >
-              <MenuItem value="-1" disabled></MenuItem>
-              {[...Array(max)].map((x, i) => (
-                <MenuItem key={i} name={i} value={i}>
-                  {i}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <Box sx={{ mt: 1 }}>{layerKeys}</Box>
         </div>
       </Collapsible>
     </React.Fragment>


### PR DESCRIPTION
Instead of having a second dropdown for the target layer, render a set of buttons below the type chooser. This makes choosing a layer key faster, and the user experience more consistent.

The buttons are always in the same position, and are always visible, regardless of the type chosen.

### Non-layer key selected

![Screenshot from 2022-05-30 20-24-34](https://user-images.githubusercontent.com/17243/171044564-18e4880c-c2ed-4568-916d-5ded28d6e7f7.png)

### Lock To Layer

![Screenshot from 2022-05-30 20-24-57](https://user-images.githubusercontent.com/17243/171044562-ccf63af2-0653-4f77-a68d-38a3e5c50886.png)

### Layer Shift for Next Action

![Screenshot from 2022-05-30 20-25-10](https://user-images.githubusercontent.com/17243/171044560-1c1438e5-4651-4eee-ad70-37a2cb0434d0.png)

## Summary

This implements my proposal in [#752](https://github.com/keyboardio/Chrysalis/issues/752#issuecomment-1141382335), turning the _second_ dropdown into buttons. We have a nice, small section this way, without needing to fold any part of it. With the type selector being full width, its size doesn't change either, so that's one less moving part in the UI.

If the proposal is accepted, then this fixes #752.
