### PR TITLE
FirmwareUpdate: Use a regular button with an icon, instead of SaveChangesButton

### DIFF
--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -18,7 +18,6 @@
 import CheckIcon from "@mui/icons-material/Check";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import Fab from "@mui/material/Fab";
 import Tooltip from "@mui/material/Tooltip";
@@ -46,47 +45,19 @@ const SaveChangesButton = (props) => {
     }, 2000);
   };
 
-  const textPart = !props.floating && (
-    <Box
-      sx={{
-        position: "relative",
-        m: 1,
-      }}
-    >
-      <Button
-        variant="contained"
-        disabled={inProgress || (props.disabled && !success)}
-        onClick={handleButtonClick}
-        color={success ? "success" : "primary"}
-        sx={{ "&.Mui-disabled": { backgroundColor: "lightGrey" } }}
-      >
-        {success
-          ? successMessage || i18n.t("components.save.success")
-          : props.children}
-      </Button>
-    </Box>
-  );
-
   const icon = props.icon || <SaveAltIcon />;
 
-  const OptionalTooltip = (props) => {
-    if (props.floating) {
-      return <Tooltip title={props.children}>{props.children}</Tooltip>;
-    }
-    return props.children;
-  };
-
   return (
-    <OptionalTooltip>
+    <Tooltip title={props.children}>
       <Box
         sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "flex-end",
-          position: props.floating && "fixed",
-          bottom: props.floating && 32,
-          left: props.floating && 32,
-          zIndex: props.floating && ((theme) => theme.zIndex.drawer - 1),
+          position: "fixed",
+          bottom: 32,
+          left: 32,
+          zIndex: (theme) => theme.zIndex.drawer - 1,
         }}
       >
         <Box sx={{ position: "relative" }}>
@@ -94,10 +65,6 @@ const SaveChangesButton = (props) => {
             disabled={inProgress || (props.disabled && !success)}
             color={success ? "success" : "primary"}
             onClick={handleButtonClick}
-            sx={{
-              marginRight: "-16px",
-              "&.Mui-disabled": { backgroundColor: "lightGrey" },
-            }}
           >
             {success ? <CheckIcon /> : icon}
           </Fab>
@@ -114,9 +81,8 @@ const SaveChangesButton = (props) => {
             />
           )}
         </Box>
-        {textPart}
       </Box>
-    </OptionalTooltip>
+    </Tooltip>
   );
 };
 

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -409,11 +409,7 @@ const Editor = (props) => {
         keymap={keymap}
         currentKey={currentKey}
       />
-      <SaveChangesButton
-        floating
-        onClick={onApply}
-        disabled={saveChangesDisabled}
-      >
+      <SaveChangesButton onClick={onApply} disabled={saveChangesDisabled}>
         {t("components.save.saveChanges")}
       </SaveChangesButton>
     </React.Fragment>

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -78,7 +78,7 @@ const MyKeyboardPreferences = (props) => {
       <PluginPreferences onSaveChanges={onSaveChanges} />
       <AdvancedKeyboardPreferences />
 
-      <SaveChangesButton floating onClick={saveChanges} disabled={!modified}>
+      <SaveChangesButton onClick={saveChanges} disabled={!modified}>
         {t("components.save.saveChanges")}
       </SaveChangesButton>
     </>


### PR DESCRIPTION
SaveChangesButton was suffering from various UX issues, such as not supporting dark mode in disabled state, and reacting to hover events separately for the circular and the regular part of it (in non-floating mode). The only use of it in non-floating mode was FirmwareUpdate, which this patch changes to use a regular Button, but still conveying similar information.

We originally used `SaveChangesButton` there because we had no other feedback about the progress of the flashing process. We have a Stepper now that adequately fulfills that role, so we no longer need the feedback on the button.

With the only user of non-floating `SaveChangesButton` gone, we can simplify it greatly by removing the text part and all the workarounds that came with it. This restores dark mode support to the button, and also makes the tooltip work again.

**FirmwareUpdate replacement button:**

![Screenshot from 2022-06-03 02-34-38](https://user-images.githubusercontent.com/17243/171762276-3eb1db20-dcb5-413c-87b0-02ecd62ba326.png)
