### PR TITLE
LayoutCard: Add an option to print only one layer per page

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -292,6 +292,10 @@ const English = {
       layoutCards: {
         label: "Customize Layout Cards",
       },
+      oneLayerPerPage: {
+        label: "Print one layer per page",
+        help: `When enabled, Chrysalis will arrange the layout cards to print one layer per page, rather than as many as fit.`,
+      },
       hideUnavailableFeatures: {
         label: `Hide features not supported by your keyboard's current firmware`,
         help: `When enabled, Chrysalis will hide configuration options for features that your keyboard's firmware doesn't support.`,

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -44,6 +44,7 @@ const LayoutCard = (props) => {
   });
 
   const [loading, setLoading] = useState(true);
+  const [oneLayerPerPage, setOneLayerPerPage] = useState(false);
   const { t } = useTranslation();
 
   const scanKeyboard = async () => {
@@ -67,6 +68,8 @@ const LayoutCard = (props) => {
   useEffectOnce(async () => {
     await scanKeyboard();
 
+    setOneLayerPerPage(settings.get("ui.layoutCards.oneLayerPerPage", false));
+
     setLoading(false);
   });
   if (loading) {
@@ -84,7 +87,11 @@ const LayoutCard = (props) => {
         // If it's not empty, add it to the keymap_pix array
         keymap_pix.push(
           <Box
-            sx={{ width: "auto", breakInside: "avoid" }}
+            sx={{
+              width: "auto",
+              breakInside: "avoid",
+              breakAfter: oneLayerPerPage && "page",
+            }}
             key={`LayerCard-${i}`}
           >
             <Typography

--- a/src/renderer/screens/Preferences/ui/LayoutCardsPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutCardsPreferences.js
@@ -28,6 +28,7 @@ function LayoutCardsPreferences(props) {
   const { t, i18n } = useTranslation();
 
   const [coloredLayoutCards, setColoredLayoutCards] = useState(false);
+  const [oneLayerPerPage, setOneLayerPerPage] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   const toggleColoredLayoutCards = () => {
@@ -35,9 +36,17 @@ function LayoutCardsPreferences(props) {
     setColoredLayoutCards(!coloredLayoutCards);
   };
 
+  const toggleOneLayerPerPage = (event) => {
+    settings.set("ui.layoutCards.oneLayerPerPage", event.target.checked);
+    setOneLayerPerPage(event.target.checked);
+  };
+
   useEffect(() => {
     const initialize = async () => {
       await setColoredLayoutCards(settings.get("ui.layoutCards.colored"));
+      await setOneLayerPerPage(
+        settings.get("ui.layoutCards.oneLayerPerPage", false)
+      );
       await setLoaded(true);
     };
 
@@ -51,6 +60,12 @@ function LayoutCardsPreferences(props) {
         option="ui.coloredLayoutCards"
         checked={coloredLayoutCards}
         onChange={toggleColoredLayoutCards}
+      />
+      <PreferenceSwitch
+        loaded={loaded}
+        option="ui.oneLayerPerPage"
+        checked={oneLayerPerPage}
+        onChange={toggleOneLayerPerPage}
       />
     </PreferenceSection>
   );


### PR DESCRIPTION
By default, the layout card screen shows - and prints - layers continously, avoiding page breaks within a layer, but having as many layers per page as it can fit. However, when one wishes to print layout cards, it is often desirable to print only one per page.

This patch introduces such a setting. When enabled, it will add a `breakAfter: "page"` CSS property to each layer, enforcing a page break after each one.

Preferences preview:

![Screenshot from 2022-06-14 07-27-40](https://user-images.githubusercontent.com/17243/173500803-849263b5-3f13-4d58-8197-58112c58cbf7.png)
