### PR TITLE
Preferences: Disallow changing tabs when in context

### DIFF
--- a/src/renderer/screens/Preferences.js
+++ b/src/renderer/screens/Preferences.js
@@ -61,6 +61,7 @@ function Preferences(props) {
   const [value, setValue] = React.useState(0);
   const globalContext = useContext(GlobalContext);
 
+  const [inContext, setInContext] = React.useState(false);
   const [connected, setConnected] = globalContext.state.connected;
 
   const { t } = useTranslation();
@@ -94,13 +95,21 @@ function Preferences(props) {
           bottom: 0,
         }}
       >
-        <Tab label={t("preferences.interface")} {...a11yProps(0)} />
+        <Tab
+          label={t("preferences.interface")}
+          disabled={inContext}
+          {...a11yProps(0)}
+        />
         <Tab
           label={t("preferences.keyboard.title")}
           {...a11yProps(1)}
           disabled={!connected}
         />
-        <Tab label={t("preferences.devtools.main.label")} {...a11yProps(2)} />
+        <Tab
+          label={t("preferences.devtools.main.label")}
+          disabled={inContext}
+          {...a11yProps(2)}
+        />
       </Tabs>
       <Box
         sx={{
@@ -114,7 +123,7 @@ function Preferences(props) {
 
         <TabPanel value={value} index={1}>
           <MyKeyboardPreferences
-            inContext={props.inContext}
+            setInContext={setInContext}
             onDisconnect={props.onDisconnect}
           />
         </TabPanel>

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -46,6 +46,7 @@ const MyKeyboardPreferences = (props) => {
     newChanges[command] = args;
     setChanges(newChanges);
 
+    props.setInContext(true);
     setModified(true);
     showContextBar();
   };
@@ -65,6 +66,7 @@ const MyKeyboardPreferences = (props) => {
     }
     setChanges({});
 
+    await props.setInContext(false);
     await setModified(false);
     await hideContextBar();
   };
@@ -75,6 +77,7 @@ const MyKeyboardPreferences = (props) => {
       if (event.data === "changes-discarded") {
         setChanges({});
         setModified(false);
+        props.setInContext(false);
       }
     };
     return () => {


### PR DESCRIPTION
When we're in context (when we have unsaved changes, on the MyKeyboard tab), prevent changing tabs, as that would silently discard pending changes. We now need to either save those changes, or discard them, before we're allowed to leave the MyKeyboard tab.

Fixes #918.
