### PR TITLE
CI: Check if yarn.lock is up to date as part of the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
         run: |
           yarn lint:css
           yarn lint:js
+
+      - name: Check if yarn.lock is up to date
+        run: git diff --exit-code -- yarn.lock


### PR DESCRIPTION
It happend a few times before that we updated `package.json`, but forgot to update `yarn.lock`. This extra steps make sure we don't miss that.
