### PR TITLE
api/flash: Do not wait the full timeout duration for device.reset

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -59,19 +59,21 @@ function FocusCommands(options) {
       });
     };
 
-    // Attempt calling device.reset first, if present.
-    const commands = await focus.supported_commands();
-    if (commands.includes("device.reset")) {
-      try {
-        await focus.request("device.reset");
-      } catch (e) {
-        // If there's a comms timeout, that's exactly what we want. the keyboard is rebooting.
-        if ("Communication timeout" !== e) {
-          logger("flash").error("Error while calling `device.reset`", {
-            error: e,
-          });
-          throw e;
-        }
+    // Attempt rebooting the keyboard programmatically. We rely on focus doing
+    // this, so it uses a shorter timeout, because if it succeeds, the keyboard
+    // isn't coming back.
+    //
+    // We do not need to check if the command exists, focus handles that
+    // transparently.
+    try {
+      await focus.command("device.reset");
+    } catch (e) {
+      // If there's a comms timeout, that's exactly what we want. the keyboard is rebooting.
+      if ("Communication timeout" !== e) {
+        logger("flash").error("Error while calling `device.reset`", {
+          error: e,
+        });
+        throw e;
       }
     }
 

--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -33,6 +33,7 @@ class Focus {
       global.chrysalis_focus_instance = this;
       this.commands = {
         help: this._help,
+        "device.reset": this._reboot,
       };
       this.timeout = 30000;
       this._supported_commands = [];
@@ -427,6 +428,18 @@ class Focus {
   async _help(s) {
     const data = await s.request("help");
     return data.split(/\r?\n/).filter((v) => v.length > 0);
+  }
+
+  async _reboot(s) {
+    // This is a gross hack, but we currently have no other easy way to
+    // accomplish the same thing: sending a command with a shorter timeout than
+    // usual.
+
+    const timeout = this.timeout;
+    this.timeout = 500;
+    const result = await s.request("device.reset");
+    this.timeout = timeout;
+    return result;
   }
 
   eepromRestoreCommands = [


### PR DESCRIPTION
When waiting for `device.reset` to complete, do not wait the full duration of our normal timeout. The keyboard isn't coming back with a result if the command succeeds.

As there is currently no way in `@api/focus` to set a custom timeout on a per-command basis, move the reboot code to focus, and temporarily set the timeout to 500ms for this command only.

Fixes #904.

Draft pull request, because I may have something better coming soon. If my other idea fails, then this'll still be here.