### PR TITLE
api/focus: Add constants to our keymap database

### DIFF
--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -19,6 +19,7 @@ import i18n from "i18next";
 import cldr from "./cldr";
 import { Base } from "./db/base";
 import { USQwerty } from "./db/us/qwerty";
+import { constants } from "./db/constants";
 
 global.chrysalis_keymapdb_instance = null;
 
@@ -33,6 +34,7 @@ class KeymapDB {
 
       this.setLayout("English (US)");
       this.loadLayouts();
+      this.constants = constants;
     }
 
     return global.chrysalis_keymapdb_instance;

--- a/src/api/focus/keymap/db/constants.js
+++ b/src/api/focus/keymap/db/constants.js
@@ -1,0 +1,43 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const constants = {
+  codes: {
+    // Keycodes
+    ESCAPE: 41,
+    LEFT_CONTROL: 224,
+    LEFT_SHIFT: 225,
+    LEFT_ALT: 226,
+    LEFT_GUI: 227,
+    RIGHT_CONTROL: 228,
+    RIGHT_SHIFT: 229,
+    RIGHT_ALT: 230,
+    RIGHT_GUI: 231,
+    ONESHOT_CANCEL: 53630,
+    BLOCKED: 65535,
+
+    // Aliases
+    FIRST_MODIFIER: 224,
+    FIRST_ONESHOT_MODIFIER: 49153,
+    EMPTY: 65535,
+  },
+  ranges: {
+    standard: {
+      start: 4,
+      end: 255,
+    },
+  },
+};

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -228,7 +228,7 @@ const Editor = (props) => {
     let empty = true;
     for (const layer of deviceKeymap.custom) {
       for (const i of layer) {
-        if (i.code != 65535) {
+        if (i.code != db.constants.codes.EMPTY) {
           empty = false;
           break;
         }

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -38,8 +38,13 @@ const KeyPicker = (props) => {
   const isStandardKey = (props) => {
     const { currentKey: key } = props;
     const code = key.baseCode || key.code;
+    const stdRange = db.constants.ranges.standard;
 
-    return code >= 4 && code <= 255 && !db.isInCategory(key.code, "dualuse");
+    return (
+      code >= stdRange.start &&
+      code <= stdRange.end &&
+      !db.isInCategory(key.code, "dualuse")
+    );
   };
 
   const isOSM = () => {
@@ -69,11 +74,12 @@ const KeyPicker = (props) => {
 
   const toggleOneShot = (event) => {
     const { currentKey: key } = props;
+    const c = db.constants.codes;
 
     if (event.target.checked) {
-      props.onKeyChange(key.code - 224 + 49153);
+      props.onKeyChange(key.code - c.FIRST_MODIFIER + c.FIRST_ONESHOT_MODIFIER);
     } else {
-      props.onKeyChange(key.code - key.rangeStart + 224);
+      props.onKeyChange(key.code - key.rangeStart + c.FIRST_MODIFIER);
     }
   };
 
@@ -123,6 +129,8 @@ const KeyPicker = (props) => {
   }
 
   const isDU = db.isInCategory(key.code, "dualuse");
+  const isMod = (key, mod) => key.baseCode == mod || key.code == mod;
+  const c = db.constants.codes;
 
   return (
     <Collapsible
@@ -140,27 +148,27 @@ const KeyPicker = (props) => {
             <FormControlLabel
               control={makeSwitch("shift")}
               label="Shift"
-              disabled={key.baseCode == 225 || key.code == 225 || isDU}
+              disabled={isMod(key, c.LEFT_SHIFT) || isDU}
             />
             <FormControlLabel
               control={makeSwitch("ctrl")}
               label="Control"
-              disabled={key.baseCode == 224 || key.code == 224 || isDU}
+              disabled={isMod(key, c.LEFT_CONTROL) || isDU}
             />
             <FormControlLabel
               control={makeSwitch("alt")}
               label="Alt"
-              disabled={key.baseCode == 226 || key.code == 226 || isDU}
+              disabled={isMod(key, c.LEFT_ALT) || isDU}
             />
             <FormControlLabel
               control={makeSwitch("gui")}
               label={GuiLabel.full}
-              disabled={key.baseCode == 227 || key.code == 227 || isDU}
+              disabled={isMod(key, c.LEFT_GUI) || isDU}
             />
             <FormControlLabel
               control={makeSwitch("altgr")}
               label="AltGr"
-              disabled={key.baseCode == 230 || key.code == 230 || isDU}
+              disabled={isMod(key, c.RIGHT_ALT) || isDU}
             />
           </FormGroup>
         </FormControl>

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -24,8 +24,6 @@ import KeyButton from "../components/KeyButton";
 
 const db = new KeymapDB();
 
-const cancelKeyCode = 53630;
-
 const OneShotKeys = (props) => {
   const { t } = useTranslation();
 
@@ -33,16 +31,17 @@ const OneShotKeys = (props) => {
   if (!pluginVisible) return null;
 
   const { currentKey: key } = props;
+  const c = db.constants.codes;
 
   return (
     <React.Fragment>
       <Collapsible
-        expanded={key.code == cancelKeyCode || key.code == 41}
+        expanded={key.code == c.ONESHOT_CANCEL || key.code == c.ESCAPE}
         title={t("editor.sidebar.oneshot.title")}
         help={t("editor.sidebar.oneshot.help")}
       >
         <KeyButton
-          keyObj={db.lookup(cancelKeyCode)}
+          keyObj={db.lookup(c.ONESHOT_CANCEL)}
           onKeyChange={props.onKeyChange}
         />
       </Collapsible>

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -50,7 +50,7 @@ const Overview = (props) => {
     for (let index = 0; index < keymap.custom.length; index++) {
       const layer = keymap.custom[index];
       for (let keyIdx = 0; keyIdx < layer.length; keyIdx++) {
-        if (layer[keyIdx].code != 65535) {
+        if (layer[keyIdx].code != db.constants.codes.EMPTY) {
           lastUsedLayer = index;
           break;
         }

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -70,9 +70,10 @@ const SecondaryFunction = (props) => {
   };
 
   const keySupportsSecondaryAction = (key) => {
+    const stdRange = db.constants.ranges.standard;
     return (
-      (key.code >= 4 &&
-        key.code <= 255 &&
+      (key.code >= stdRange.start &&
+        key.code <= stdRange.end &&
         !db.isInCategory(key.code, "modifier")) ||
       db.isInCategory(key.code, "dualuse")
     );

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -84,7 +84,7 @@ const LayoutCard = (props) => {
 
   for (let i = 0; i < keymap.custom.length; i++) {
     for (const j of keymap.custom[i]) {
-      if (j.code != 65535) {
+      if (j.code != db.constants.codes.EMPTY) {
         // If it's not empty, add it to the keymap_pix array
         keymap_pix.push(
           <Box

--- a/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/EscapeOneShot.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import KeymapDB from "@api/focus/keymap/db";
+
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
 import Slider from "@mui/material/Slider";
@@ -26,10 +28,9 @@ import PreferenceSwitch from "../../components/PreferenceSwitch";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-const EscapeOneShotPreferences = (props) => {
-  const oneShotCancelKeyCode = 53630;
-  const escKeyCode = 41;
+const db = new KeymapDB();
 
+const EscapeOneShotPreferences = (props) => {
   const { t } = useTranslation();
   const { onSaveChanges } = props;
 
@@ -41,7 +42,7 @@ const EscapeOneShotPreferences = (props) => {
         return false;
       }
 
-      return parseInt(value) == escKeyCode;
+      return parseInt(value) == db.constants.codes.ESCAPE;
     };
 
     const key = await focus.command("escape_oneshot.cancel_key");
@@ -52,10 +53,11 @@ const EscapeOneShotPreferences = (props) => {
 
   const onChange = async (event) => {
     const v = event.target.checked;
+    const c = db.constants.codes;
     await setEscOneShot(v);
     await onSaveChanges(
       "escape_oneshot.cancel_key",
-      v ? escKeyCode : oneShotCancelKeyCode
+      v ? c.ESCAPE : c.ONESHOT_CANCEL
     );
   };
 


### PR DESCRIPTION
There are a number of places in our code where we need to know the keycode of a particular key. Our keymap database isn't set up for easy queries that'd let us find these codes, and getting there would be complicated, so instead of doing that, I extracted the codes and ranges we used into `db.constants`.

This is a curated list of keycodes Chrysalis needs, and isn't a general purpose list.

All places that were using keycodes directly, either as keycodes, or as part of checking whether a key falls within a range, have been updated to use the new constants table instead.

It still has a bit of duplication, because the constants and the database must be in sync, but as our keycodes are static, this little duplication - a well contained one - is acceptable.

Fixes #877.
