### PR TITLE
App: Set the onDisconnect property on LayoutCard

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -240,7 +240,10 @@ const App = (props) => {
                       focusDeviceDescriptor={focusDeviceDescriptor}
                       onConnect={onKeyboardConnect}
                     />
-                    <LayoutCard path="/layout-card" />
+                    <LayoutCard
+                      path="/layout-card"
+                      onDisconnect={onKeyboardDisconnect}
+                    />
                     <KeyboardSelect
                       path="/keyboard-select"
                       onConnect={onKeyboardConnect}


### PR DESCRIPTION
For LayoutCard to be able to handle errors properly, it needs the `onDisconnect` handler. Pass it along.

Fixes #896.
