### PR TITLE
Editor: Switch to the default layer, if any

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -258,6 +258,9 @@ const Editor = (props) => {
 
       const deviceMacros = await focus.command("macros");
       setMacros(deviceMacros);
+
+      const defLayer = await focus.command("settings.defaultLayer");
+      if (defLayer <= deviceKeymap.custom.length) setCurrentLayer(defLayer);
     } catch (e) {
       toast.error(e);
       props.onDisconnect();


### PR DESCRIPTION
During `scanKeyboard()`, look at `settings.defaultLayer` too, and if it has a sensible value, set the current layer to that.

Fixes #610.
