### PR TITLE
logging: Create a symlink to the current log & cull old ones

### DIFF
--- a/src/api/log/transports.js
+++ b/src/api/log/transports.js
@@ -14,9 +14,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ipcRenderer } from "electron";
 import winston from "winston";
 import { LEVEL, MESSAGE, SPLAT } from "triple-beam";
 import TransportStream from "winston-transport";
+
+export class Ipc extends TransportStream {
+  constructor(opts) {
+    super(opts);
+
+    this.port = new MessageChannel().port1;
+  }
+
+  log(info, next) {
+    setImmediate(() => this.emit("logged", info));
+
+    ipcRenderer.invoke("logging.store-info", info[LEVEL], info[MESSAGE]);
+
+    if (next) {
+      next();
+    }
+  }
+}
 
 export class BrowserConsole extends TransportStream {
   methods = {


### PR DESCRIPTION
To ease development, create a symlink to the current log file on startup, and also cull old files, so they don't accumulate endlessly. We keep the last 10 only.

Fixes #911.

Requires - and includes - #915.