### PR TITLE
api/log: Implement a simple log suppressor

### DIFF
--- a/src/api/log.js
+++ b/src/api/log.js
@@ -18,6 +18,8 @@ import fs from "fs";
 import winston from "winston";
 import { ipcRenderer } from "electron";
 
+import { suppress } from "./log/format";
+
 const Store = require("electron-store");
 const settings = new Store();
 
@@ -32,13 +34,14 @@ export const setupLogging = async () => {
 
   winston.loggers.add("default", {
     transports: [new transports.Console({ level: logLevel }), fileLogger],
-    format: format.combine(format.timestamp(), format.json()),
+    format: format.combine(suppress(), format.timestamp(), format.json()),
   });
 
   winston.loggers.add("focus", {
     transports: [new transports.Console({ level: logLevel }), fileLogger],
     format: format.combine(
       format.label({ label: "focus" }),
+      suppress(),
       format.timestamp(),
       format.json()
     ),
@@ -48,6 +51,7 @@ export const setupLogging = async () => {
     transports: [new transports.Console({ level: logLevel }), fileLogger],
     format: format.combine(
       format.label({ label: "flash" }),
+      suppress(),
       format.timestamp(),
       format.json()
     ),

--- a/src/api/log/format.js
+++ b/src/api/log/format.js
@@ -1,0 +1,46 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import winston from "winston";
+
+export const suppress = (() => {
+  let cache = [];
+
+  return winston.format((info, opts) => {
+    const lookback = opts?.lookback || 2;
+
+    const current = Object.assign({}, info, { timestamp: null });
+    let result = info;
+
+    // Are we in the cache?
+    for (const i of cache) {
+      const cached = Object.assign({}, i, { timestamp: null });
+      if (JSON.stringify(current) == JSON.stringify(cached)) {
+        // We are, set the result appropriately
+        result = false;
+        break;
+      }
+    }
+
+    // push ourselves onto the cache
+    cache.push(info);
+
+    // keep the last N
+    cache = cache.splice(-lookback);
+
+    return result;
+  });
+})();


### PR DESCRIPTION
We'd like to suppress logs if we've logged the same (sans timestamp) recently, because there are parts of Chrysalis that can be very noisy otherwise. To this end, implement a simple suppressor, that keeps a cache of the last few logs, and suppresses new messages that have been seen recently. Any log that goes through the suppressor will be added to the cache, regardless of eventual outcome, so we always have the last N most recent ones in there.

The suppressor keeps the cache size small and tidy, defaulting to a convenient two lines.

This, in turn, makes the `focus.find()` logs far less noisy, even on disk.