### PR TITLE
MacroEditor: Add a step id  to newly added steps

### DIFF
--- a/src/renderer/screens/Editor/Macros/MacroEditor.js
+++ b/src/renderer/screens/Editor/Macros/MacroEditor.js
@@ -41,6 +41,7 @@ const MacroEditor = (props) => {
 
   const addStep = (step) => {
     const newMacro = macro.map((v) => Object.assign({}, v));
+    step.id = Date.now();
     newMacro.push(step);
     onMacroChange(macroId, newMacro);
     setMacroStep(newMacro.length - 1);
@@ -125,10 +126,10 @@ const MacroEditor = (props) => {
   if (macroId == null) return null;
 
   const steps = macro.map((step, index) => {
-    const key = "macro-step-" + index.toString();
+    const key = "macro-step-" + step.id.toString();
     return (
       <MacroStep
-        key={step.id}
+        key={key}
         step={step}
         id={step.id}
         index={index}


### PR DESCRIPTION
React wants a unique key for things it handles, including macro step components. For existing steps, we were using `step.id` as a key, but newly added steps did not have such a property, and we ended up with an empty key, which React complained about.

To fix this, add an id to newly created steps, and use a key for our macro steps that can never be empty.
