### PR TITLE
Preferences: Add support for setting the default LED mode

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -390,6 +390,8 @@ class Focus {
     "escape_oneshot.cancel_key",
     "idleleds.time_limit",
     "led.brightness",
+    "led_mode.auto_save",
+    "led_mode.default",
     "macros",
     "tapdance.map",
     "hostos.type",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -365,6 +365,14 @@ const English = {
           label: "LED Brightness",
           help: "Adjust the brightness of the LEDs on the keyboard.",
         },
+        default: {
+          autoSave: {
+            label: "Enable automatically saving the default led mode",
+            help: `When enabled, whenever the led mode is changed, it gets saved as the default.`,
+          },
+          label: "Default led mode",
+          help: "Select the led mode the keyboard should start up with.",
+        },
       },
       plugins: {
         label: "Plugin preferences",

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -38,6 +38,8 @@ const MyKeyboardPreferences = (props) => {
   const [defaultLayer, setDefaultLayer] = useState(126);
   const [ledBrightness, setLedBrightness] = useState(255);
   const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
+  const [ledModeDefault, setLedModeDefault] = useState(0);
+  const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
   const [escOneShot, setEscOneShot] = useState(true);
 
   const { t } = useTranslation();
@@ -48,6 +50,11 @@ const MyKeyboardPreferences = (props) => {
     await activeDevice.focus.command("settings.defaultLayer", defaultLayer);
     await activeDevice.focus.command("led.brightness", ledBrightness);
     await activeDevice.focus.command("idleleds.time_limit", ledIdleTimeLimit);
+    await activeDevice.focus.command("led_mode.default", ledModeDefault);
+    await activeDevice.focus.command(
+      "led_mode.auto_save",
+      ledModeAutoSave ? 1 : 0
+    );
     await activeDevice.focus.command(
       "escape_oneshot.cancel_key",
       escOneShot ? escKeyCode : oneShotCancelKeyCode
@@ -71,6 +78,10 @@ const MyKeyboardPreferences = (props) => {
         setLedBrightness={setLedBrightness}
         ledIdleTimeLimit={ledIdleTimeLimit}
         setLedIdleTimeLimit={setLedIdleTimeLimit}
+        ledModeDefault={ledModeDefault}
+        setLedModeDefault={setLedModeDefault}
+        ledModeAutoSave={ledModeAutoSave}
+        setLedModeAutoSave={setLedModeAutoSave}
       />
       <PluginPreferences
         setModified={setModified}

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -1,0 +1,67 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import FormHelperText from "@mui/material/FormHelperText";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import PreferenceSwitch from "../../components/PreferenceSwitch";
+
+const DefaultLedMode = (props) => {
+  const { t } = useTranslation();
+
+  const { visible, onLedModeChange, ledMode, onAutoSaveChange, autoSave } =
+    props;
+
+  if (!visible) return null;
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <PreferenceSwitch
+        option="keyboard.led.default.autoSave"
+        checked={autoSave}
+        onChange={onAutoSaveChange}
+      />
+      <FormControl sx={{ my: 2 }}>
+        <TextField
+          disabled={autoSave}
+          label={t("preferences.keyboard.led.default.label")}
+          type="number"
+          min={0}
+          max={31}
+          value={ledMode}
+          onChange={onLedModeChange}
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+        <FormHelperText>
+          {t("preferences.keyboard.led.default.help")}
+        </FormHelperText>
+      </FormControl>
+    </Box>
+  );
+};
+
+export { DefaultLedMode as default };


### PR DESCRIPTION
When the PersistentLEDMode plugin is enabled on the firmware side, we can set a default LED mode, or even let it auto-save whenever we change modes. This little patch teaches Chrysalis how to configure said plugin.

![Screenshot from 2022-05-31 12-47-11](https://user-images.githubusercontent.com/17243/171158017-f138f845-5ced-4205-8c54-e91e20c0fab3.png)

When auto-saving is enabled, the default layer input box gets disabled.

Fixes #846.
