### PR TITLE
Editor: Justify the color picker on the sidebar to the center

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -16,6 +16,7 @@
  */
 
 import React from "react";
+import Box from "@mui/material/Box";
 import { ChromePicker } from "react-color";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
@@ -65,14 +66,13 @@ const Colormap = (props) => {
         onClick={onPaletteSwatchChange}
       />
       <br />
-      <ChromePicker
-        color={color}
-        disableAlpha
-        sx={{
-          width: "295px !important",
-        }}
-        onChangeComplete={colorChangeComplete}
-      />
+      <Box sx={{ justifyContent: "center", display: "flex" }}>
+        <ChromePicker
+          color={color}
+          disableAlpha
+          onChangeComplete={colorChangeComplete}
+        />
+      </Box>
     </Collapsible>
   );
 };


### PR DESCRIPTION
We used to override the width of the picker, but that no longer works, so wrap it in a Box and justify it to the center instead.

![Screenshot from 2022-05-31 10-40-24](https://user-images.githubusercontent.com/17243/171131236-efc49242-9388-4c07-90e0-6a15e3afb629.png)
