### PR TITLE
Harmonize our IPC call naming

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -93,7 +93,7 @@ class Focus {
 
     for (let attempt = 0; attempt < 10; attempt++) {
       const found = await ipcRenderer.invoke(
-        "usb-scan-for-devices",
+        "usb.scan-for-devices",
         bootloader.productId,
         bootloader.vendorId
       );

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -112,11 +112,11 @@ async function createMainWindow() {
   window.webContents.on("new-window", handleRedirect);
 
   window.webContents.on("devtools-opened", () => {
-    window.webContents.send("devtools-opened");
+    window.webContents.send("devtools.opened");
   });
 
   window.webContents.on("devtools-closed", () => {
-    window.webContents.send("devtools-closed");
+    window.webContents.send("devtools.closed");
   });
 
   windows.push(window);

--- a/src/main/ipc_device_discovery.js
+++ b/src/main/ipc_device_discovery.js
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Focus
-import Focus from "@api/focus";
-import Hardware from "@api/hardware";
 import { BrowserWindow, ipcMain } from "electron";
 import { findByIds, getDeviceList, WebUSB } from "usb";
-const focus = new Focus();
 
 const webusb = new WebUSB({
   allowAllDevices: true,
@@ -30,7 +26,7 @@ export const notifyUsbDisconnect = (event) => {
   const product_id = event?.device?.productId;
   BrowserWindow.getAllWindows().forEach((win) => {
     if (win) {
-      win.send("usb-device-disconnected", vendor_id, product_id);
+      win.send("usb.device-disconnected", vendor_id, product_id);
     }
   });
 };
@@ -39,7 +35,7 @@ export const notifyUsbConnect = (event) => {
   const product_id = event?.device?.productId;
   BrowserWindow.getAllWindows().forEach((win) => {
     if (win) {
-      win.send("usb-device-connected", vendor_id, product_id);
+      win.send("usb.device-connected", vendor_id, product_id);
     }
   });
 };
@@ -61,21 +57,17 @@ export const registerDeviceDiscoveryHandlers = () => {
   // them first to notice disconnects. We do that here.
   webusb.getDevices();
 
-  ipcMain.handle("usb-scan-for-devices", (event) => {
+  ipcMain.handle("usb.scan-for-devices", (event) => {
     const webContents = event.sender;
     const devices = getDeviceList();
     return devices;
   });
-  ipcMain.handle("usb-is-device-connected", (event, vid, pid) => {
+  ipcMain.handle("usb.is-device-connected", (event, vid, pid) => {
     const device = findByIds(vid, pid);
     if (device) {
       return true;
     } else {
       return false;
     }
-  });
-
-  ipcMain.handle("focus-find-serial-devices", (event) => {
-    return focus.find(Hardware.serial);
   });
 };

--- a/src/main/ipc_devtools.js
+++ b/src/main/ipc_devtools.js
@@ -17,16 +17,7 @@
 import { ipcMain } from "electron";
 
 export const registerDevtoolsHandlers = () => {
-  ipcMain.on("show-devtools", (event, boolFocus) => {
-    const webContents = event.sender;
-    if (boolFocus) {
-      webContents.openDevTools();
-    } else {
-      webContents.closeDevTools();
-    }
-  });
-  ipcMain.handle("devtools-is-open", (event) => {
-    const webContents = event.sender;
-    return webContents.isDevToolsOpened();
-  });
+  ipcMain.handle("devtools.open", ({ sender }) => sender.openDevTools());
+  ipcMain.handle("devtools.close", ({ sender }) => sender.closeDevTools());
+  ipcMain.handle("devtools.is-open", ({ sender }) => sender.isDevToolsOpened());
 };

--- a/src/main/ipc_nativetheme.js
+++ b/src/main/ipc_nativetheme.js
@@ -17,14 +17,14 @@
 import { ipcMain, nativeTheme, BrowserWindow } from "electron";
 
 export const registerNativeThemeHandlers = () => {
-  ipcMain.on("native-theme-should-use-dark-colors", (event) => {
+  ipcMain.on("native-theme.should-use-dark-colors", (event) => {
     event.returnValue = nativeTheme.shouldUseDarkColors;
   });
 
   nativeTheme.on("updated", () => {
     BrowserWindow.getAllWindows().forEach((win) => {
       win.webContents.send(
-        "native-theme-updated",
+        "native-theme.updated",
         nativeTheme.shouldUseDarkColors
       );
     });

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -112,17 +112,17 @@ const App = (props) => {
   };
 
   useEffect(() => {
-    ipcRenderer.on("usb-device-disconnected", handleDeviceDisconnect);
-    ipcRenderer.on("native-theme-updated", handleNativeThemeUpdate);
+    ipcRenderer.on("usb.device-disconnected", handleDeviceDisconnect);
+    ipcRenderer.on("native-theme.updated", handleNativeThemeUpdate);
 
     // Specify how to clean up after this effect:
     return function cleanup() {
       ipcRenderer.removeListener(
-        "native-theme-updated",
+        "native-theme.updated",
         handleNativeThemeUpdate
       );
       ipcRenderer.removeListener(
-        "usb-device-disconnected",
+        "usb.device-disconnected",
         handleDeviceDisconnect
       );
     };

--- a/src/renderer/Error.js
+++ b/src/renderer/Error.js
@@ -18,7 +18,7 @@
 import React, { ipcRenderer } from "react";
 
 const Error = () => {
-  ipcRenderer.send("show-devtools", true);
+  ipcRenderer.invoke("devtools.open");
   return (
     <main>
       <h1>An error occurred!</h1>

--- a/src/renderer/components/GlobalContext.js
+++ b/src/renderer/components/GlobalContext.js
@@ -28,7 +28,7 @@ export const GlobalContextProvider = (props) => {
 
   const getDarkMode = () => {
     if (theme == "system") {
-      return ipcRenderer.sendSync("native-theme-should-use-dark-colors");
+      return ipcRenderer.sendSync("native-theme.should-use-dark-colors");
     }
     return theme == "dark";
   };

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -19,6 +19,7 @@ const English = {
   language: "English",
   errors: {
     deviceDisconnected: "Keyboard disconnected",
+    saveFile: "Error saving a file: {{ error }}",
   },
   components: {
     layer: "Layer {{index}}",

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -39,6 +39,6 @@ try {
     document.getElementById("app")
   );
 } catch (e) {
-  ipcRenderer.send("show-devtools", true);
+  ipcRenderer.invoke("devtools.open");
   ReactDOM.render(<Error error={e} />, document.getElementById("app"));
 }

--- a/src/renderer/screens/Editor/Sidebar/LayoutSharing/ExportToFile.js
+++ b/src/renderer/screens/Editor/Sidebar/LayoutSharing/ExportToFile.js
@@ -15,8 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { logger } from "@api/log";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import { toast } from "@renderer/components/Toast";
 import { ipcRenderer } from "electron";
 import jsonStringify from "json-stringify-pretty-compact";
 import React from "react";
@@ -24,14 +26,14 @@ import { useTranslation } from "react-i18next";
 
 export const ExportToFile = (props) => {
   const { t } = useTranslation();
-  const exportToFile = () => {
+  const exportToFile = async () => {
     const { keymap, colormap } = props;
     const data = {
       keymaps: keymap.custom,
       colormaps: colormap.colorMap,
       palette: colormap.palette,
     };
-    ipcRenderer.send("file-save", {
+    const error = await ipcRenderer.sendSync("file.save-with-dialog", {
       content: jsonStringify(data),
       title: t("editor.sharing.selectExportFile"),
       defaultPath: "Layout.json",
@@ -46,6 +48,10 @@ export const ExportToFile = (props) => {
         },
       ],
     });
+    if (error) {
+      logger().error("Error saving a layout export", { error: error });
+      toast.error(t("errors.saveFile", { error: error }));
+    }
   };
   return (
     <Box sx={{ mb: 2 }}>

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -106,7 +106,7 @@ const FirmwareUpdate = (props) => {
       return setFirmwareFilename("");
     }
 
-    const [fileName, fileData] = ipcRenderer.sendSync("file-open", {
+    const [fileName, fileData] = ipcRenderer.sendSync("file.open-with-dialog", {
       title: t("firmwareUpdate.dialog.selectFirmware"),
       filters: [
         {

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -101,13 +101,13 @@ const KeyboardSelect = (props) => {
   });
 
   useEffect(() => {
-    ipcRenderer.on("usb-device-connected", scanDevices);
-    ipcRenderer.on("usb-device-disconnected", scanDevices);
+    ipcRenderer.on("usb.device-connected", scanDevices);
+    ipcRenderer.on("usb.device-disconnected", scanDevices);
 
     // Specify how to clean up after this effect:
     return function cleanup() {
-      ipcRenderer.removeListener("usb-device-connected", scanDevices);
-      ipcRenderer.removeListener("usb-device-disconnected", scanDevices);
+      ipcRenderer.removeListener("usb.device-connected", scanDevices);
+      ipcRenderer.removeListener("usb.device-disconnected", scanDevices);
     };
   });
 

--- a/src/renderer/screens/Preferences/Devtools.js
+++ b/src/renderer/screens/Preferences/Devtools.js
@@ -34,13 +34,13 @@ function DevtoolsPreferences(props) {
 
   useEffect(() => {
     const initialize = async () => {
-      const isOpen = await ipcRenderer.invoke("devtools-is-open");
+      const isOpen = await ipcRenderer.invoke("devtools.is-open");
       await setDevConsole(isOpen);
 
-      ipcRenderer.on("devtools-opened", () => {
+      ipcRenderer.on("devtools.opened", () => {
         setDevConsole(true);
       });
-      ipcRenderer.on("devtools-closed", () => {
+      ipcRenderer.on("devtools.closed", () => {
         setDevConsole(false);
       });
 
@@ -58,17 +58,17 @@ function DevtoolsPreferences(props) {
 
     // Cleanup when component unmounts.
     return () => {
-      ipcRenderer.removeAllListeners("devtools-opened");
-      ipcRenderer.removeAllListeners("devtools-closed");
+      ipcRenderer.removeAllListeners("devtools.opened");
+      ipcRenderer.removeAllListeners("devtools.closed");
     };
   });
 
   const toggleDevConsole = (event) => {
     setDevConsole(event.target.checked);
     if (event.target.checked) {
-      ipcRenderer.send("show-devtools", true);
+      ipcRenderer.invoke("devtools.open");
     } else {
-      ipcRenderer.send("show-devtools", false);
+      ipcRenderer.invoke("devtools.close");
     }
   };
 

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -16,7 +16,7 @@
  */
 
 import Focus from "@api/focus";
-import { collectLogs } from "@api/log";
+import { logger, collectLogs } from "@api/log";
 import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -32,6 +32,7 @@ import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { PageTitle } from "@renderer/components/PageTitle";
+import { toast } from "@renderer/components/Toast";
 import logo from "@renderer/logo-small.png";
 import { version } from "@root/package.json";
 import { ipcRenderer } from "electron";
@@ -55,15 +56,19 @@ function SystemInfo(props) {
   };
 
   const saveBundle = async () => {
-    ipcRenderer.send("file-save", {
+    const error = await ipcRenderer.sendSync("file.save-with-dialog", {
       content: jsonStringify(info),
       title: t("systeminfo.dialog.title"),
       defaultPath: "chrysalis-debug.bundle.json",
     });
-
-    setCollected(false);
-    setViewing(false);
-    setInfo({});
+    if (error) {
+      logger().error("Error saving the debug bundle", { error: error });
+      toast.error(t("errors.saveFile", { error: error }));
+    } else {
+      setCollected(false);
+      setViewing(false);
+      setInfo({});
+    }
   };
 
   const createBundle = async () => {

--- a/src/renderer/utils/findKeyboards.js
+++ b/src/renderer/utils/findKeyboards.js
@@ -20,7 +20,7 @@ import Hardware from "@api/hardware";
 import { ipcRenderer } from "electron";
 
 const findNonSerialKeyboards = async (deviceList) => {
-  return ipcRenderer.invoke("usb-scan-for-devices").then((devicesConnected) => {
+  return ipcRenderer.invoke("usb.scan-for-devices").then((devicesConnected) => {
     const devices = devicesConnected.map((device) => device.deviceDescriptor);
     devices.forEach((desc) => {
       Hardware.nonSerial.forEach((port) => {


### PR DESCRIPTION
This harmonizes our IPC call naming, so everything follows the same pattern.

As an additional benefit, I found an issue with the save/open handlers of `ipc_file_io`, where errors weren't properly sent back to the renderer, so we silently hid save errors, among other things. We no longer do that.

Fixes #876.
