### PR TITLE
Pregenerate the CLDR data, rather than loading it from the renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "homepage": "https://github.com/keyboardio/Chrysalis",
   "scripts": {
+    "precompile": "node tools/precompile.mjs",
     "preinstall": "node tools/preinstall.js",
     "postinstall": "electron-builder install-app-deps",
-    "start": "electron-webpack dev",
+    "start": "yarn run precompile &&  electron-webpack dev",
     "compile": "electron-webpack",
     "build:all": "npm-run-all compile --parallel 'electron-builder -m' 'electron-builder -w' 'electron-builder -l'",
     "build:osx": "yarn compile && electron-builder -m",

--- a/src/api/focus/keymap/.gitignore
+++ b/src/api/focus/keymap/.gitignore
@@ -1,0 +1,1 @@
+/cldr_data.json

--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -14,9 +14,9 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cldr_ from "cldr";
+import cldr from "cldr";
 import i18n from "i18next";
-import cldr from "./cldr";
+import cldr_data from "./cldr_data";
 import { Base } from "./db/base";
 import { USQwerty } from "./db/us/qwerty";
 import { constants } from "./db/constants";
@@ -41,16 +41,12 @@ class KeymapDB {
   }
 
   loadLayouts = async () => {
-    this._layouts = Object.assign(
-      {},
-      this._layouts,
-      await cldr.loadAllKeymaps()
-    );
+    this._layouts = Object.assign({}, this._layouts, cldr_data);
   };
 
   getLayoutLanguage = (layout) => {
     const languageCode = this._layouts[layout].group;
-    return cldr_.extractLanguageDisplayNames(i18n.language)[languageCode];
+    return cldr.extractLanguageDisplayNames(i18n.language)[languageCode];
   };
 
   getSupportedLayouts() {

--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -14,7 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cldr from "cldr";
+import { ipcRenderer } from "electron";
 import i18n from "i18next";
 import cldr_data from "./cldr_data";
 import { Base } from "./db/base";
@@ -46,7 +46,11 @@ class KeymapDB {
 
   getLayoutLanguage = (layout) => {
     const languageCode = this._layouts[layout].group;
-    return cldr.extractLanguageDisplayNames(i18n.language)[languageCode];
+    return ipcRenderer.sendSync(
+      "cldr.getLayoutLanguage",
+      i18n.language,
+      languageCode
+    );
   };
 
   getSupportedLayouts() {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -29,6 +29,7 @@ import {
   addUsbEventListeners,
   registerDeviceDiscoveryHandlers,
 } from "./ipc_device_discovery";
+import { registerCLDRHandlers } from "./ipc_cldr";
 import { registerDevtoolsHandlers } from "./ipc_devtools";
 import { registerExitHandlers } from "./ipc_exit";
 import { registerFileIoHandlers } from "./ipc_file_io";
@@ -188,6 +189,7 @@ process.on("uncaughtException", function (error) {
 });
 
 registerBackupHandlers();
+registerCLDRHandlers();
 registerDeviceDiscoveryHandlers();
 registerDevtoolsHandlers();
 registerFileIoHandlers();

--- a/src/main/ipc_cldr.js
+++ b/src/main/ipc_cldr.js
@@ -1,0 +1,24 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ipcMain } from "electron";
+import cldr from "cldr";
+
+export const registerCLDRHandlers = () => {
+  ipcMain.on("cldr.getLayoutLanguage", async (event, lang, code) => {
+    event.returnValue = cldr.extractLanguageDisplayNames(lang)[code];
+  });
+};

--- a/tools/precompile.mjs
+++ b/tools/precompile.mjs
@@ -1,0 +1,32 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import fs from "fs";
+
+import { loadAllKeymaps } from "./precompile/cldr_data.mjs";
+
+const generateCLDRData = async () => {
+  console.log("* Generating CLDR data...");
+
+  const db = await loadAllKeymaps();
+
+  fs.writeFileSync(
+    "./src/api/focus/keymap/cldr_data.json",
+    JSON.stringify(db, null, 2)
+  );
+}
+
+generateCLDRData();

--- a/tools/precompile/cldr_data.mjs
+++ b/tools/precompile/cldr_data.mjs
@@ -14,12 +14,22 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getStaticPath } from "@renderer/config";
 import fs from "fs";
 import path from "path";
-import unraw from "unraw";
+import { unraw } from "unraw";
 import xml2js from "xml2js";
-import { addModifier } from "./db/modifiers";
+
+const modMap = {
+  ctrl: 1 << 8,
+  alt: 1 << 9,
+  altgr: 1 << 10,
+  shift: 1 << 11,
+  gui: 1 << 12,
+};
+
+const addModifier = (keyCode, mod) => {
+  return keyCode + modMap[mod];
+};
 
 const cldr2keycode = {
   E00: 53,
@@ -152,16 +162,16 @@ const loadKeyboard = async (group, isDefault, file) => {
   };
 };
 
-const loadAllKeymaps = async () => {
+export const loadAllKeymaps = async () => {
   const windowsFiles = fs.readdirSync(
-    path.join(getStaticPath(), "cldr/keyboards/windows/")
+    "./static/cldr/keyboards/windows/"
   );
   // There are some layouts that aren't available in CLDR's windows layouts, but
   // are on others. We slurp those up here in addition. We can't just slurp up
   // all of the osx layouts and filter out the duplicates, because naming is
   // inconsistent, so we go on a case-by-case basis for now.
   const osxFiles = fs
-    .readdirSync(path.join(getStaticPath(), "cldr/keyboards/osx"))
+    .readdirSync("static/cldr/keyboards/osx")
     .filter((fn) => fn.match("^hr-t-k0"));
   const files = windowsFiles.concat(osxFiles);
 
@@ -179,7 +189,7 @@ const loadAllKeymaps = async () => {
     const layout = await loadKeyboard(
       l.match("^(...?)-t-")[1],
       true,
-      path.join(getStaticPath(), "cldr/keyboards", os, l)
+      path.join("static/cldr/keyboards", os, l)
     );
 
     db[layout.name] = layout;
@@ -201,7 +211,7 @@ const loadAllKeymaps = async () => {
     const layout = await loadKeyboard(
       l.match("^(...?)-")[1],
       false,
-      path.join(getStaticPath(), "cldr/keyboards", os, l)
+      path.join("static/cldr/keyboards", os, l)
     );
 
     db[layout.name] = layout;
@@ -209,9 +219,3 @@ const loadAllKeymaps = async () => {
 
   return db;
 };
-
-const cldr = {
-  loadAllKeymaps: loadAllKeymaps,
-};
-
-export default cldr;

--- a/tools/precompile/cldr_data.mjs
+++ b/tools/precompile/cldr_data.mjs
@@ -14,6 +14,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+const cldrDir = "static/cldr";
+
 import fs from "fs";
 import path from "path";
 import { unraw } from "unraw";
@@ -163,15 +165,13 @@ const loadKeyboard = async (group, isDefault, file) => {
 };
 
 export const loadAllKeymaps = async () => {
-  const windowsFiles = fs.readdirSync(
-    "./static/cldr/keyboards/windows/"
-  );
+  const windowsFiles = fs.readdirSync(path.join(cldrDir, "keyboards/windows/"));
   // There are some layouts that aren't available in CLDR's windows layouts, but
   // are on others. We slurp those up here in addition. We can't just slurp up
   // all of the osx layouts and filter out the duplicates, because naming is
   // inconsistent, so we go on a case-by-case basis for now.
   const osxFiles = fs
-    .readdirSync("static/cldr/keyboards/osx")
+    .readdirSync(path.join(cldrDir, "keyboards/osx"))
     .filter((fn) => fn.match("^hr-t-k0"));
   const files = windowsFiles.concat(osxFiles);
 
@@ -189,7 +189,7 @@ export const loadAllKeymaps = async () => {
     const layout = await loadKeyboard(
       l.match("^(...?)-t-")[1],
       true,
-      path.join("static/cldr/keyboards", os, l)
+      path.join(cldrDir, "keyboards", os, l)
     );
 
     db[layout.name] = layout;
@@ -211,7 +211,7 @@ export const loadAllKeymaps = async () => {
     const layout = await loadKeyboard(
       l.match("^(...?)-")[1],
       false,
-      path.join("static/cldr/keyboards", os, l)
+      path.join(cldrDir, "keyboards", os, l)
     );
 
     db[layout.name] = layout;


### PR DESCRIPTION
We still import cldr from the renderer process, for `cldr.extractLanguageDisplayNames`, but that hopefully doesn't expect to be in a node environment.

If it does, we'll have to push it (along with the cldr data) to the main process.

Fixes #924.
