### PR TITLE
Another huge set of Preferences changes: both visible and code quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react": "^17.0.2",
     "react-color": "^2.14.1",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-i18next": "^11.8.5",
     "react-localization": "^1.0.15",
     "react-markdown": "^7.1.0",

--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -390,6 +390,8 @@ class Focus {
     "escape_oneshot.cancel_key",
     "idleleds.time_limit",
     "led.brightness",
+    "led_mode.auto_save",
+    "led_mode.default",
     "macros",
     "tapdance.map",
     "hostos.type",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -26,7 +26,8 @@ import {
   StyledEngineProvider,
   ThemeProvider,
 } from "@mui/material/styles";
-import React, { Suspense, useContext, useEffect } from "react";
+import React, { Suspense, useState, useContext, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import "typeface-roboto/index.css";
 import "typeface-source-code-pro/index.css";
@@ -76,6 +77,7 @@ const App = (props) => {
   const [theme, setTheme] = globalContext.state.theme;
   const darkMode = globalContext.state.darkMode;
   const [activeDevice, setActiveDevice] = globalContext.state.activeDevice;
+  const [bgColor, setBgColor] = useState(null);
 
   migrateDarkModeToTheme();
   setTheme(settings.get("ui.theme", "system"));
@@ -133,6 +135,23 @@ const App = (props) => {
     };
   });
 
+  const uiTheme = createTheme({
+    palette: {
+      mode: darkMode() ? "dark" : "light",
+      primary: {
+        main: "#EF5022",
+      },
+      secondary: {
+        main: "#939597",
+      },
+      body: darkMode() ? "#353535" : "#f5f5f5",
+    },
+  });
+
+  useEffect(() => {
+    setBgColor(uiTheme.palette.body);
+  }, [theme, uiTheme]);
+
   const toggleFlashing = async () => {
     flashing = !flashing;
     if (!flashing) {
@@ -188,18 +207,6 @@ const App = (props) => {
     await navigate("/keyboard-select");
   };
 
-  const uiTheme = createTheme({
-    palette: {
-      mode: darkMode() ? "dark" : "light",
-      primary: {
-        main: "#EF5022",
-      },
-      secondary: {
-        main: "#939597",
-      },
-    },
-  });
-
   const deviceInfo =
     focus?.focusDeviceDescriptor?.info || focusDeviceDescriptor?.info;
 
@@ -207,6 +214,9 @@ const App = (props) => {
     <Suspense>
       <StyledEngineProvider injectFirst>
         <ThemeProvider theme={uiTheme}>
+          <Helmet>
+            <body style={`background-color: ${bgColor}`} />
+          </Helmet>
           <Box
             sx={{
               display: "flex",

--- a/src/renderer/hooks/useCheckDeviceSupportsPlugins.js
+++ b/src/renderer/hooks/useCheckDeviceSupportsPlugins.js
@@ -18,7 +18,7 @@ import { GlobalContext } from "@renderer/components/GlobalContext";
 
 import { useEffect, useState, useContext } from "react";
 
-const usePluginCheck = (desiredPlugins) => {
+const useCheckDeviceSupportsPlugins = (desiredPlugins) => {
   const globalContext = useContext(GlobalContext);
   const [activeDevice] = globalContext.state.activeDevice;
   const [foundPlugins, setFoundPlugins] = useState({});
@@ -44,4 +44,4 @@ const usePluginCheck = (desiredPlugins) => {
   return [initialized, foundPlugins];
 };
 
-export { usePluginCheck as default };
+export { useCheckDeviceSupportsPlugins as default };

--- a/src/renderer/hooks/usePluginCheck.js
+++ b/src/renderer/hooks/usePluginCheck.js
@@ -1,0 +1,47 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
+import { useEffect, useState, useContext } from "react";
+
+const usePluginCheck = (desiredPlugins) => {
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
+  const [foundPlugins, setFoundPlugins] = useState({});
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    const init = async () => {
+      const plugins = await activeDevice.focus.plugins();
+      const commands = await activeDevice.focus.supported_commands();
+      const found = {};
+
+      for (const p of desiredPlugins) {
+        found[p] = plugins.includes(p) || commands.includes(p);
+      }
+
+      setFoundPlugins(found);
+      setInitialized(true);
+    };
+
+    if (!initialized) init();
+  }, [activeDevice, desiredPlugins, initialized]);
+
+  return [initialized, foundPlugins];
+};
+
+export { usePluginCheck as default };

--- a/src/renderer/hooks/usePluginEffect.js
+++ b/src/renderer/hooks/usePluginEffect.js
@@ -1,0 +1,49 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
+import { useEffect, useState, useContext } from "react";
+
+const usePluginEffect = (initialize) => {
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    const channel = new BroadcastChannel("context_bar");
+    channel.onmessage = async (event) => {
+      if (event.data === "changes-discarded") {
+        await initialize(activeDevice.focus);
+      }
+    };
+
+    const init = async () => {
+      await initialize(activeDevice.focus);
+      setInitialized(true);
+    };
+
+    if (!initialized) init();
+
+    return () => {
+      channel.close();
+    };
+  }, [activeDevice, initialize, initialized]);
+
+  return initialized;
+};
+
+export { usePluginEffect as default };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -286,28 +286,27 @@ const English = {
     },
     ui: {
       layoutEditor: {
-        label: "Layout Editor Preferences",
+        label: "Customize the Layout Editor",
       },
       layoutCards: {
-        label: "Layout Cards Preferences",
+        label: "Customize Layout Cards",
       },
       hideUnavailableFeatures: {
         label: `Hide features not supported by your keyboard's current firmware`,
         help: `When enabled, Chrysalis will hide configuration options for features that your keyboard's firmware doesn't support.`,
       },
       lookNFeel: {
-        label: "Look & Feel",
-        description: `The settings below control the general look an feel of Chrysalis.`,
+        label: "Customize appearance",
       },
       theme: {
-        label: "Choose the theme Chrysalis should use:",
-        system: "Match the system theme",
-        dark: "Use a dark theme",
-        light: "Use a light theme",
+        label: "Overall appearance",
+        system: "System default",
+        dark: "Dark",
+        light: "Light",
       },
       language: {
         label: "Language",
-        help: "Choose the language Chrysalis should use.",
+        help: "Choose the language Chrysalis should use",
       },
       coloredLayoutCards: {
         label: "Enable colors on the layout cards",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -365,6 +365,14 @@ const English = {
           label: "LED Brightness",
           help: "Adjust the brightness of the LEDs on the keyboard.",
         },
+        default: {
+          autoSave: {
+            label: "Enable automatically saving the default led mode",
+            help: `When enabled, whenever the led mode is changed, it gets saved as the default.`,
+          },
+          label: "Default led mode",
+          help: "Select the led mode the keyboard should start up with.",
+        },
       },
       plugins: {
         label: "Plugin preferences",

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -313,7 +313,7 @@ const English = {
         help: `When enabled, the layout cards will show not only key labels, but if available, colors too.`,
       },
       host: {
-        layout: "{{hostos}} layout",
+        label: "Keyboard layout",
         help: "Select the key layout you use on your computer",
       },
     },

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -73,10 +73,7 @@ function Preferences(props) {
     <Box
       sx={{
         flexGrow: 1,
-        bgcolor: "action.hover",
         display: "flex",
-        height: "100%",
-        width: "100%",
       }}
     >
       <PageTitle title={t("app.menu.preferences")} />
@@ -91,7 +88,10 @@ function Preferences(props) {
           borderColor: "divider",
           display: "flex",
           alignItems: "left",
-          minWidth: 300,
+          width: 300,
+          position: "fixed",
+          top: "48px",
+          bottom: 0,
         }}
       >
         <Tab label={t("preferences.interface")} {...a11yProps(0)} />
@@ -105,6 +105,7 @@ function Preferences(props) {
       <Box
         sx={{
           flexGrow: 1,
+          ml: "300px",
         }}
       >
         <TabPanel value={value} index={0}>

--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -29,7 +29,7 @@ import { MyKeyboardPreferences } from "./Preferences/MyKeyboard";
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
   return (
-    <div
+    <Box
       role="tabpanel"
       hidden={value !== index}
       id={`vertical-tabpanel-${index}`}
@@ -39,14 +39,15 @@ function TabPanel(props) {
       {value === index && (
         <Box
           sx={{
-            m: 2,
-            px: 3,
+            height: "100%",
+            mt: 2,
+            px: 5,
           }}
         >
           {children}
         </Box>
       )}
-    </div>
+    </Box>
   );
 }
 function a11yProps(index) {
@@ -72,7 +73,7 @@ function Preferences(props) {
     <Box
       sx={{
         flexGrow: 1,
-        bgcolor: "background.paper",
+        bgcolor: "action.hover",
         display: "flex",
         height: "100%",
         width: "100%",
@@ -85,11 +86,11 @@ function Preferences(props) {
         value={value}
         onChange={handleChange}
         sx={{
+          bgcolor: "background.paper",
           borderRight: 1,
           borderColor: "divider",
           display: "flex",
           alignItems: "left",
-          height: "100%",
           minWidth: 300,
         }}
       >
@@ -104,7 +105,6 @@ function Preferences(props) {
       <Box
         sx={{
           flexGrow: 1,
-          mb: 2,
         }}
       >
         <TabPanel value={value} index={0}>

--- a/src/renderer/screens/Preferences/Devtools.js
+++ b/src/renderer/screens/Preferences/Devtools.js
@@ -16,6 +16,7 @@
  */
 
 import Focus from "@api/focus";
+import Divider from "@mui/material/Divider";
 import Skeleton from "@mui/material/Skeleton";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -83,6 +84,7 @@ function DevtoolsPreferences(props) {
       ) : (
         <Skeleton variant="text" width="100%" height={56} />
       )}
+      <Divider sx={{ my: 2, mx: -2 }} />
       <PreferenceSwitch
         option="devtools.verboseLogging"
         checked={verboseFocus}

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -22,7 +22,7 @@ import {
 } from "@renderer/components/ContextBar";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import SaveChangesButton from "@renderer/components/SaveChangesButton";
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import AdvancedKeyboardPreferences from "./keyboard/AdvancedKeyboardPreferences";
@@ -31,63 +31,51 @@ import KeyboardLEDPreferences from "./keyboard/KeyboardLEDPreferences";
 import PluginPreferences from "./keyboard/PluginPreferences";
 
 const MyKeyboardPreferences = (props) => {
-  const oneShotCancelKeyCode = 53630;
-  const escKeyCode = 41;
-
   const [modified, setModified] = useState(false);
-  const [defaultLayer, setDefaultLayer] = useState(126);
-  const [ledBrightness, setLedBrightness] = useState(255);
-  const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
-  const [ledModeDefault, setLedModeDefault] = useState(0);
-  const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
-  const [escOneShot, setEscOneShot] = useState(true);
+  const [saveCallbacks, setSaveCallbacks] = useState({});
 
   const { t } = useTranslation();
   const globalContext = useContext(GlobalContext);
   const [activeDevice] = globalContext.state.activeDevice;
 
+  const registerModifications = (command, args) => {
+    const newCbs = Object.assign({}, saveCallbacks);
+    newCbs[command] = args;
+    setSaveCallbacks(newCbs);
+
+    setModified(true);
+    showContextBar();
+  };
+
   const saveKeymapChanges = async () => {
-    await activeDevice.focus.command("settings.defaultLayer", defaultLayer);
-    await activeDevice.focus.command("led.brightness", ledBrightness);
-    await activeDevice.focus.command("idleleds.time_limit", ledIdleTimeLimit);
-    await activeDevice.focus.command("led_mode.default", ledModeDefault);
-    await activeDevice.focus.command(
-      "led_mode.auto_save",
-      ledModeAutoSave ? 1 : 0
-    );
-    await activeDevice.focus.command(
-      "escape_oneshot.cancel_key",
-      escOneShot ? escKeyCode : oneShotCancelKeyCode
-    );
+    for (const cmd of Object.keys(saveCallbacks)) {
+      const args = saveCallbacks[cmd];
+      await activeDevice.focus.command(cmd, args);
+    }
+    setSaveCallbacks({});
 
     await setModified(false);
     await hideContextBar();
   };
 
+  useEffect(() => {
+    const channel = new BroadcastChannel("context_bar");
+    channel.onmessage = async (event) => {
+      if (event.data === "changes-discarded") {
+        setSaveCallbacks({});
+        setModified(false);
+      }
+    };
+    return () => {
+      channel.close();
+    };
+  });
+
   return (
     <>
-      <KeyboardLayerPreferences
-        setModified={setModified}
-        defaultLayer={defaultLayer}
-        setDefaultLayer={setDefaultLayer}
-      />
-      <KeyboardLEDPreferences
-        modified={modified}
-        setModified={setModified}
-        ledBrightness={ledBrightness}
-        setLedBrightness={setLedBrightness}
-        ledIdleTimeLimit={ledIdleTimeLimit}
-        setLedIdleTimeLimit={setLedIdleTimeLimit}
-        ledModeDefault={ledModeDefault}
-        setLedModeDefault={setLedModeDefault}
-        ledModeAutoSave={ledModeAutoSave}
-        setLedModeAutoSave={setLedModeAutoSave}
-      />
-      <PluginPreferences
-        setModified={setModified}
-        escOneShot={escOneShot}
-        setEscOneShot={setEscOneShot}
-      />
+      <KeyboardLayerPreferences registerModifications={registerModifications} />
+      <KeyboardLEDPreferences registerModifications={registerModifications} />
+      <PluginPreferences registerModifications={registerModifications} />
       <AdvancedKeyboardPreferences />
 
       <SaveChangesButton

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -38,6 +38,8 @@ const MyKeyboardPreferences = (props) => {
   const [defaultLayer, setDefaultLayer] = useState(126);
   const [ledBrightness, setLedBrightness] = useState(255);
   const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
+  const [ledModeDefault, setLedModeDefault] = useState(0);
+  const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
   const [escOneShot, setEscOneShot] = useState(true);
 
   const { t } = useTranslation();
@@ -48,6 +50,11 @@ const MyKeyboardPreferences = (props) => {
     await activeDevice.focus.command("settings.defaultLayer", defaultLayer);
     await activeDevice.focus.command("led.brightness", ledBrightness);
     await activeDevice.focus.command("idleleds.time_limit", ledIdleTimeLimit);
+    await activeDevice.focus.command("led_mode.default", ledModeDefault);
+    await activeDevice.focus.command(
+      "led_mode.auto_save",
+      ledModeAutoSave ? 1 : 0
+    );
     await activeDevice.focus.command(
       "escape_oneshot.cancel_key",
       escOneShot ? escKeyCode : oneShotCancelKeyCode
@@ -71,6 +78,10 @@ const MyKeyboardPreferences = (props) => {
         setLedBrightness={setLedBrightness}
         ledIdleTimeLimit={ledIdleTimeLimit}
         setLedIdleTimeLimit={setLedIdleTimeLimit}
+        ledModeDefault={ledModeDefault}
+        setLedModeDefault={setLedModeDefault}
+        ledModeAutoSave={ledModeAutoSave}
+        setLedModeAutoSave={setLedModeAutoSave}
       />
       <PluginPreferences
         setModified={setModified}

--- a/src/renderer/screens/Preferences/components/PreferenceSection.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSection.js
@@ -18,7 +18,7 @@
 import React from "react";
 
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 
 import { useTranslation } from "react-i18next";
@@ -29,17 +29,12 @@ const PreferenceSection = (props) => {
   const description = t("preferences." + props.name + ".description", "");
 
   return (
-    <>
-      <Divider textAlign="left" sx={{ my: 2 }}>
+    <Box sx={{ my: 2 }}>
+      <Typography variant="h6" gutterBottom>
         {t("preferences." + props.name + ".label")}
-      </Divider>
-      {description && (
-        <Typography variant="body2" gutterBottom>
-          {description}
-        </Typography>
-      )}
-      <Box sx={{ my: 2 }}>{props.children}</Box>
-    </>
+      </Typography>
+      <Paper sx={{ p: 2, width: "75%" }}>{props.children}</Paper>
+    </Box>
   );
 };
 

--- a/src/renderer/screens/Preferences/components/PreferenceSection.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSection.js
@@ -19,6 +19,7 @@ import React from "react";
 
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
+import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 
 import { useTranslation } from "react-i18next";
@@ -26,6 +27,7 @@ import { useTranslation } from "react-i18next";
 const PreferenceSection = (props) => {
   const { t } = useTranslation();
 
+  const loaded = props.loaded === undefined ? true : props.loaded;
   const description = t("preferences." + props.name + ".description", "");
 
   return (
@@ -33,7 +35,13 @@ const PreferenceSection = (props) => {
       <Typography variant="h6" gutterBottom>
         {t("preferences." + props.name + ".label")}
       </Typography>
-      <Paper sx={{ p: 2, width: "75%" }}>{props.children}</Paper>
+      <Paper sx={{ p: 2, width: "75%" }}>
+        {loaded ? (
+          props.children
+        ) : (
+          <Skeleton variant="rectangle" width="100%" height={80} />
+        )}
+      </Paper>
     </Box>
   );
 };

--- a/src/renderer/screens/Preferences/components/PreferenceSection.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSection.js
@@ -27,7 +27,15 @@ import { useTranslation } from "react-i18next";
 const PreferenceSection = (props) => {
   const { t } = useTranslation();
 
-  const loaded = props.loaded === undefined ? true : props.loaded;
+  // The goal here is to make <PreferenceSection> usable in contexts where
+  // loading makes no sense (because the data is readily available), without
+  // having to pass a `loaded={true}` property.
+  //
+  // We check if the property has been defined, and if not, default to true,
+  // otherwise we use the property as specified.
+  // prettier-ignore
+  const loaded = (props.loaded === undefined) ? true : props.loaded;
+
   const description = t("preferences." + props.name + ".description", "");
 
   return (

--- a/src/renderer/screens/Preferences/components/PreferenceSwitch.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSwitch.js
@@ -20,11 +20,14 @@ import React from "react";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
+import Skeleton from "@mui/material/Skeleton";
 import Switch from "@mui/material/Switch";
 import { useTranslation } from "react-i18next";
 
 const PreferenceSwitch = (props) => {
   const { t } = useTranslation();
+
+  const loaded = props.loaded === undefined ? true : props.loaded;
 
   const SwitchLabel = (props) => {
     const secondary = t("preferences." + props.option + ".help", "");
@@ -45,7 +48,13 @@ const PreferenceSwitch = (props) => {
         display: "flex",
         mx: 0,
       }}
-      control={<Switch checked={props.checked} onChange={props.onChange} />}
+      control={
+        loaded ? (
+          <Switch checked={props.checked} onChange={props.onChange} />
+        ) : (
+          <Skeleton variant="rectangle" width={58} height={38} />
+        )
+      }
       labelPlacement="start"
       label={<SwitchLabel option={props.option} />}
       disableTypography

--- a/src/renderer/screens/Preferences/components/PreferenceSwitch.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSwitch.js
@@ -27,7 +27,14 @@ import { useTranslation } from "react-i18next";
 const PreferenceSwitch = (props) => {
   const { t } = useTranslation();
 
-  const loaded = props.loaded === undefined ? true : props.loaded;
+  // The goal here is to make <PreferenceSwitch> usable in contexts where
+  // loading makes no sense (because the data is readily available), without
+  // having to pass a `loaded={true}` property.
+  //
+  // We check if the property has been defined, and if not, default to true,
+  // otherwise we use the property as specified.
+  // prettier-ignore
+  const loaded = (props.loaded === undefined) ? true : props.loaded;
 
   const SwitchLabel = (props) => {
     const secondary = t("preferences." + props.option + ".help", "");

--- a/src/renderer/screens/Preferences/components/PreferenceSwitch.js
+++ b/src/renderer/screens/Preferences/components/PreferenceSwitch.js
@@ -43,9 +43,10 @@ const PreferenceSwitch = (props) => {
       sx={{
         alignItems: "start",
         display: "flex",
+        mx: 0,
       }}
       control={<Switch checked={props.checked} onChange={props.onChange} />}
-      labelPlacement="end"
+      labelPlacement="start"
       label={<SwitchLabel option={props.option} />}
       disableTypography
     />

--- a/src/renderer/screens/Preferences/components/PreferenceWithHeading.js
+++ b/src/renderer/screens/Preferences/components/PreferenceWithHeading.js
@@ -1,0 +1,40 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+import React from "react";
+
+const PreferenceWithHeading = (props) => {
+  return (
+    <Box sx={{ display: "flex" }}>
+      <Box>
+        <Typography variant="body1">{props.heading}</Typography>
+        {props.subheading && (
+          <Typography variant="body2" color="text.secondary">
+            {props.subheading}
+          </Typography>
+        )}
+      </Box>
+      <span style={{ flexGrow: 1 }} />
+      {props.children}
+    </Box>
+  );
+};
+
+export { PreferenceWithHeading as default };

--- a/src/renderer/screens/Preferences/keyboard/AdvancedKeyboardPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/AdvancedKeyboardPreferences.js
@@ -19,6 +19,7 @@ import { FocusCommands } from "@api/flash";
 import Backdrop from "@mui/material/Backdrop";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
+import Divider from "@mui/material/Divider";
 import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import checkExternalFlasher from "@renderer/utils/checkExternalFlasher";
@@ -84,16 +85,18 @@ const AdvancedKeyboardPreferences = (props) => {
   return (
     <PreferenceSection name="keyboard.advanced">
       {externalFlasherAvailable && (
-        <PreferenceSwitch
-          option="keyboard.flash.preferExternal"
-          checked={preferExternalFlasher}
-          onChange={setPreferExternalFlasher}
-        />
+        <>
+          <PreferenceSwitch
+            option="keyboard.flash.preferExternal"
+            checked={preferExternalFlasher}
+            onChange={setPreferExternalFlasher}
+          />
+          <Divider sx={{ mx: -2, my: 2 }} />
+        </>
       )}
       <Button
-        sx={{ my: 2 }}
         disabled={working}
-        variant="contained"
+        variant="outlined"
         color="secondary"
         onClick={openEEPROMResetConfirmation}
       >

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -184,6 +184,7 @@ const KeyboardLEDPreferences = (props) => {
       ) : (
         <Skeleton variant="rectangle" width={422} height={79} sx={{ mb: 2 }} />
       )}
+      <Divider sx={{ mx: -2, my: 2 }} />
       {loaded ? (
         <Brightness
           onChange={setBrightness}

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Divider from "@mui/material/Divider";
 import Skeleton from "@mui/material/Skeleton";
 import {
   hideContextBar,
@@ -173,6 +174,7 @@ const KeyboardLEDPreferences = (props) => {
       ) : (
         <Skeleton variant="rectange" width={600} height={167} sx={{ my: 2 }} />
       )}
+      <Divider sx={{ mx: -2, my: 2 }} />
       {loaded ? (
         <IdleTimeLimit
           visible={hasIdleTime}

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -43,7 +43,7 @@ const KeyboardLEDPreferences = (props) => {
   if (loaded && !foundSomePlugins) return null;
 
   return (
-    <PreferenceSection name="keyboard.led">
+    <PreferenceSection name="keyboard.led" loaded={loaded}>
       {plugins["PersistentLEDMode"] && (
         <DefaultLedMode registerModifications={registerModifications} />
       )}

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -29,8 +29,6 @@ import PreferenceSection from "../components/PreferenceSection";
 
 import { dividePreferences } from "../utils/dividePreferences";
 
-const delay = (ms) => new Promise((res) => setTimeout(res, ms));
-
 const KeyboardLEDPreferences = (props) => {
   const { t } = useTranslation();
   const { onSaveChanges } = props;
@@ -41,7 +39,7 @@ const KeyboardLEDPreferences = (props) => {
     "led.brightness",
   ]);
 
-  const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
+  const foundSomePlugins = Object.values(plugins).some((v) => v);
   if (loaded && !foundSomePlugins) return null;
 
   const preferences = [

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -17,11 +17,7 @@
  */
 
 import Divider from "@mui/material/Divider";
-import Skeleton from "@mui/material/Skeleton";
-import {
-  hideContextBar,
-  showContextBar,
-} from "@renderer/components/ContextBar";
+
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
@@ -40,21 +36,9 @@ const KeyboardLEDPreferences = (props) => {
   const [hasBrightness, setHasBrightness] = useState(false);
   const [hasIdleTime, setHasIdleTime] = useState(false);
   const [hasPersistentLedMode, setHasPersistentLedMode] = useState(false);
-  const [loaded, setLoaded] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
-  const {
-    modified,
-    setModified,
-    ledBrightness,
-    setLedBrightness,
-    ledIdleTimeLimit,
-    setLedIdleTimeLimit,
-    ledModeDefault,
-    setLedModeDefault,
-    ledModeAutoSave,
-    setLedModeAutoSave,
-  } = props;
+  const { registerModifications } = props;
 
   // Do the initial loading
   useEffect(() => {
@@ -78,121 +62,25 @@ const KeyboardLEDPreferences = (props) => {
     if (!initialized) initialize();
   }, [activeDevice, initialized]);
 
-  // Fetch the data, once we're initialized
-  useEffect(() => {
-    const fetchData = async () => {
-      if (hasBrightness) {
-        let brightness = await activeDevice.focus.command("led.brightness");
-        brightness = parseInt(brightness);
-        setLedBrightness(brightness);
-      }
-
-      if (hasIdleTime) {
-        let limit = await activeDevice.focus.command("idleleds.time_limit");
-        limit = parseInt(limit);
-        setLedIdleTimeLimit(limit);
-      }
-
-      if (hasPersistentLedMode) {
-        const def = await activeDevice.focus.command("led_mode.default");
-        const autoSave = await activeDevice.focus.command("led_mode.auto_save");
-
-        setLedModeDefault(parseInt(def));
-        setLedModeAutoSave(autoSave == "1");
-      }
-
-      setLoaded(true);
-    };
-
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await fetchData();
-        setModified(false);
-      }
-    };
-
-    if (initialized) {
-      fetchData();
-    }
-
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [
-    activeDevice,
-    hasBrightness,
-    hasIdleTime,
-    hasPersistentLedMode,
-    initialized,
-    setLedBrightness,
-    setLedIdleTimeLimit,
-    setLedModeDefault,
-    setLedModeAutoSave,
-    setModified,
-  ]);
-
-  const selectIdleLEDTime = (event) => {
-    setLedIdleTimeLimit(event.target.value);
-    setModified(true);
-    showContextBar();
-  };
-
-  const setBrightness = (event, value) => {
-    setLedBrightness(value);
-    setModified(true);
-    showContextBar();
-  };
-
-  const selectLedModeDefault = (event) => {
-    const v = event.target.value;
-    const value = Math.max(0, Math.min(32, v == "" ? 0 : parseInt(v)));
-    setLedModeDefault(value);
-    setModified(true);
-    showContextBar();
-  };
-
-  const toggleLedModeAutoSave = (event) => {
-    setLedModeAutoSave(event.target.checked);
-    setModified(true);
-    showContextBar();
-  };
-
   if (initialized && !hasIdleTime && !hasBrightness && !hasPersistentLedMode)
     return null;
 
   return (
     <PreferenceSection name="keyboard.led">
-      {loaded ? (
-        <DefaultLedMode
-          visible={hasPersistentLedMode}
-          onLedModeChange={selectLedModeDefault}
-          ledMode={ledModeDefault}
-          onAutoSaveChange={toggleLedModeAutoSave}
-          autoSave={ledModeAutoSave}
-        />
-      ) : (
-        <Skeleton variant="rectange" width={600} height={167} sx={{ my: 2 }} />
+      {hasPersistentLedMode && (
+        <DefaultLedMode registerModifications={registerModifications} />
       )}
-      <Divider sx={{ mx: -2, my: 2 }} />
-      {loaded ? (
-        <IdleTimeLimit
-          visible={hasIdleTime}
-          onChange={selectIdleLEDTime}
-          value={ledIdleTimeLimit}
-        />
-      ) : (
-        <Skeleton variant="rectangle" width={422} height={79} sx={{ mb: 2 }} />
+      {hasPersistentLedMode && (hasIdleTime || hasBrightness) && (
+        <Divider sx={{ mx: -2, my: 2 }} />
       )}
-      <Divider sx={{ mx: -2, my: 2 }} />
-      {loaded ? (
-        <Brightness
-          onChange={setBrightness}
-          value={ledBrightness}
-          visible={hasBrightness}
-        />
-      ) : (
-        <Skeleton variant="rectangle" width={422} height={79} sx={{ mb: 2 }} />
+      {hasIdleTime && (
+        <IdleTimeLimit registerModifications={registerModifications} />
+      )}
+      {hasBrightness && (hasIdleTime || hasPersistentLedMode) && (
+        <Divider sx={{ mx: -2, my: 2 }} />
+      )}
+      {hasBrightness && (
+        <Brightness registerModifications={registerModifications} />
       )}
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -27,6 +27,8 @@ import DefaultLedMode from "./leds/DefaultLedMode";
 import IdleTimeLimit from "./leds/IdleTimeLimit";
 import PreferenceSection from "../components/PreferenceSection";
 
+import { dividePreferences } from "../utils/dividePreferences";
+
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const KeyboardLEDPreferences = (props) => {
@@ -42,25 +44,15 @@ const KeyboardLEDPreferences = (props) => {
   const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
   if (loaded && !foundSomePlugins) return null;
 
+  const preferences = [
+    { plugin: "PersistentLEDMode", Component: DefaultLedMode },
+    { plugin: "PersistentIdleLEDs", Component: IdleTimeLimit },
+    { plugin: "led.brightness", Component: Brightness },
+  ];
+
   return (
     <PreferenceSection name="keyboard.led" loaded={loaded}>
-      {plugins["PersistentLEDMode"] && (
-        <DefaultLedMode onSaveChanges={onSaveChanges} />
-      )}
-      {plugins["PersistentLEDMode"] &&
-        (plugins["PersistentIdleLEDs"] || plugins["led.brightness"]) && (
-          <Divider sx={{ mx: -2, my: 2 }} />
-        )}
-      {plugins["PersistentIdleLEDs"] && (
-        <IdleTimeLimit onSaveChanges={onSaveChanges} />
-      )}
-      {plugins["led.brightness"] &&
-        (plugins["PersistentIdleLEDs"] || plugins["PersistentLEDMode"]) && (
-          <Divider sx={{ mx: -2, my: 2 }} />
-        )}
-      {plugins["led.brightness"] && (
-        <Brightness onSaveChanges={onSaveChanges} />
-      )}
+      {dividePreferences(plugins, preferences, onSaveChanges, "keyboard.led")}
     </PreferenceSection>
   );
 };

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -31,7 +31,7 @@ const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const KeyboardLEDPreferences = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [loaded, plugins] = useCheckDeviceSupportsPlugins([
     "PersistentIdleLEDs",
@@ -45,21 +45,21 @@ const KeyboardLEDPreferences = (props) => {
   return (
     <PreferenceSection name="keyboard.led" loaded={loaded}>
       {plugins["PersistentLEDMode"] && (
-        <DefaultLedMode registerModifications={registerModifications} />
+        <DefaultLedMode onSaveChanges={onSaveChanges} />
       )}
       {plugins["PersistentLEDMode"] &&
         (plugins["PersistentIdleLEDs"] || plugins["led.brightness"]) && (
           <Divider sx={{ mx: -2, my: 2 }} />
         )}
       {plugins["PersistentIdleLEDs"] && (
-        <IdleTimeLimit registerModifications={registerModifications} />
+        <IdleTimeLimit onSaveChanges={onSaveChanges} />
       )}
       {plugins["led.brightness"] &&
         (plugins["PersistentIdleLEDs"] || plugins["PersistentLEDMode"]) && (
           <Divider sx={{ mx: -2, my: 2 }} />
         )}
       {plugins["led.brightness"] && (
-        <Brightness registerModifications={registerModifications} />
+        <Brightness onSaveChanges={onSaveChanges} />
       )}
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLEDPreferences.js
@@ -18,7 +18,7 @@
 
 import Divider from "@mui/material/Divider";
 
-import usePluginCheck from "@renderer/hooks/usePluginCheck";
+import useCheckDeviceSupportsPlugins from "@renderer/hooks/useCheckDeviceSupportsPlugins";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -33,7 +33,7 @@ const KeyboardLEDPreferences = (props) => {
   const { t } = useTranslation();
   const { registerModifications } = props;
 
-  const [loaded, plugins] = usePluginCheck([
+  const [loaded, plugins] = useCheckDeviceSupportsPlugins([
     "PersistentIdleLEDs",
     "PersistentLEDMode",
     "led.brightness",

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -21,10 +21,6 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
-import {
-  hideContextBar,
-  showContextBar,
-} from "@renderer/components/ContextBar";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
@@ -35,13 +31,14 @@ const KeyboardLayerPreferences = (props) => {
   const { t } = useTranslation();
   const globalContext = useContext(GlobalContext);
   const [activeDevice] = globalContext.state.activeDevice;
-  const { setModified, defaultLayer, setDefaultLayer } = props;
+  const { registerModifications } = props;
 
   const [keymap, setKeymap] = useState({
     custom: [],
     default: [],
     onlyCustom: false,
   });
+  const [defaultLayer, setDefaultLayer] = useState(126);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -58,7 +55,6 @@ const KeyboardLayerPreferences = (props) => {
     context_bar_channel.onmessage = async (event) => {
       if (event.data === "changes-discarded") {
         await initialize();
-        setModified(false);
       }
     };
 
@@ -67,13 +63,12 @@ const KeyboardLayerPreferences = (props) => {
     return () => {
       context_bar_channel.close();
     };
-  }, [activeDevice, setDefaultLayer, setModified]);
+  }, [activeDevice]);
 
-  const selectDefaultLayer = (event) => {
-    setDefaultLayer(event.target.value);
-
-    setModified(true);
-    showContextBar();
+  const selectDefaultLayer = async (event) => {
+    const layer = event.target.value;
+    await setDefaultLayer(layer);
+    await registerModifications("settings.defaultLayer", layer);
   };
 
   const layers = keymap.custom.map((_, index) => {

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
-import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
+import Typography from "@mui/material/Typography";
 import {
   hideContextBar,
   showContextBar,
@@ -87,24 +87,29 @@ const KeyboardLayerPreferences = (props) => {
   return (
     <PreferenceSection name="keyboard.layers">
       {loaded ? (
-        <FormControl sx={{ minWidth: "20em" }}>
-          <InputLabel>
-            {t("preferences.keyboard.defaultLayer.label")}
-          </InputLabel>
-          <Select
-            onChange={selectDefaultLayer}
-            value={defaultLayer}
-            label={t("preferences.keyboard.defaultLayer.label")}
-          >
-            <MenuItem value={126}>
-              {t("preferences.keyboard.defaultLayer.noDefault")}
-            </MenuItem>
-            {layers}
-          </Select>
-          <FormHelperText>
-            {t("preferences.keyboard.defaultLayer.help")}
-          </FormHelperText>
-        </FormControl>
+        <Box sx={{ display: "flex" }}>
+          <Box>
+            <Typography variant="body1">
+              {t("preferences.keyboard.defaultLayer.label")}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t("preferences.keyboard.defaultLayer.help")}
+            </Typography>
+          </Box>
+          <span style={{ flexGrow: 1 }} />
+          <FormControl size="small">
+            <Select
+              onChange={selectDefaultLayer}
+              value={defaultLayer}
+              sx={{ minWidth: "10em" }}
+            >
+              <MenuItem value={126}>
+                {t("preferences.keyboard.defaultLayer.noDefault")}
+              </MenuItem>
+              {layers}
+            </Select>
+          </FormControl>
+        </Box>
       ) : (
         <Skeleton variant="rectangular" width={320} height={79} />
       )}

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -30,7 +30,7 @@ import PreferenceSection from "../components/PreferenceSection";
 
 const KeyboardLayerPreferences = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [keymap, setKeymap] = useState({
     custom: [],
@@ -51,7 +51,7 @@ const KeyboardLayerPreferences = (props) => {
   const selectDefaultLayer = async (event) => {
     const layer = event.target.value;
     await setDefaultLayer(layer);
-    await registerModifications("settings.defaultLayer", layer);
+    await onSaveChanges("settings.defaultLayer", layer);
   };
 
   const layers = keymap.custom.map((_, index) => {

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -62,10 +62,6 @@ const KeyboardLayerPreferences = (props) => {
     );
   });
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   return (
     <PreferenceSection name="keyboard.layers">
       <Box sx={{ display: "flex" }}>
@@ -78,18 +74,22 @@ const KeyboardLayerPreferences = (props) => {
           </Typography>
         </Box>
         <span style={{ flexGrow: 1 }} />
-        <FormControl size="small">
-          <Select
-            onChange={selectDefaultLayer}
-            value={defaultLayer}
-            sx={{ minWidth: "10em" }}
-          >
-            <MenuItem value={126}>
-              {t("preferences.keyboard.defaultLayer.noDefault")}
-            </MenuItem>
-            {layers}
-          </Select>
-        </FormControl>
+        {loaded ? (
+          <FormControl size="small">
+            <Select
+              onChange={selectDefaultLayer}
+              value={defaultLayer}
+              sx={{ minWidth: "10em" }}
+            >
+              <MenuItem value={126}>
+                {t("preferences.keyboard.defaultLayer.noDefault")}
+              </MenuItem>
+              {layers}
+            </Select>
+          </FormControl>
+        ) : (
+          <Skeleton variant="rectangle" width="10em" height={40} />
+        )}
       </Box>
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -15,18 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
-import Typography from "@mui/material/Typography";
 
 import usePluginEffect from "@renderer/hooks/usePluginEffect";
 import React, { useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
+import PreferenceWithHeading from "../components/PreferenceWithHeading";
 
 const KeyboardLayerPreferences = (props) => {
   const { t } = useTranslation();
@@ -64,16 +63,10 @@ const KeyboardLayerPreferences = (props) => {
 
   return (
     <PreferenceSection name="keyboard.layers">
-      <Box sx={{ display: "flex" }}>
-        <Box>
-          <Typography variant="body1">
-            {t("preferences.keyboard.defaultLayer.label")}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {t("preferences.keyboard.defaultLayer.help")}
-          </Typography>
-        </Box>
-        <span style={{ flexGrow: 1 }} />
+      <PreferenceWithHeading
+        heading={t("preferences.keyboard.defaultLayer.label")}
+        subheading={t("preferences.keyboard.defaultLayer.help")}
+      >
         {loaded ? (
           <FormControl size="small">
             <Select
@@ -90,7 +83,7 @@ const KeyboardLayerPreferences = (props) => {
         ) : (
           <Skeleton variant="rectangle" width="10em" height={40} />
         )}
-      </Box>
+      </PreferenceWithHeading>
     </PreferenceSection>
   );
 };

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Skeleton from "@mui/material/Skeleton";
 import usePluginCheck from "@renderer/hooks/usePluginCheck";
 
 import React, { useState } from "react";
@@ -30,15 +29,11 @@ const PluginPreferences = (props) => {
 
   const [loaded, plugins] = usePluginCheck(["EscapeOneShot"]);
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
   if (loaded && !foundSomePlugins) return null;
 
   return (
-    <PreferenceSection name="keyboard.plugins">
+    <PreferenceSection name="keyboard.plugins" loaded={loaded}>
       {plugins["EscapeOneShot"] && (
         <EscapeOneShotPreferences
           registerModifications={registerModifications}

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -16,8 +16,9 @@
  */
 
 import Skeleton from "@mui/material/Skeleton";
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useEffect, useState, useContext } from "react";
+import usePluginCheck from "@renderer/hooks/usePluginCheck";
+
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
@@ -25,37 +26,20 @@ import EscapeOneShotPreferences from "./plugins/EscapeOneShot";
 
 const PluginPreferences = (props) => {
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-  const [activeDevice] = globalContext.state.activeDevice;
-
-  const [initialized, setInitialized] = useState(false);
-  const [hasEscOneShot, setHasEscOneShot] = useState(false);
-
   const { registerModifications } = props;
 
-  // Initialize: check for plugins
-  useEffect(() => {
-    const initialize = async () => {
-      const plugins = await activeDevice.plugins();
+  const [loaded, plugins] = usePluginCheck(["EscapeOneShot"]);
 
-      if (plugins.includes("EscapeOneShot")) {
-        setHasEscOneShot(true);
-      }
-
-      setInitialized(true);
-    };
-
-    if (!initialized) initialize();
-  }, [activeDevice, initialized]);
-
-  if (!initialized) {
+  if (!loaded) {
     return <Skeleton variant="rectangle" />;
   }
-  if (initialized && !hasEscOneShot) return null;
+
+  const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
+  if (loaded && !foundSomePlugins) return null;
 
   return (
     <PreferenceSection name="keyboard.plugins">
-      {hasEscOneShot && (
+      {plugins["EscapeOneShot"] && (
         <EscapeOneShotPreferences
           registerModifications={registerModifications}
         />

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -29,7 +29,7 @@ const PluginPreferences = (props) => {
 
   const [loaded, plugins] = useCheckDeviceSupportsPlugins(["EscapeOneShot"]);
 
-  const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
+  const foundSomePlugins = Object.values(plugins).some((v) => v);
   if (loaded && !foundSomePlugins) return null;
 
   return (

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -25,7 +25,7 @@ import EscapeOneShotPreferences from "./plugins/EscapeOneShot";
 
 const PluginPreferences = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [loaded, plugins] = useCheckDeviceSupportsPlugins(["EscapeOneShot"]);
 
@@ -35,9 +35,7 @@ const PluginPreferences = (props) => {
   return (
     <PreferenceSection name="keyboard.plugins" loaded={loaded}>
       {plugins["EscapeOneShot"] && (
-        <EscapeOneShotPreferences
-          registerModifications={registerModifications}
-        />
+        <EscapeOneShotPreferences onSaveChanges={onSaveChanges} />
       )}
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -16,7 +16,6 @@
  */
 
 import Skeleton from "@mui/material/Skeleton";
-import { showContextBar } from "@renderer/components/ContextBar";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,17 +24,14 @@ import PreferenceSection from "../components/PreferenceSection";
 import EscapeOneShotPreferences from "./plugins/EscapeOneShot";
 
 const PluginPreferences = (props) => {
-  const escKeyCode = 41;
-
   const { t } = useTranslation();
   const globalContext = useContext(GlobalContext);
   const [activeDevice] = globalContext.state.activeDevice;
 
-  const [loaded, setLoaded] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [hasEscOneShot, setHasEscOneShot] = useState(false);
 
-  const { setModified, escOneShot, setEscOneShot } = props;
+  const { registerModifications } = props;
 
   // Initialize: check for plugins
   useEffect(() => {
@@ -52,57 +48,17 @@ const PluginPreferences = (props) => {
     if (!initialized) initialize();
   }, [activeDevice, initialized]);
 
-  const doesEscCancelOneShot = (value) => {
-    if (value.length == 0) {
-      return false;
-    }
-
-    return parseInt(value) == escKeyCode;
-  };
-
-  // Fetch data, after initialization
-  useEffect(() => {
-    const fetchData = async () => {
-      const key = await activeDevice.focus.command("escape_oneshot.cancel_key");
-      setEscOneShot(doesEscCancelOneShot(key));
-
-      setLoaded(true);
-    };
-
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await fetchData();
-        setModified(false);
-      }
-    };
-
-    if (initialized) fetchData();
-
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [activeDevice, setEscOneShot, setModified, setLoaded, initialized]);
-
-  const toggleEscOneShot = (event) => {
-    setEscOneShot(event.target.checked);
-
-    setModified(true);
-    showContextBar();
-  };
-
+  if (!initialized) {
+    return <Skeleton variant="rectangle" />;
+  }
   if (initialized && !hasEscOneShot) return null;
 
   return (
     <PreferenceSection name="keyboard.plugins">
-      {loaded ? (
+      {hasEscOneShot && (
         <EscapeOneShotPreferences
-          value={escOneShot}
-          onChange={toggleEscOneShot}
-          visible={hasEscOneShot}
+          registerModifications={registerModifications}
         />
-      ) : (
-        <Skeleton variant="text" width="100%" height={56} />
       )}
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import usePluginCheck from "@renderer/hooks/usePluginCheck";
+import useCheckDeviceSupportsPlugins from "@renderer/hooks/useCheckDeviceSupportsPlugins";
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -27,7 +27,7 @@ const PluginPreferences = (props) => {
   const { t } = useTranslation();
   const { registerModifications } = props;
 
-  const [loaded, plugins] = usePluginCheck(["EscapeOneShot"]);
+  const [loaded, plugins] = useCheckDeviceSupportsPlugins(["EscapeOneShot"]);
 
   const foundSomePlugins = Object.values(plugins).filter((v) => v).length > 0;
   if (loaded && !foundSomePlugins) return null;

--- a/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
@@ -21,42 +21,23 @@ import Skeleton from "@mui/material/Skeleton";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useEffect, useState, useContext } from "react";
+import usePluginEffect from "@renderer/hooks/usePluginEffect";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const Brightness = (props) => {
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-
-  const [activeDevice] = globalContext.state.activeDevice;
-  const [ledBrightness, setLedBrightness] = useState(255);
-  const [loaded, setLoaded] = useState(false);
-
   const { registerModifications } = props;
 
-  useEffect(() => {
-    const initialize = async () => {
-      let brightness = await activeDevice.focus.command("led.brightness");
-      brightness = parseInt(brightness);
+  const [ledBrightness, setLedBrightness] = useState(255);
 
-      setLedBrightness(brightness);
-      setLoaded(true);
-    };
+  const initialize = async (focus) => {
+    let brightness = await focus.command("led.brightness");
+    brightness = parseInt(brightness);
 
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await initialize();
-      }
-    };
-
-    initialize();
-
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [activeDevice]);
+    setLedBrightness(brightness);
+  };
+  const loaded = usePluginEffect(initialize);
 
   const formatValue = (value) => {
     return ((value / 255) * 100).toFixed(0) + "%";

--- a/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
+import Box from "@mui/material/Box";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
@@ -35,10 +34,16 @@ const Brightness = (props) => {
   if (!visible) return null;
 
   return (
-    <FormControl sx={{ display: "flex" }}>
-      <Typography gutterBottom>
-        {t("preferences.keyboard.led.brightness.label")}
-      </Typography>
+    <Box sx={{ display: "flex" }}>
+      <Box>
+        <Typography variant="body1">
+          {t("preferences.keyboard.led.brightness.label")}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t("preferences.keyboard.led.brightness.help")}
+        </Typography>
+      </Box>
+      <span style={{ flexGrow: 1 }} />
       <Slider
         max={255}
         step={16}
@@ -47,12 +52,9 @@ const Brightness = (props) => {
         valueLabelFormat={formatValue}
         value={value}
         onChange={onChange}
-        sx={{ width: "20em" }}
+        sx={{ width: "20em", mr: 1 }}
       />
-      <FormHelperText>
-        {t("preferences.keyboard.led.brightness.help")}
-      </FormHelperText>
-    </FormControl>
+    </Box>
   );
 };
 

--- a/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
@@ -27,7 +27,7 @@ import { useTranslation } from "react-i18next";
 
 const Brightness = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [ledBrightness, setLedBrightness] = useState(255);
 
@@ -46,7 +46,7 @@ const Brightness = (props) => {
   const onChange = async (event) => {
     const brightness = event.target.value;
     await setLedBrightness(brightness);
-    await registerModifications("led.brightness", brightness);
+    await onSaveChanges("led.brightness", brightness);
   };
 
   return (

--- a/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
@@ -49,10 +49,6 @@ const Brightness = (props) => {
     await registerModifications("led.brightness", brightness);
   };
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   return (
     <Box sx={{ display: "flex" }}>
       <Box>
@@ -64,16 +60,20 @@ const Brightness = (props) => {
         </Typography>
       </Box>
       <span style={{ flexGrow: 1 }} />
-      <Slider
-        max={255}
-        step={16}
-        marks
-        valueLabelDisplay="auto"
-        valueLabelFormat={formatValue}
-        value={ledBrightness}
-        onChange={onChange}
-        sx={{ width: "20em", mr: 1 }}
-      />
+      {loaded ? (
+        <Slider
+          max={255}
+          step={16}
+          marks
+          valueLabelDisplay="auto"
+          valueLabelFormat={formatValue}
+          value={ledBrightness}
+          onChange={onChange}
+          sx={{ width: "20em", mr: 1 }}
+        />
+      ) : (
+        <Skeleton variant="rectangle" width="20em" height={30} />
+      )}
     </Box>
   );
 };

--- a/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/Brightness.js
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Slider from "@mui/material/Slider";
-import Typography from "@mui/material/Typography";
 
 import usePluginEffect from "@renderer/hooks/usePluginEffect";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import PreferenceWithHeading from "../../components/PreferenceWithHeading";
 
 const Brightness = (props) => {
   const { t } = useTranslation();
@@ -50,16 +50,10 @@ const Brightness = (props) => {
   };
 
   return (
-    <Box sx={{ display: "flex" }}>
-      <Box>
-        <Typography variant="body1">
-          {t("preferences.keyboard.led.brightness.label")}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {t("preferences.keyboard.led.brightness.help")}
-        </Typography>
-      </Box>
-      <span style={{ flexGrow: 1 }} />
+    <PreferenceWithHeading
+      heading={t("preferences.keyboard.led.brightness.label")}
+      subheading={t("preferences.keyboard.led.brightness.help")}
+    >
       {loaded ? (
         <Slider
           max={255}
@@ -74,7 +68,7 @@ const Brightness = (props) => {
       ) : (
         <Skeleton variant="rectangle" width="20em" height={30} />
       )}
-    </Box>
+    </PreferenceWithHeading>
   );
 };
 

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -28,7 +28,7 @@ import PreferenceSwitch from "../../components/PreferenceSwitch";
 
 const DefaultLedMode = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [ledModeDefault, setLedModeDefault] = useState(0);
   const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
@@ -45,14 +45,14 @@ const DefaultLedMode = (props) => {
   const onAutoSaveChange = async (event) => {
     const autoSave = event.target.checked;
     await setLedModeAutoSave(autoSave);
-    await registerModifications("led_mode.auto_save", autoSave ? 1 : 0);
+    await onSaveChanges("led_mode.auto_save", autoSave ? 1 : 0);
   };
 
   const onLedModeChange = async (event) => {
     const v = event.target.value;
     const mode = Math.max(0, Math.min(32, v == "" ? 0 : parseInt(v)));
     await setLedModeDefault(mode);
-    await registerModifications("led_mode.default", mode);
+    await onSaveChanges("led_mode.default", mode);
   };
 
   return (

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -1,0 +1,67 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import FormHelperText from "@mui/material/FormHelperText";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import PreferenceSwitch from "../../components/PreferenceSwitch";
+
+const DefaultLedMode = (props) => {
+  const { t } = useTranslation();
+
+  const { visible, onLedModeChange, ledMode, onAutoSaveChange, autoSave } =
+    props;
+
+  if (!visible) return null;
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <PreferenceSwitch
+        option="keyboard.led.default.autoSave"
+        checked={autoSave}
+        onChange={onAutoSaveChange}
+      />
+      <FormControl sx={{ my: 2 }}>
+        <TextField
+          disabled={autoSave}
+          label={t("preferences.keyboard.led.default.label")}
+          type="number"
+          min={0}
+          max={31}
+          value={ledMode}
+          onChange={onLedModeChange}
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+        <FormHelperText>
+          {t("preferences.keyboard.led.default.help")}
+        </FormHelperText>
+      </FormControl>
+    </Box>
+  );
+};
+
+export { DefaultLedMode as default };

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -42,10 +42,6 @@ const DefaultLedMode = (props) => {
   };
   const loaded = usePluginEffect(initialize);
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   const onAutoSaveChange = async (event) => {
     const autoSave = event.target.checked;
     await setLedModeAutoSave(autoSave);
@@ -59,13 +55,10 @@ const DefaultLedMode = (props) => {
     await registerModifications("led_mode.default", mode);
   };
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   return (
     <>
       <PreferenceSwitch
+        loaded={loaded}
         option="keyboard.led.default.autoSave"
         checked={ledModeAutoSave}
         onChange={onAutoSaveChange}
@@ -80,19 +73,23 @@ const DefaultLedMode = (props) => {
           </Typography>
         </Box>
         <span style={{ flexGrow: 1 }} />
-        <TextField
-          sx={{ width: "10em" }}
-          size="small"
-          disabled={ledModeAutoSave}
-          type="number"
-          min={0}
-          max={31}
-          value={ledModeDefault}
-          onChange={onLedModeChange}
-          InputLabelProps={{
-            shrink: true,
-          }}
-        />
+        {loaded ? (
+          <TextField
+            sx={{ width: "10em" }}
+            size="small"
+            disabled={ledModeAutoSave}
+            type="number"
+            min={0}
+            max={31}
+            value={ledModeDefault}
+            onChange={onLedModeChange}
+            InputLabelProps={{
+              shrink: true,
+            }}
+          />
+        ) : (
+          <Skeleton variant="rectangle" width="10em" height={40} />
+        )}
       </Box>
     </>
   );

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -20,46 +20,27 @@ import Skeleton from "@mui/material/Skeleton";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useEffect, useState, useContext } from "react";
+import usePluginEffect from "@renderer/hooks/usePluginEffect";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSwitch from "../../components/PreferenceSwitch";
 
 const DefaultLedMode = (props) => {
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-
-  const [activeDevice] = globalContext.state.activeDevice;
-  const [ledModeDefault, setLedModeDefault] = useState(0);
-  const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
-  const [loaded, setLoaded] = useState(false);
-
   const { registerModifications } = props;
 
-  useEffect(() => {
-    const initialize = async () => {
-      const def = await activeDevice.focus.command("led_mode.default");
-      const autoSave = await activeDevice.focus.command("led_mode.auto_save");
+  const [ledModeDefault, setLedModeDefault] = useState(0);
+  const [ledModeAutoSave, setLedModeAutoSave] = useState(true);
 
-      setLedModeDefault(parseInt(def));
-      setLedModeAutoSave(autoSave == "1");
-      setLoaded(true);
-    };
+  const initialize = async (focus) => {
+    const def = await focus.command("led_mode.default");
+    const autoSave = await focus.command("led_mode.auto_save");
 
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await initialize();
-      }
-    };
-
-    initialize();
-
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [activeDevice]);
+    setLedModeDefault(parseInt(def));
+    setLedModeAutoSave(autoSave == "1");
+  };
+  const loaded = usePluginEffect(initialize);
 
   if (!loaded) {
     return <Skeleton variant="rectangle" />;

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -15,16 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
 
 import usePluginEffect from "@renderer/hooks/usePluginEffect";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSwitch from "../../components/PreferenceSwitch";
+import PreferenceWithHeading from "../../components/PreferenceWithHeading";
 
 const DefaultLedMode = (props) => {
   const { t } = useTranslation();
@@ -63,16 +62,10 @@ const DefaultLedMode = (props) => {
         checked={ledModeAutoSave}
         onChange={onAutoSaveChange}
       />
-      <Box sx={{ display: "flex" }}>
-        <Box>
-          <Typography variant="body1">
-            {t("preferences.keyboard.led.default.label")}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {t("preferences.keyboard.led.default.help")}
-          </Typography>
-        </Box>
-        <span style={{ flexGrow: 1 }} />
+      <PreferenceWithHeading
+        heading={t("preferences.keyboard.led.default.label")}
+        subheading={t("preferences.keyboard.led.default.help")}
+      >
         {loaded ? (
           <TextField
             sx={{ width: "10em" }}
@@ -90,7 +83,7 @@ const DefaultLedMode = (props) => {
         ) : (
           <Skeleton variant="rectangle" width="10em" height={40} />
         )}
-      </Box>
+      </PreferenceWithHeading>
     </>
   );
 };

--- a/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/DefaultLedMode.js
@@ -16,12 +16,8 @@
  */
 
 import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -37,16 +33,26 @@ const DefaultLedMode = (props) => {
   if (!visible) return null;
 
   return (
-    <Box sx={{ my: 2 }}>
+    <>
       <PreferenceSwitch
         option="keyboard.led.default.autoSave"
         checked={autoSave}
         onChange={onAutoSaveChange}
       />
-      <FormControl sx={{ my: 2 }}>
+      <Box sx={{ display: "flex" }}>
+        <Box>
+          <Typography variant="body1">
+            {t("preferences.keyboard.led.default.label")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t("preferences.keyboard.led.default.help")}
+          </Typography>
+        </Box>
+        <span style={{ flexGrow: 1 }} />
         <TextField
+          sx={{ width: "10em" }}
+          size="small"
           disabled={autoSave}
-          label={t("preferences.keyboard.led.default.label")}
           type="number"
           min={0}
           max={31}
@@ -56,11 +62,8 @@ const DefaultLedMode = (props) => {
             shrink: true,
           }}
         />
-        <FormHelperText>
-          {t("preferences.keyboard.led.default.help")}
-        </FormHelperText>
-      </FormControl>
-    </Box>
+      </Box>
+    </>
   );
 };
 

--- a/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
@@ -29,7 +29,7 @@ import { useTranslation } from "react-i18next";
 
 const IdleTimeLimit = (props) => {
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
 
@@ -44,7 +44,7 @@ const IdleTimeLimit = (props) => {
   const onChange = async (event) => {
     const limit = event.target.checked;
     await setLedIdleTimeLimit(limit);
-    await registerModifications("idleleds.time_limit", limit);
+    await onSaveChanges("idleleds.time_limit", limit);
   };
 
   return (

--- a/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
@@ -47,10 +47,6 @@ const IdleTimeLimit = (props) => {
     await registerModifications("idleleds.time_limit", limit);
   };
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   return (
     <Box sx={{ display: "flex" }}>
       <Box>
@@ -62,47 +58,51 @@ const IdleTimeLimit = (props) => {
         </Typography>
       </Box>
       <span style={{ flexGrow: 1 }} />
-      <FormControl size="small">
-        <Select
-          onChange={onChange}
-          value={ledIdleTimeLimit}
-          sx={{ width: "10em" }}
-        >
-          <MenuItem value={0}>
-            {t("preferences.keyboard.led.idle.disabled")}
-          </MenuItem>
-          <MenuItem value={60}>
-            {t("preferences.keyboard.led.idle.oneMinute")}
-          </MenuItem>
-          <MenuItem value={120}>
-            {t("preferences.keyboard.led.idle.twoMinutes")}
-          </MenuItem>
-          <MenuItem value={180}>
-            {t("preferences.keyboard.led.idle.threeMinutes")}
-          </MenuItem>
-          <MenuItem value={240}>
-            {t("preferences.keyboard.led.idle.fourMinutes")}
-          </MenuItem>
-          <MenuItem value={300}>
-            {t("preferences.keyboard.led.idle.fiveMinutes")}
-          </MenuItem>
-          <MenuItem value={600}>
-            {t("preferences.keyboard.led.idle.tenMinutes")}
-          </MenuItem>
-          <MenuItem value={900}>
-            {t("preferences.keyboard.led.idle.fifteenMinutes")}
-          </MenuItem>
-          <MenuItem value={1200}>
-            {t("preferences.keyboard.led.idle.twentyMinutes")}
-          </MenuItem>
-          <MenuItem value={1800}>
-            {t("preferences.keyboard.led.idle.thirtyMinutes")}
-          </MenuItem>
-          <MenuItem value={3600}>
-            {t("preferences.keyboard.led.idle.sixtyMinutes")}
-          </MenuItem>
-        </Select>
-      </FormControl>
+      {loaded ? (
+        <FormControl size="small">
+          <Select
+            onChange={onChange}
+            value={ledIdleTimeLimit}
+            sx={{ width: "10em" }}
+          >
+            <MenuItem value={0}>
+              {t("preferences.keyboard.led.idle.disabled")}
+            </MenuItem>
+            <MenuItem value={60}>
+              {t("preferences.keyboard.led.idle.oneMinute")}
+            </MenuItem>
+            <MenuItem value={120}>
+              {t("preferences.keyboard.led.idle.twoMinutes")}
+            </MenuItem>
+            <MenuItem value={180}>
+              {t("preferences.keyboard.led.idle.threeMinutes")}
+            </MenuItem>
+            <MenuItem value={240}>
+              {t("preferences.keyboard.led.idle.fourMinutes")}
+            </MenuItem>
+            <MenuItem value={300}>
+              {t("preferences.keyboard.led.idle.fiveMinutes")}
+            </MenuItem>
+            <MenuItem value={600}>
+              {t("preferences.keyboard.led.idle.tenMinutes")}
+            </MenuItem>
+            <MenuItem value={900}>
+              {t("preferences.keyboard.led.idle.fifteenMinutes")}
+            </MenuItem>
+            <MenuItem value={1200}>
+              {t("preferences.keyboard.led.idle.twentyMinutes")}
+            </MenuItem>
+            <MenuItem value={1800}>
+              {t("preferences.keyboard.led.idle.thirtyMinutes")}
+            </MenuItem>
+            <MenuItem value={3600}>
+              {t("preferences.keyboard.led.idle.sixtyMinutes")}
+            </MenuItem>
+          </Select>
+        </FormControl>
+      ) : (
+        <Skeleton variant="rectangle" width="10em" height={40} />
+      )}
     </Box>
   );
 };

--- a/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
@@ -16,16 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
-import Typography from "@mui/material/Typography";
 
 import usePluginEffect from "@renderer/hooks/usePluginEffect";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import PreferenceWithHeading from "../../components/PreferenceWithHeading";
 
 const IdleTimeLimit = (props) => {
   const { t } = useTranslation();
@@ -48,16 +48,10 @@ const IdleTimeLimit = (props) => {
   };
 
   return (
-    <Box sx={{ display: "flex" }}>
-      <Box>
-        <Typography variant="body1">
-          {t("preferences.keyboard.led.idle.label")}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {t("preferences.keyboard.led.idle.help")}
-        </Typography>
-      </Box>
-      <span style={{ flexGrow: 1 }} />
+    <PreferenceWithHeading
+      heading={t("preferences.keyboard.led.idle.label")}
+      subheading={t("preferences.keyboard.led.idle.help")}
+    >
       {loaded ? (
         <FormControl size="small">
           <Select
@@ -103,7 +97,7 @@ const IdleTimeLimit = (props) => {
       ) : (
         <Skeleton variant="rectangle" width="10em" height={40} />
       )}
-    </Box>
+    </PreferenceWithHeading>
   );
 };
 

--- a/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
-import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
 
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -33,49 +33,54 @@ const IdleTimeLimit = (props) => {
   if (!visible) return null;
 
   return (
-    <FormControl sx={{ minWidth: "20em", mb: 2 }}>
-      <InputLabel>{t("preferences.keyboard.led.idle.label")}</InputLabel>
-      <Select
-        onChange={onChange}
-        value={value}
-        label={t("preferences.keyboard.led.idle.label")}
-      >
-        <MenuItem value={0}>
-          {t("preferences.keyboard.led.idle.disabled")}
-        </MenuItem>
-        <MenuItem value={60}>
-          {t("preferences.keyboard.led.idle.oneMinute")}
-        </MenuItem>
-        <MenuItem value={120}>
-          {t("preferences.keyboard.led.idle.twoMinutes")}
-        </MenuItem>
-        <MenuItem value={180}>
-          {t("preferences.keyboard.led.idle.threeMinutes")}
-        </MenuItem>
-        <MenuItem value={240}>
-          {t("preferences.keyboard.led.idle.fourMinutes")}
-        </MenuItem>
-        <MenuItem value={300}>
-          {t("preferences.keyboard.led.idle.fiveMinutes")}
-        </MenuItem>
-        <MenuItem value={600}>
-          {t("preferences.keyboard.led.idle.tenMinutes")}
-        </MenuItem>
-        <MenuItem value={900}>
-          {t("preferences.keyboard.led.idle.fifteenMinutes")}
-        </MenuItem>
-        <MenuItem value={1200}>
-          {t("preferences.keyboard.led.idle.twentyMinutes")}
-        </MenuItem>
-        <MenuItem value={1800}>
-          {t("preferences.keyboard.led.idle.thirtyMinutes")}
-        </MenuItem>
-        <MenuItem value={3600}>
-          {t("preferences.keyboard.led.idle.sixtyMinutes")}
-        </MenuItem>
-      </Select>
-      <FormHelperText>{t("preferences.keyboard.led.idle.help")}</FormHelperText>
-    </FormControl>
+    <Box sx={{ display: "flex" }}>
+      <Box>
+        <Typography variant="body1">
+          {t("preferences.keyboard.led.idle.label")}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t("preferences.keyboard.led.idle.help")}
+        </Typography>
+      </Box>
+      <span style={{ flexGrow: 1 }} />
+      <FormControl size="small">
+        <Select onChange={onChange} value={value} sx={{ width: "10em" }}>
+          <MenuItem value={0}>
+            {t("preferences.keyboard.led.idle.disabled")}
+          </MenuItem>
+          <MenuItem value={60}>
+            {t("preferences.keyboard.led.idle.oneMinute")}
+          </MenuItem>
+          <MenuItem value={120}>
+            {t("preferences.keyboard.led.idle.twoMinutes")}
+          </MenuItem>
+          <MenuItem value={180}>
+            {t("preferences.keyboard.led.idle.threeMinutes")}
+          </MenuItem>
+          <MenuItem value={240}>
+            {t("preferences.keyboard.led.idle.fourMinutes")}
+          </MenuItem>
+          <MenuItem value={300}>
+            {t("preferences.keyboard.led.idle.fiveMinutes")}
+          </MenuItem>
+          <MenuItem value={600}>
+            {t("preferences.keyboard.led.idle.tenMinutes")}
+          </MenuItem>
+          <MenuItem value={900}>
+            {t("preferences.keyboard.led.idle.fifteenMinutes")}
+          </MenuItem>
+          <MenuItem value={1200}>
+            {t("preferences.keyboard.led.idle.twentyMinutes")}
+          </MenuItem>
+          <MenuItem value={1800}>
+            {t("preferences.keyboard.led.idle.thirtyMinutes")}
+          </MenuItem>
+          <MenuItem value={3600}>
+            {t("preferences.keyboard.led.idle.sixtyMinutes")}
+          </MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
   );
 };
 

--- a/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
+++ b/src/renderer/screens/Preferences/keyboard/leds/IdleTimeLimit.js
@@ -23,42 +23,23 @@ import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useEffect, useState, useContext } from "react";
+import usePluginEffect from "@renderer/hooks/usePluginEffect";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const IdleTimeLimit = (props) => {
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-
-  const [activeDevice] = globalContext.state.activeDevice;
-  const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
-  const [loaded, setLoaded] = useState(false);
-
   const { registerModifications } = props;
 
-  useEffect(() => {
-    const initialize = async () => {
-      let limit = await activeDevice.focus.command("idleleds.time_limit");
-      limit = parseInt(limit);
+  const [ledIdleTimeLimit, setLedIdleTimeLimit] = useState(0);
 
-      setLedIdleTimeLimit(limit);
-      setLoaded(true);
-    };
+  const initialize = async (focus) => {
+    let limit = await focus.command("idleleds.time_limit");
+    limit = parseInt(limit);
 
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await initialize();
-      }
-    };
-
-    initialize();
-
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [activeDevice]);
+    setLedIdleTimeLimit(limit);
+  };
+  const loaded = usePluginEffect(initialize);
 
   const onChange = async (event) => {
     const limit = event.target.checked;

--- a/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
@@ -31,7 +31,7 @@ const EscapeOneShotPreferences = (props) => {
   const escKeyCode = 41;
 
   const { t } = useTranslation();
-  const { registerModifications } = props;
+  const { onSaveChanges } = props;
 
   const [escOneShot, setEscOneShot] = useState(true);
 
@@ -53,7 +53,7 @@ const EscapeOneShotPreferences = (props) => {
   const onChange = async (event) => {
     const v = event.target.checked;
     await setEscOneShot(v);
-    await registerModifications(
+    await onSaveChanges(
       "escape_oneshot.cancel_key",
       v ? escKeyCode : oneShotCancelKeyCode
     );

--- a/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
@@ -17,7 +17,6 @@
 
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
-import Skeleton from "@mui/material/Skeleton";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
@@ -60,13 +59,10 @@ const EscapeOneShotPreferences = (props) => {
     );
   };
 
-  if (!loaded) {
-    return <Skeleton variant="rectangle" />;
-  }
-
   return (
     <PreferenceSwitch
       option="keyboard.plugins.escOneShot"
+      loaded={loaded}
       checked={escOneShot}
       onChange={onChange}
     />

--- a/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
@@ -21,10 +21,10 @@ import Skeleton from "@mui/material/Skeleton";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
+import usePluginEffect from "@renderer/hooks/usePluginEffect";
 import PreferenceSwitch from "../../components/PreferenceSwitch";
 
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import React, { useEffect, useState, useContext } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const EscapeOneShotPreferences = (props) => {
@@ -32,42 +32,24 @@ const EscapeOneShotPreferences = (props) => {
   const escKeyCode = 41;
 
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-
-  const [activeDevice] = globalContext.state.activeDevice;
-  const [escOneShot, setEscOneShot] = useState(true);
-  const [loaded, setLoaded] = useState(false);
-
   const { registerModifications } = props;
 
-  useEffect(() => {
-    const initialize = async () => {
-      const doesEscCancelOneShot = (value) => {
-        if (value.length == 0) {
-          return false;
-        }
+  const [escOneShot, setEscOneShot] = useState(true);
 
-        return parseInt(value) == escKeyCode;
-      };
-
-      const key = await activeDevice.focus.command("escape_oneshot.cancel_key");
-      setEscOneShot(doesEscCancelOneShot(key));
-      setLoaded(true);
-    };
-
-    const context_bar_channel = new BroadcastChannel("context_bar");
-    context_bar_channel.onmessage = async (event) => {
-      if (event.data === "changes-discarded") {
-        await initialize();
+  const initialize = async (focus) => {
+    const doesEscCancelOneShot = (value) => {
+      if (value.length == 0) {
+        return false;
       }
+
+      return parseInt(value) == escKeyCode;
     };
 
-    initialize();
+    const key = await focus.command("escape_oneshot.cancel_key");
+    setEscOneShot(doesEscCancelOneShot(key));
+  };
 
-    return () => {
-      context_bar_channel.close();
-    };
-  }, [activeDevice]);
+  const loaded = usePluginEffect(initialize);
 
   const onChange = async (event) => {
     const v = event.target.checked;

--- a/src/renderer/screens/Preferences/ui/LayoutCardsPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutCardsPreferences.js
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Skeleton from "@mui/material/Skeleton";
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -47,15 +46,12 @@ function LayoutCardsPreferences(props) {
 
   return (
     <PreferenceSection name="ui.layoutCards">
-      {loaded ? (
-        <PreferenceSwitch
-          option="ui.coloredLayoutCards"
-          checked={coloredLayoutCards}
-          onChange={toggleColoredLayoutCards}
-        />
-      ) : (
-        <Skeleton variant="text" width="100%" height={56} />
-      )}
+      <PreferenceSwitch
+        loaded={loaded}
+        option="ui.coloredLayoutCards"
+        checked={coloredLayoutCards}
+        onChange={toggleColoredLayoutCards}
+      />
     </PreferenceSection>
   );
 }

--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -18,10 +18,13 @@
 import KeymapDB from "@api/focus/keymap/db";
 
 import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
 import Skeleton from "@mui/material/Skeleton";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -35,37 +38,24 @@ const settings = new Store();
 const db = new KeymapDB();
 
 const LayoutSelect = (props) => {
-  const { layout, setLayout, ...rest } = props;
-  const { t } = useTranslation();
-  const platforms = {
-    linux: "Linux",
-    win32: "Windows",
-    darwin: "macOS",
-  };
-  const hostos = platforms[process.platform];
-  const label = t("preferences.ui.host.layout", {
-    hostos: hostos,
-  });
+  const { layout, setLayout } = props;
 
   const changeLayout = (_, value) => {
     setLayout(value || props.layout);
   };
 
   return (
-    <FormControl {...rest}>
-      <Autocomplete
-        value={layout}
-        groupBy={(option) => db.getLayoutLanguage(option)}
-        onChange={changeLayout}
-        options={db.getSupportedLayouts()}
-        getOptionLabel={(option) => option}
-        disableClearable
-        renderInput={(params) => (
-          <TextField {...params} label={label} variant="outlined" />
-        )}
-      />
-      <FormHelperText>{t("preferences.ui.host.help")}</FormHelperText>
-    </FormControl>
+    <Autocomplete
+      size="small"
+      sx={{ minWidth: "20em" }}
+      value={layout}
+      groupBy={(option) => db.getLayoutLanguage(option)}
+      onChange={changeLayout}
+      options={db.getSupportedLayouts()}
+      getOptionLabel={(option) => option}
+      disableClearable
+      renderInput={(params) => <TextField {...params} variant="outlined" />}
+    />
   );
 };
 
@@ -115,18 +105,23 @@ function LayoutEditorPreferences(props) {
 
   return (
     <PreferenceSection name="ui.layoutEditor">
-      {loaded ? (
-        <LayoutSelect
-          sx={{
-            my: 2,
-            minWidth: "20em",
-          }}
-          layout={layout}
-          setLayout={changeLayout}
-        />
-      ) : (
-        <Skeleton variant="rectangular" width={320} height={111} />
-      )}
+      <Box sx={{ display: "flex" }}>
+        <Box sx={{ my: "auto" }}>
+          <Typography variant="body1">
+            {t("preferences.ui.host.label")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t("preferences.ui.host.help")}
+          </Typography>
+        </Box>
+        <span style={{ flexGrow: 1 }} />
+        {loaded ? (
+          <LayoutSelect layout={layout} setLayout={changeLayout} />
+        ) : (
+          <Skeleton variant="rectangular" />
+        )}
+      </Box>
+      <Divider sx={{ my: 2, mx: -2 }} />
       {loaded ? (
         <PreferenceSwitch
           option="ui.hideUnavailableFeatures"

--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -122,15 +122,12 @@ function LayoutEditorPreferences(props) {
         )}
       </Box>
       <Divider sx={{ my: 2, mx: -2 }} />
-      {loaded ? (
-        <PreferenceSwitch
-          option="ui.hideUnavailableFeatures"
-          checked={hideUnavailableFeatures}
-          onChange={toggleHideUnavailableFeatures}
-        />
-      ) : (
-        <Skeleton variant="text" width="100%" height={56} />
-      )}
+      <PreferenceSwitch
+        loaded={loaded}
+        option="ui.hideUnavailableFeatures"
+        checked={hideUnavailableFeatures}
+        onChange={toggleHideUnavailableFeatures}
+      />
     </PreferenceSection>
   );
 }

--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -18,19 +18,16 @@
 import KeymapDB from "@api/focus/keymap/db";
 
 import Autocomplete from "@mui/material/Autocomplete";
-import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
-import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
 import Skeleton from "@mui/material/Skeleton";
 import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
 
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
 import PreferenceSwitch from "../components/PreferenceSwitch";
+import PreferenceWithHeading from "../components/PreferenceWithHeading";
 
 const Store = require("electron-store");
 const settings = new Store();
@@ -105,22 +102,16 @@ function LayoutEditorPreferences(props) {
 
   return (
     <PreferenceSection name="ui.layoutEditor">
-      <Box sx={{ display: "flex" }}>
-        <Box sx={{ my: "auto" }}>
-          <Typography variant="body1">
-            {t("preferences.ui.host.label")}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {t("preferences.ui.host.help")}
-          </Typography>
-        </Box>
-        <span style={{ flexGrow: 1 }} />
+      <PreferenceWithHeading
+        heading={t("preferences.ui.host.label")}
+        subheading={t("preferences.ui.host.help")}
+      >
         {loaded ? (
           <LayoutSelect layout={layout} setLayout={changeLayout} />
         ) : (
           <Skeleton variant="rectangular" />
         )}
-      </Box>
+      </PreferenceWithHeading>
       <Divider sx={{ my: 2, mx: -2 }} />
       <PreferenceSwitch
         loaded={loaded}

--- a/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
@@ -30,6 +30,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
+import PreferenceWithHeading from "../components/PreferenceWithHeading";
 
 const Store = require("electron-store");
 const settings = new Store();
@@ -190,11 +191,7 @@ function LookAndFeelPreferences(props) {
         />
       </Box>
       <Divider sx={{ my: 2, mx: -2 }} />
-      <Box sx={{ display: "flex" }}>
-        <Typography sx={{ my: "auto" }} variant="body1">
-          {t("preferences.ui.language.help")}
-        </Typography>
-        <span style={{ flexGrow: 1 }} />
+      <PreferenceWithHeading heading={t("preferences.ui.language.help")}>
         <Select
           size="small"
           value={language}
@@ -203,7 +200,7 @@ function LookAndFeelPreferences(props) {
         >
           {languages}
         </Select>
-      </Box>
+      </PreferenceWithHeading>
     </PreferenceSection>
   );
 }

--- a/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
@@ -16,15 +16,15 @@
  */
 
 import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import FormLabel from "@mui/material/FormLabel";
-import FormHelperText from "@mui/material/FormHelperText";
-import InputLabel from "@mui/material/InputLabel";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
-import Radio from "@mui/material/Radio";
-import RadioGroup from "@mui/material/RadioGroup";
 import Select from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import { styled } from "@mui/material/styles";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -34,17 +34,88 @@ import PreferenceSection from "../components/PreferenceSection";
 const Store = require("electron-store");
 const settings = new Store();
 
+const memoize = (factory, ctx) => {
+  var cache = {};
+  return (key) => {
+    if (!(key in cache)) {
+      cache[key] = factory.call(ctx, key);
+    }
+    return cache[key];
+  };
+};
+
+const colorToRGBA = (() => {
+  var canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  var ctx = canvas.getContext("2d");
+
+  return memoize((col) => {
+    ctx.clearRect(0, 0, 1, 1);
+    // In order to detect invalid values,
+    // we can't rely on col being in the same format as what fillStyle is computed as,
+    // but we can ask it to implicitly compute a normalized value twice and compare.
+    ctx.fillStyle = "#000";
+    ctx.fillStyle = col;
+    var computed = ctx.fillStyle;
+    ctx.fillStyle = "#fff";
+    ctx.fillStyle = col;
+    if (computed !== ctx.fillStyle) {
+      return; // invalid color
+    }
+    ctx.fillRect(0, 0, 1, 1);
+    return [...ctx.getImageData(0, 0, 1, 1).data];
+  });
+})();
+
+const ModeCardBase = (props) => {
+  const { t } = useTranslation();
+  const { raised, onClick, name, image, ...rest } = props;
+
+  return (
+    <Card raised={raised} {...rest}>
+      <CardActionArea onClick={onClick}>
+        <CardMedia height="66">{image}</CardMedia>
+        <CardContent>
+          <Typography variant="caption" color="text.secondary">
+            {t(`preferences.ui.theme.${name}`)}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};
+
+const ModeCard = styled(ModeCardBase)((props) => {
+  const { theme, raised } = props;
+
+  if (raised) {
+    const color = colorToRGBA(theme.palette.primary[theme.palette.mode]);
+    return {
+      width: 120,
+      marginLeft: `${theme.spacing(2)}`,
+      marginRight: `${theme.spacing(2)}`,
+      boxShadow: `0px 5px 5px -3px rgb(${color[0]} ${color[1]} ${color[2]} / 40%),
+                  0px 8px 10px 1px rgb(${color[0]} ${color[1]} ${color[2]} / 28%),
+                  0px 3px 14px 2px rgb(${color[0]} ${color[1]} ${color[2]} / 24%)`,
+    };
+  } else {
+    return {
+      width: 120,
+      marginLeft: `${theme.spacing(2)}`,
+      marginRight: `${theme.spacing(2)}`,
+    };
+  }
+});
+
 function LookAndFeelPreferences(props) {
   const { t, i18n } = useTranslation();
   const globalContext = React.useContext(GlobalContext);
   const [theme, setTheme] = globalContext.state.theme;
   const [language, setLanguage] = useState(i18n.language);
 
-  const changeTheme = async (event) => {
-    const newTheme = event.target.value;
-
-    settings.set("ui.theme", newTheme);
-    setTheme(newTheme);
+  const changeTheme = (name) => (event) => {
+    settings.set("ui.theme", name);
+    setTheme(name);
   };
 
   const updateLanguage = async (event) => {
@@ -65,40 +136,73 @@ function LookAndFeelPreferences(props) {
     );
   });
 
+  const systemSvg = (
+    <svg
+      width="120"
+      height="73"
+      viewBox="0 0 120 73"
+      fill="none"
+      xmlns="https://www.w3.org/2000/svg"
+    >
+      <path d="M0 0L120 73H0V0Z" fill="#1B1B1B" />
+      <path d="M120 73L5.94475e-06 -7.78063e-06L120 0L120 73Z" fill="#EDEDED" />
+    </svg>
+  );
+
+  const solidSvg = (color) => (
+    <svg
+      width="120"
+      height="73"
+      viewBox="0 0 120 73"
+      fill="none"
+      xmlns="https://www.w3.org/2000/svg"
+    >
+      <rect width="100%" height="100%" fill={color} />
+    </svg>
+  );
+
+  const lightSvg = solidSvg("#EDEDED");
+  const darkSvg = solidSvg("#1b1b1b");
+
   return (
     <PreferenceSection name="ui.lookNFeel">
-      <FormControl sx={{ minWidth: "20em" }}>
-        <InputLabel>{t("preferences.ui.language.label")}</InputLabel>
+      <Typography sx={{ my: "auto" }} variant="body1">
+        {t("preferences.ui.theme.label")}
+      </Typography>
+      <Box sx={{ display: "inline-flex", my: 2 }}>
+        <ModeCard
+          name="system"
+          image={systemSvg}
+          raised={theme == "system"}
+          onClick={changeTheme("system")}
+        />
+        <ModeCard
+          name="light"
+          image={lightSvg}
+          raised={theme == "light"}
+          onClick={changeTheme("light")}
+        />
+        <ModeCard
+          name="dark"
+          image={darkSvg}
+          raised={theme == "dark"}
+          onClick={changeTheme("dark")}
+        />
+      </Box>
+      <Divider sx={{ my: 2, mx: -2 }} />
+      <Box sx={{ display: "flex" }}>
+        <Typography sx={{ my: "auto" }} variant="body1">
+          {t("preferences.ui.language.help")}
+        </Typography>
+        <span style={{ flexGrow: 1 }} />
         <Select
+          size="small"
           value={language}
           onChange={updateLanguage}
-          label={t("preferences.ui.language.label")}
+          sx={{ minWidth: "10em" }}
         >
           {languages}
         </Select>
-        <FormHelperText>{t("preferences.ui.language.help")}</FormHelperText>
-      </FormControl>
-      <Box sx={{ my: 2 }}>
-        <FormControl>
-          <FormLabel>{t("preferences.ui.theme.label")}</FormLabel>
-          <RadioGroup value={theme} onChange={changeTheme} sx={{ ml: 1 }}>
-            <FormControlLabel
-              value="system"
-              control={<Radio />}
-              label={t("preferences.ui.theme.system")}
-            />
-            <FormControlLabel
-              value="light"
-              control={<Radio />}
-              label={t("preferences.ui.theme.light")}
-            />
-            <FormControlLabel
-              value="dark"
-              control={<Radio />}
-              label={t("preferences.ui.theme.dark")}
-            />
-          </RadioGroup>
-        </FormControl>
       </Box>
     </PreferenceSection>
   );

--- a/src/renderer/screens/Preferences/utils/dividePreferences.js
+++ b/src/renderer/screens/Preferences/utils/dividePreferences.js
@@ -1,0 +1,33 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import Divider from "@mui/material/Divider";
+
+export const dividePreferences = (plugins, components, onSaveChanges, key) => {
+  const result = [];
+  components.forEach(({ plugin, Component }, index) => {
+    if (plugins[plugin]) {
+      result.push(
+        <Component onSaveChanges={onSaveChanges} key={`${key}/${index}`} />
+      );
+      result.push(<Divider sx={{ mx: -2, my: 2 }} />);
+    }
+  });
+  result.pop();
+  return result;
+};

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -105,10 +105,3 @@ button {
     -webkit-print-color-adjust: exact;
   }
 }
-
-html,
-body,
-#app,
-#router {
-  height: 100%;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9583,7 +9583,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9796,6 +9796,21 @@ react-draggable@4.4.4:
     clsx "^1.1.1"
     prop-types "^15.6.0"
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-i18next@^11.8.5:
   version "11.16.9"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.16.9.tgz#890cdac0c49120e075d6c520b43dbad3f91bd2df"
@@ -9855,6 +9870,11 @@ react-rnd@^10.3.7:
     re-resizable "6.9.6"
     react-draggable "4.4.4"
     tslib "2.3.1"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-transition-group@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
Inspired by a combination of great suggestions given in [#880](https://github.com/keyboardio/Chrysalis/issues/880#issuecomment-1142443368), and [review notes](https://github.com/keyboardio/Chrysalis/pull/879#discussion_r885951725) in [#879](https://github.com/keyboardio/Chrysalis/pull/879#issuecomment-1142458353), I had another pass on the Preferences screen, and everything beneath.

The visible results are best explained in a video, just below. For demonstration purposes, all communication between keyboard and host had a two second delay added. Under normal circumstances, things are much, much more snappy - but I wanted to show how Skeletons appear during load.

https://user-images.githubusercontent.com/17243/171470122-7dc43ec8-5b90-4e15-820d-57667d46fe50.mp4

Under the hood, lots of cleanups have been made. I extracted common parts into hooks, where that made sense, and redid the whole My Keyboards architecture. Previously, it was MyKeyboards that held all the knowledge, all the state, and pushed that down to its children. That made it complicated and painful to add support for new plugins, because the state would need to be added to MyKeyboards, then pushed down to the component that actually renders the inputs, usually with one or two more components inbetween.

In the new MyKeyboards architecture, none of that happens. MyKeyboards lets its children register a callback to run when things need to be saved, and lets them handle the state and data fetching and whatnot. This pushes the data fetching into the components that do the display. It's all in one place. On top of that, because there are many common operations, those were extracted into hooks, so the leaf components don't even need to pull in GlobalState for activeDevice - the hooks handle that for us. So it's mostly just display + some scaffolding to massage the data into a shape we can use.

Fixes #880 and also fixes #846, since it's build on the now-scrapped #879.