### PR TITLE
Let our json pretty printer print lines up to 1k long in systeminfo dumps to make them default to a more compact, more scannable format

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "i18next": "^21.6.14",
     "i18next-electron-language-detector": "^0.0.10",
     "immutability-helper": "^3.1.1",
-    "json-stringify-pretty-compact": "^2.0.0",
+    "json-stringify-pretty-compact": "^3.0.0",
     "react": "^17.0.2",
     "react-color": "^2.14.1",
     "react-dnd": "^16.0.1",

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -36,7 +36,7 @@ import { toast } from "@renderer/components/Toast";
 import logo from "@renderer/logo-small.png";
 import { version } from "@root/package.json";
 import { ipcRenderer } from "electron";
-import jsonStringify from "json-stringify-pretty-compact";
+import stringify from "json-stringify-pretty-compact";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import si from "systeminformation";
@@ -57,7 +57,7 @@ function SystemInfo(props) {
 
   const saveBundle = async () => {
     const error = await ipcRenderer.sendSync("file.save-with-dialog", {
-      content: jsonStringify(info),
+      content: stringify(info, { maxLength: 1024 }),
       title: t("systeminfo.dialog.title"),
       defaultPath: "chrysalis-debug.bundle.json",
     });
@@ -135,7 +135,12 @@ function SystemInfo(props) {
     <Dialog open={viewing} scroll="paper" onClose={closeViewBundle} fullScreen>
       <DialogTitle>{t("systeminfo.title")}</DialogTitle>
       <DialogContent dividers>
-        <TextField disabled multiline fullWidth value={jsonStringify(info)} />
+        <TextField
+          disabled
+          multiline
+          fullWidth
+          value={stringify(info, { maxLength: 1024 })}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-pretty-compact@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz#e77c419f52ff00c45a31f07f4c820c2433143885"
-  integrity sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==
+json-stringify-pretty-compact@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
+  integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
 
 json-stringify-safe@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
I don't feel *super* strongly about this, but 
![image](https://user-images.githubusercontent.com/45416/172497273-a5bfbd85-b0f6-4a4b-b4f2-7fa34a707082.png)
 is pretty hard to follow.

With this PR,

![image](https://user-images.githubusercontent.com/45416/172497361-6b267ba5-716b-4286-b190-bf2127ea8baf.png)


becomes

![image](https://user-images.githubusercontent.com/45416/172497071-8874da25-005e-48fe-b7a9-9717666a3194.png)
