### PR TITLE
Initialize the host keyboard layout early, in App

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -16,6 +16,7 @@
  */
 
 import Focus from "@api/focus";
+import KeymapDB from "@api/focus/keymap/db";
 import { logger } from "@api/log";
 import { LocationProvider, Router } from "@gatsbyjs/reach-router";
 import Box from "@mui/material/Box";
@@ -110,6 +111,14 @@ const App = (props) => {
     setTheme(null);
     setTheme("system");
   };
+
+  useEffect(async () => {
+    const layoutSetting = await settings.get("keyboard.layout", "English (US)");
+
+    const db = new KeymapDB();
+    await db.loadLayouts();
+    await db.setLayout(layoutSetting);
+  }, []);
 
   useEffect(() => {
     ipcRenderer.on("usb.device-disconnected", handleDeviceDisconnect);

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -43,15 +43,8 @@ const LayoutCard = (props) => {
     colorMap: [],
   });
 
-  const [layout, _setLayout] = useState("English (US)");
   const [loading, setLoading] = useState(true);
   const { t } = useTranslation();
-
-  const initializeHostKeyboardLayout = async () => {
-    const layoutSetting = await settings.get("keyboard.layout", "English (US)");
-    db.setLayout(layoutSetting);
-    _setLayout(layoutSetting);
-  };
 
   const scanKeyboard = async () => {
     try {
@@ -73,7 +66,6 @@ const LayoutCard = (props) => {
 
   useEffectOnce(async () => {
     await scanKeyboard();
-    await initializeHostKeyboardLayout();
 
     setLoading(false);
   });

--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -65,7 +65,6 @@ function LayoutEditorPreferences(props) {
 
   const initializeHostKeyboardLayout = async () => {
     const layoutSetting = await settings.get("keyboard.layout", "English (US)");
-    db.setLayout(layoutSetting);
     setLayout(layoutSetting);
   };
 


### PR DESCRIPTION
Instead of trying to initialize the host keyboard layout when rendering LayoutCards or Preferences, do so in App, and make sure we _load_ the available layouts first.

This guarantees that the layout will be properly set for every screen, including the layout editor.

Fixes #932.
