### PR TITLE
Hide the Header when printing

### DIFF
--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -23,6 +23,7 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,6 +39,7 @@ function Header({ device }) {
   const [contextBarVisibility, setContextBarVisibility] = useState(false);
   const [discardChangesDialogVisibility, setDiscardChangesDialogVisibility] =
     useState(false);
+  const isPrinting = useMediaQuery("print");
 
   const { t } = useTranslation();
 
@@ -92,6 +94,8 @@ function Header({ device }) {
     contextBarChangesDiscarded();
     setContextBarVisibility(false);
   };
+
+  if (isPrinting) return null;
 
   return (
     <>


### PR DESCRIPTION
When printing, the header does not add any useful information, but takes up space - and colors - on the first page. Lets not show the header in print.

Fixes #943.
