### PR TITLE
linux: If /run/udev is not accessible, give a useful error message

### DIFF
--- a/src/main/ipc_device_discovery.js
+++ b/src/main/ipc_device_discovery.js
@@ -16,6 +16,7 @@
  */
 
 import { ipcMain } from "electron";
+import fs from "fs";
 import { findByIds, getDeviceList, WebUSB } from "usb";
 import { sendToRenderer } from "./utils";
 
@@ -63,4 +64,15 @@ export const registerDeviceDiscoveryHandlers = () => {
       return false;
     }
   });
+  if (process.platform == "linux") {
+    ipcMain.on("udev.isAvailable", (event) => {
+      try {
+        fs.accessSync("/run/udev");
+      } catch (_) {
+        event.returnValue = false;
+        return;
+      }
+      event.returnValue = true;
+    });
+  }
 };

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -350,6 +350,7 @@
     "noDevices": "No keyboards found.",
     "connect": "Connect",
     "disconnect": "Disconnect",
+    "noUdev": "Chysalis requires udev to be able to scan for devices, but it appears it is not available.",
     "installUdevRules": "Fix it",
     "permissionError": "Your computer won't let Chrysalis talk to your keyboard. (You do not have read/write permissions to {{path}}.)",
     "permissionErrorSuggestion": "Chrysalis can fix this by installing a udev rules file into /etc/udev/rules.d/."


### PR DESCRIPTION
We need `/run/udev` to be able to scan devices, so if it is not accessible, or doesn't exist, we will now display a useful error message.

Fixes #700.

![Screenshot from 2022-06-24 16-58-47](https://user-images.githubusercontent.com/17243/175563276-b07aeae2-efbe-4642-afe2-bb2f15df84e2.png)
