### PR TITLE
api/log: Implement our own browser console transport

### DIFF
--- a/src/api/log.js
+++ b/src/api/log.js
@@ -19,6 +19,7 @@ import winston from "winston";
 import { ipcRenderer } from "electron";
 
 import { suppress } from "./log/format";
+import { BrowserConsole } from "./log/transports";
 
 const Store = require("electron-store");
 const settings = new Store();
@@ -33,12 +34,12 @@ export const setupLogging = async () => {
   const logLevel = await settings.get("log.level", "info");
 
   winston.loggers.add("default", {
-    transports: [new transports.Console({ level: logLevel }), fileLogger],
+    transports: [new BrowserConsole({ level: logLevel }), fileLogger],
     format: format.combine(suppress(), format.timestamp(), format.json()),
   });
 
   winston.loggers.add("focus", {
-    transports: [new transports.Console({ level: logLevel }), fileLogger],
+    transports: [new BrowserConsole({ level: logLevel }), fileLogger],
     format: format.combine(
       format.label({ label: "focus" }),
       suppress(),
@@ -48,7 +49,7 @@ export const setupLogging = async () => {
   });
 
   winston.loggers.add("flash", {
-    transports: [new transports.Console({ level: logLevel }), fileLogger],
+    transports: [new BrowserConsole({ level: logLevel }), fileLogger],
     format: format.combine(
       format.label({ label: "flash" }),
       suppress(),

--- a/src/api/log/transports.js
+++ b/src/api/log/transports.js
@@ -1,0 +1,45 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import winston from "winston";
+import { LEVEL, MESSAGE, SPLAT } from "triple-beam";
+import TransportStream from "winston-transport";
+
+export class BrowserConsole extends TransportStream {
+  methods = {
+    debug: "debug",
+    error: "error",
+    info: "info",
+    warn: "warn",
+  };
+
+  log(info, next) {
+    setImmediate(() => this.emit("logged", info));
+
+    const m = this.methods[info.level] || "log";
+    const cleanMsg = Object.assign({}, info);
+    delete cleanMsg[LEVEL];
+    delete cleanMsg[MESSAGE];
+    delete cleanMsg[SPLAT];
+    delete cleanMsg.timestamp;
+    delete cleanMsg.message;
+    console[m](info.timestamp, info.message, cleanMsg);
+
+    if (next) {
+      next();
+    }
+  }
+}


### PR DESCRIPTION
Winston's built-in Console transport is simple, but has a major drawback: it transports everything via `console.log`, formatted as our formatters decided to. However, for Chrysalis, we'd like a different format on the browser console than in files, logged at the appropriate levels, and the log info as a javascript object, rather than stringified JSON.

The BrowserConsole transport implemented herein does just that.

**Winston's transport.Console**:

![Screenshot from 2022-06-04 19-34-10](https://user-images.githubusercontent.com/17243/172018987-68f718cb-bceb-493d-a38d-f279041567d0.png)

**BrowserConsole**:

![Screenshot from 2022-06-04 19-35-15](https://user-images.githubusercontent.com/17243/172018999-4aa543ca-3943-4c04-ac74-7e4b65d1b92e.png)
