### PR TITLE
Improve our theme system

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -32,6 +32,7 @@ import {
 } from "./ipc_device_discovery";
 import { registerDevtoolsHandlers } from "./ipc_devtools";
 import { registerFileIoHandlers } from "./ipc_file_io";
+import { registerNativeThemeHandlers } from "./ipc_nativetheme";
 import { buildMenu } from "./menu";
 
 // This is a workaround for electron-webpack#275[1]. We need to use backticks
@@ -201,3 +202,4 @@ registerDeviceDiscoveryHandlers();
 registerFileIoHandlers();
 registerDevtoolsHandlers();
 registerBackupHandlers();
+registerNativeThemeHandlers();

--- a/src/main/ipc_nativetheme.js
+++ b/src/main/ipc_nativetheme.js
@@ -1,0 +1,32 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ipcMain, nativeTheme, BrowserWindow } from "electron";
+
+export const registerNativeThemeHandlers = () => {
+  ipcMain.on("native-theme-should-use-dark-colors", (event) => {
+    event.returnValue = nativeTheme.shouldUseDarkColors;
+  });
+
+  nativeTheme.on("updated", () => {
+    BrowserWindow.getAllWindows().forEach((win) => {
+      win.webContents.send(
+        "native-theme-updated",
+        nativeTheme.shouldUseDarkColors
+      );
+    });
+  });
+};

--- a/src/renderer/components/GlobalContext.js
+++ b/src/renderer/components/GlobalContext.js
@@ -15,19 +15,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ipcRenderer } from "electron";
 import React, { createContext, useState } from "react";
 
 export const GlobalContext = createContext();
 
 export const GlobalContextProvider = (props) => {
-  const [darkMode, setDarkMode] = useState(false);
+  const [theme, setTheme] = useState("system");
   const [connected, setConnected] = useState(false);
   const [focusDeviceDescriptor, setFocusDeviceDescriptor] = useState(null);
   const [activeDevice, setActiveDevice] = useState(null);
 
+  const getDarkMode = () => {
+    if (theme == "system") {
+      return ipcRenderer.sendSync("native-theme-should-use-dark-colors");
+    }
+    return theme == "dark";
+  };
+
   const state = {
     connected: [connected, setConnected],
-    darkMode: [darkMode, setDarkMode],
+    darkMode: getDarkMode,
+    theme: [theme, setTheme],
     focusDeviceDescriptor: [focusDeviceDescriptor, setFocusDeviceDescriptor],
     activeDevice: [activeDevice, setActiveDevice],
   };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -303,9 +303,11 @@ const English = {
         label: "Look & Feel",
         description: `The settings below control the general look an feel of Chrysalis.`,
       },
-      darkMode: {
-        label: "Enable dark mode",
-        help: "Choose between a Light or a Dark theme.",
+      theme: {
+        label: "Choose the theme Chrysalis should use:",
+        system: "Match the system theme",
+        dark: "Use a dark theme",
+        light: "Use a light theme",
       },
       language: {
         label: "Language",

--- a/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
@@ -17,16 +17,19 @@
 
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormLabel from "@mui/material/FormLabel";
 import FormHelperText from "@mui/material/FormHelperText";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
 import Select from "@mui/material/Select";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
-import PreferenceSwitch from "../components/PreferenceSwitch";
 
 const Store = require("electron-store");
 const settings = new Store();
@@ -34,12 +37,14 @@ const settings = new Store();
 function LookAndFeelPreferences(props) {
   const { t, i18n } = useTranslation();
   const globalContext = React.useContext(GlobalContext);
-  const [darkMode, setDarkMode] = globalContext.state.darkMode;
+  const [theme, setTheme] = globalContext.state.theme;
   const [language, setLanguage] = useState(i18n.language);
 
-  const toggleDarkMode = async () => {
-    settings.set("ui.darkMode", !darkMode);
-    setDarkMode(!darkMode);
+  const changeTheme = async (event) => {
+    const newTheme = event.target.value;
+
+    settings.set("ui.theme", newTheme);
+    setTheme(newTheme);
   };
 
   const updateLanguage = async (event) => {
@@ -73,12 +78,27 @@ function LookAndFeelPreferences(props) {
         </Select>
         <FormHelperText>{t("preferences.ui.language.help")}</FormHelperText>
       </FormControl>
-      <Box sx={{ my: 1 }}>
-        <PreferenceSwitch
-          option="ui.darkMode"
-          checked={darkMode}
-          onChange={toggleDarkMode}
-        />
+      <Box sx={{ my: 2 }}>
+        <FormControl>
+          <FormLabel>{t("preferences.ui.theme.label")}</FormLabel>
+          <RadioGroup value={theme} onChange={changeTheme} sx={{ ml: 1 }}>
+            <FormControlLabel
+              value="system"
+              control={<Radio />}
+              label={t("preferences.ui.theme.system")}
+            />
+            <FormControlLabel
+              value="light"
+              control={<Radio />}
+              label={t("preferences.ui.theme.light")}
+            />
+            <FormControlLabel
+              value="dark"
+              control={<Radio />}
+              label={t("preferences.ui.theme.dark")}
+            />
+          </RadioGroup>
+        </FormControl>
       </Box>
     </PreferenceSection>
   );

--- a/src/renderer/utils/darkMode.js
+++ b/src/renderer/utils/darkMode.js
@@ -1,0 +1,30 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const Store = require("electron-store");
+const settings = new Store();
+
+const migrateDarkModeToTheme = () => {
+  // Migrate old `ui.darkMode` to new `ui.theme`
+  const legacyDarkMode = settings.get("ui.darkMode");
+  if (legacyDarkMode !== undefined) {
+    settings.set("ui.theme", legacyDarkMode ? "dark" : "light");
+    settings.delete("ui.darkMode");
+  }
+};
+
+export { migrateDarkModeToTheme };


### PR DESCRIPTION
Instead of having a toggle between light and dark mode, support arbitrary themes by storing the theme name in a setting, rather than a dark mode toggle.

This allows us to have a "system" theme (along with "light" and "dark"), which follows the system theme on operating systems that have one (macOS & Windows).

The old `ui.darkMode` setting is honored, and will be migrated automatically to the new setting. For new users, we default to the system theme.

Fixes #874.
