### PR TITLE
Firmware upgrade/redesign

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -308,7 +308,7 @@ class Focus {
       data = data.toString("utf-8");
       logger("focus").debug("incoming data", { data: data });
 
-      const [resolve] = this.callbacks.shift();
+      const [resolve] = this.callbacks?.shift();
       this._parser.endTimer();
       if (data == ".") {
         resolve();

--- a/src/api/hardware-ez-ergodox/index.js
+++ b/src/api/hardware-ez-ergodox/index.js
@@ -41,7 +41,13 @@ const ErgoDox = {
     keymap: Keymap,
   },
 
-  flashSteps: ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"],
+  flashSteps: (options) => {
+    if (options?.factoryReset) {
+      return ["factoryRestore", "flash"];
+    }
+
+    return ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"];
+  },
   flash: async (_, filename, options) => {
     return teensy(filename, options);
   },

--- a/src/api/hardware-keyboardio-atreus2/index.js
+++ b/src/api/hardware-keyboardio-atreus2/index.js
@@ -53,14 +53,20 @@ const Atreus2 = {
     keymap: Keymap,
   },
 
-  flashSteps: [
-    "saveEEPROM",
-    "bootloaderTrigger",
-    "bootloaderWait",
-    "flash",
-    "reconnect",
-    "restoreEEPROM",
-  ],
+  flashSteps: (options) => {
+    if (options?.factoryReset) {
+      return ["factoryRestore", "bootloaderTrigger", "bootloaderWait", "flash"];
+    }
+
+    return [
+      "saveEEPROM",
+      "bootloaderTrigger",
+      "bootloaderWait",
+      "flash",
+      "reconnect",
+      "restoreEEPROM",
+    ];
+  },
   externalFlasher: "avrdude",
   flash: async (port, filename, options) => {
     const board = {

--- a/src/api/hardware-keyboardio-model01/index.js
+++ b/src/api/hardware-keyboardio-model01/index.js
@@ -121,14 +121,20 @@ const Model100 = {
     keymap: Keymap,
   },
 
-  flashSteps: [
-    "saveEEPROM",
-    "bootloaderTrigger",
-    "bootloaderWait",
-    "flash",
-    "reconnect",
-    "restoreEEPROM",
-  ],
+  flashSteps: (options) => {
+    if (options?.factoryReset) {
+      return ["factoryRestore", "bootloaderTrigger", "bootloaderWait", "flash"];
+    }
+
+    return [
+      "saveEEPROM",
+      "bootloaderTrigger",
+      "bootloaderWait",
+      "flash",
+      "reconnect",
+      "restoreEEPROM",
+    ];
+  },
   flash: async (port, filename, options) => {
     return DFUUtil(port, filename, options);
   },
@@ -172,7 +178,9 @@ const Model100Bootloader = {
     keymap: Keymap,
   },
 
-  flashSteps: ["flash"],
+  flashSteps: () => {
+    return ["flash"];
+  },
   flash: async (port, filename, options) => {
     return DFUUtilBootloader(port, filename, options);
   },

--- a/src/api/hardware-softhruf-splitography/index.js
+++ b/src/api/hardware-softhruf-splitography/index.js
@@ -41,7 +41,13 @@ const Splitography = {
     keymap: Keymap,
   },
 
-  flashSteps: ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"],
+  flashSteps: (options) => {
+    if (options?.factoryReset) {
+      return ["factoryRestore", "flash"];
+    }
+
+    return ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"];
+  },
   flash: async (_, filename, options) => {
     return await DFUProgrammer(filename, options);
   },

--- a/src/api/hardware-technomancy-atreus/index.js
+++ b/src/api/hardware-technomancy-atreus/index.js
@@ -41,7 +41,13 @@ const Atreus = {
     keymap: Keymap,
   },
 
-  flashSteps: ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"],
+  flashSteps: (options) => {
+    if (options?.factoryReset) {
+      return ["factoryRestore", "flash"];
+    }
+
+    return ["saveEEPROM", "flash", "reconnect", "restoreEEPROM"];
+  },
   flash: async (_, filename, options) => {
     return teensy(filename, options);
   },

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -16,6 +16,8 @@
  */
 
 import Focus from "@api/focus";
+import path from "path";
+import { getStaticPath } from "@renderer/config";
 
 export function ActiveDevice() {
   this.port = undefined;
@@ -65,5 +67,18 @@ export function ActiveDevice() {
     } else {
       return false;
     }
+  };
+  this.defaultFirmwareFilename = () => {
+    const { vendor, product } = this.focus.focusDeviceDescriptor.info;
+    const firmwareType =
+      this.focus.focusDeviceDescriptor.info.firmwareType || "hex";
+    const cVendor = vendor.replace("/", ""),
+      cProduct = product.replace("/", "");
+    return path.join(
+      getStaticPath(),
+      cVendor,
+      cProduct,
+      "default." + firmwareType
+    );
   };
 }

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -357,23 +357,21 @@
   "firmwareUpdate": {
     "firmwareChangelog": {
       "title": "Firmware Changelog",
-      "view": "Changelog"
+      "view": "View changes in Chrysalis' version of the firmware"
     },
+    "firmwareSources": "Firmware sources",
     "calloutTitle": "Important!",
     "dialog": {
       "selectFirmware": "Select a firmware",
       "firmwareFiles": "Firmware files",
       "allFiles": "All files"
     },
-    "options": {
-      "onFlash": "Restore to factory defaults when flashing",
-      "title": "Firmware update options"
-    },
     "flashing": {
       "error": "Error flashing the firmware",
       "releasePROG": "Bootloader detected. If you're holding a key down, please release it.",
       "success": "Firmware flashed successfully!",
       "button": "Update",
+      "factoryResetButton": "Factory reset",
       "steps": {
         "factoryRestore": "Restoring factory defaults",
         "bootloaderTrigger": "Triggering bootloader",
@@ -386,15 +384,21 @@
       }
     },
     "confirmDialog": {
-      "title": "Replace the firmware and reset to factory defaults?",
-      "contents": "This will replace the firmware on the device, and reset all settings to factory defaults. You will lose all customizations made."
+      "title": "Are you sure you want to update the firmware?",
+      "description": "Installing new firmware will replace the existing one on the device. Once the new firmware is installed, Chrysalis will take you back to the keyboard selection screen."
     },
-    "defaultFirmware": "Chrysalis {{version}}",
+    "factoryConfirmDialog": {
+      "title": "Replace the firmware and reset to factory defaults?",
+      "contents": "This will replace the firmware on the device, and reset all settings to factory defaults. You will lose all customizations made. Once the new firmware is installed, Chrysalis will take you back to the keyboard selection screen."
+    },
+    "yourFirmware": "Your keyboard's firmware",
+    "chooseFirmware": "Choose a firmware to use:",
+    "chooseCustomFirmwareFile": "Choose a file...",
     "defaultFirmwareDescription": "Standard firmware shipped with Chrysalis",
-    "selected": "Selected firmware",
     "custom": "Custom firmware",
-    "description": "Updating or \"flashing\" your keyboard's firmware is how we teach it new tricks. Chrysalis will install a new version of your keyboard's firmware which includes support for customizing the key layout, as well as other features. If you've previously customized your keyboard's firmware, this will overwrite your custom firmware. You can always find the source code of the firmware Chrysalis is installing here:",
-    "postUpload": "Once the upload is done, Chrysalis will take you back to the keyboard selection screen."
+    "current": "Current firmware",
+    "firmwareVersion": "{{version}}",
+    "description": "Updating or \"flashing\" your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, it can keep your firmware untouched, or it can install custom firmware of your choosing too."
   },
   "focus-not-detected": {
     "title": "Welcome to Chrysalis",

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -357,9 +357,9 @@
   "firmwareUpdate": {
     "firmwareChangelog": {
       "title": "Firmware Changelog",
-      "view": "What's new?"
+      "view": "What's new in {{version}}?"
     },
-    "firmwareSources": "Firmware sources",
+    "firmwareSources": "Source code",
     "calloutTitle": "Important!",
     "dialog": {
       "selectFirmware": "Select a firmware",
@@ -394,10 +394,14 @@
     "yourFirmware": "Update your keyboard's firmware",
     "chooseFirmware": "Update firmware:",
     "defaultFirmwareDescription": "Latest version",
+    "defaultFirmwareExplanation": "This is the latest version of the firmware for your keyboard.",
+    
     "custom": "Choose a local firmware build",
     "customChooseFile": "Choose a file...",
+    "customFirmwareExplanation": "You can install an alternate firmware build you've downloaded or built locally. As long as it includes support for the 'Focus' keyboard protocol, Chrysalis should work just fine.",
     "currentFirmwareVersion": "Current firmware version",
-    "firmwareVersion": "Latest: {{version}}",
+    "customFirmwareLinkText": "Learn about building firmware",
+    "firmwareVersion": "{{version}}",
     "description": "Updating your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, or a custom firmware build you provide."
   },
   "focus-not-detected": {

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -357,7 +357,7 @@
   "firmwareUpdate": {
     "firmwareChangelog": {
       "title": "Firmware Changelog",
-      "view": "View changes in Chrysalis' version of the firmware"
+      "view": "Changelog"
     },
     "firmwareSources": "Firmware sources",
     "calloutTitle": "Important!",
@@ -392,13 +392,13 @@
       "contents": "This will replace the firmware on the device, and reset all settings to factory defaults. You will lose all customizations made. Once the new firmware is installed, Chrysalis will take you back to the keyboard selection screen."
     },
     "yourFirmware": "Your keyboard's firmware",
-    "chooseFirmware": "Choose a firmware to use:",
-    "chooseCustomFirmwareFile": "Choose a file...",
-    "defaultFirmwareDescription": "Standard firmware shipped with Chrysalis",
-    "custom": "Custom firmware",
-    "current": "Current firmware",
+    "chooseFirmware": "Update firmware:",
+    "defaultFirmwareDescription": "Latest version",
+    "custom": "Something else",
+    "customChooseFile": "Choose a file...",
+    "currentFirmwareVersion": "Current firmware version",
     "firmwareVersion": "{{version}}",
-    "description": "Updating or \"flashing\" your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, it can keep your firmware untouched, or it can install custom firmware of your choosing too."
+    "description": "Updating or \"flashing\" your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, or it can install custom firmware of your choosing too."
   },
   "focus-not-detected": {
     "title": "Welcome to Chrysalis",

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -357,7 +357,7 @@
   "firmwareUpdate": {
     "firmwareChangelog": {
       "title": "Firmware Changelog",
-      "view": "Changelog"
+      "view": "What's new?"
     },
     "firmwareSources": "Firmware sources",
     "calloutTitle": "Important!",
@@ -391,14 +391,14 @@
       "title": "Replace the firmware and reset to factory defaults?",
       "contents": "This will replace the firmware on the device, and reset all settings to factory defaults. You will lose all customizations made. Once the new firmware is installed, Chrysalis will take you back to the keyboard selection screen."
     },
-    "yourFirmware": "Your keyboard's firmware",
+    "yourFirmware": "Update your keyboard's firmware",
     "chooseFirmware": "Update firmware:",
     "defaultFirmwareDescription": "Latest version",
-    "custom": "Something else",
+    "custom": "Choose a local firmware build",
     "customChooseFile": "Choose a file...",
     "currentFirmwareVersion": "Current firmware version",
-    "firmwareVersion": "{{version}}",
-    "description": "Updating or \"flashing\" your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, or it can install custom firmware of your choosing too."
+    "firmwareVersion": "Latest: {{version}}",
+    "description": "Updating your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, or a custom firmware build you provide."
   },
   "focus-not-detected": {
     "title": "Welcome to Chrysalis",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -23,6 +23,7 @@ import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
 import Paper from "@mui/material/Paper";
@@ -38,6 +39,7 @@ import path from "path";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import FirmwareVersion from "./FirmwareUpdate/FirmwareVersion";
 import FirmwareSelect from "./FirmwareUpdate/FirmwareSelect";
 import FlashSteps from "./FirmwareUpdate/FlashSteps";
 import UpdateDescription from "./FirmwareUpdate/UpdateDescription";
@@ -49,7 +51,7 @@ const FirmwareUpdate = (props) => {
   const focus = new Focus();
 
   const [firmwareFilename, setFirmwareFilename] = useState("");
-  const [selected, setSelected] = useState("current");
+  const [selected, setSelected] = useState("default");
 
   const [factoryConfirmationOpen, setFactoryConfirmationOpen] = useState(false);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
@@ -160,9 +162,7 @@ const FirmwareUpdate = (props) => {
   );
 
   const buttonsDisabled =
-    progress == "flashing" ||
-    selected == "current" ||
-    (selected == "custom" && !firmwareFilename);
+    progress == "flashing" || (selected == "custom" && !firmwareFilename);
 
   return (
     <>
@@ -174,8 +174,8 @@ const FirmwareUpdate = (props) => {
         <Paper sx={{ p: 2 }}>
           <UpdateDescription />
           <Divider sx={{ my: 2 }} />
+          <FirmwareVersion />
           <FirmwareSelect
-            focusDeviceDescriptor={focusDeviceDescriptor}
             selectedFirmware={[selected, setSelected]}
             firmwareFilename={[firmwareFilename, setFirmwareFilename]}
           />

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -198,6 +198,7 @@ const FirmwareUpdate = (props) => {
         </Paper>
       </Container>
       <FlashSteps steps={flashSteps} activeStep={activeStep} />
+
       <ConfirmationDialog
         title={t("firmwareUpdate.factoryConfirmDialog.title")}
         open={factoryConfirmationOpen}
@@ -209,6 +210,7 @@ const FirmwareUpdate = (props) => {
         </Typography>
         {instructions}
       </ConfirmationDialog>
+
       <ConfirmationDialog
         title={t("firmwareUpdate.confirmDialog.title")}
         open={confirmationOpen}

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -51,7 +51,7 @@ const FirmwareUpdate = (props) => {
   const [activeDevice] = globalContext.state.activeDevice;
 
   const [firmwareFilename, setFirmwareFilename] = useState("");
-  const [selected, setSelected] = useState("default");
+  const [selectedFirmwareType, setSelectedFirmwareType] = useState("default");
 
   const [factoryConfirmationOpen, setFactoryConfirmationOpen] = useState(false);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
@@ -66,7 +66,7 @@ const FirmwareUpdate = (props) => {
     const focus = new Focus();
     let filename;
 
-    if (selected == "default") {
+    if (selectedFirmwareType == "default") {
       filename = activeDevice.defaultFirmwareFilename();
     } else {
       filename = firmwareFilename;
@@ -149,7 +149,8 @@ const FirmwareUpdate = (props) => {
   );
 
   const buttonsDisabled =
-    progress == "flashing" || (selected == "custom" && !firmwareFilename);
+    progress == "flashing" ||
+    (selectedFirmwareType == "custom" && !firmwareFilename);
 
   return (
     <>
@@ -163,7 +164,7 @@ const FirmwareUpdate = (props) => {
           <Divider sx={{ my: 2 }} />
           <FirmwareVersion />
           <FirmwareSelect
-            selectedFirmware={[selected, setSelected]}
+            selectedFirmware={[selectedFirmwareType, setSelectedFirmwareType]}
             firmwareFilename={[firmwareFilename, setFirmwareFilename]}
           />
           <Divider sx={{ my: 2 }} />

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -64,13 +64,6 @@ const FirmwareUpdate = (props) => {
 
   const _flash = async (options) => {
     const focus = new Focus();
-    let filename;
-
-    if (selectedFirmwareType == "default") {
-      filename = activeDevice.defaultFirmwareFilename();
-    } else {
-      filename = firmwareFilename;
-    }
 
     const nextStep = async (desiredState) => {
       const steps = focusDeviceDescriptor.flashSteps(options);
@@ -92,7 +85,10 @@ const FirmwareUpdate = (props) => {
       (await checkExternalFlasher(focusDeviceDescriptor));
     return focusDeviceDescriptor.flash(
       focus._port,
-      filename,
+      selectedFirmwareType === "default"
+        ? activeDevice.defaultFirmwareFilename()
+        : firmwareFilename,
+
       Object.assign({}, options, {
         preferExternalFlasher: preferExternalFlasher,
         device: focusDeviceDescriptor,

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -31,12 +31,10 @@ import Typography from "@mui/material/Typography";
 import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
 import { PageTitle } from "@renderer/components/PageTitle";
 import { toast } from "@renderer/components/Toast";
-import { getStaticPath } from "@renderer/config";
 import checkExternalFlasher from "@renderer/utils/checkExternalFlasher";
-import { ipcRenderer } from "electron";
-import fs from "fs";
-import path from "path";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
 import { useTranslation } from "react-i18next";
 
 import FirmwareVersion from "./FirmwareUpdate/FirmwareVersion";
@@ -49,6 +47,8 @@ const settings = new Store();
 
 const FirmwareUpdate = (props) => {
   const focus = new Focus();
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
 
   const [firmwareFilename, setFirmwareFilename] = useState("");
   const [selected, setSelected] = useState("default");
@@ -62,25 +62,12 @@ const FirmwareUpdate = (props) => {
   const focusDeviceDescriptor =
     props.focusDeviceDescriptor || focus.focusDeviceDescriptor;
 
-  const _defaultFirmwareFilename = () => {
-    const { vendor, product } = focusDeviceDescriptor.info;
-    const firmwareType = focusDeviceDescriptor.info.firmwareType || "hex";
-    const cVendor = vendor.replace("/", ""),
-      cProduct = product.replace("/", "");
-    return path.join(
-      getStaticPath(),
-      cVendor,
-      cProduct,
-      "default." + firmwareType
-    );
-  };
-
   const _flash = async (options) => {
     const focus = new Focus();
     let filename;
 
     if (selected == "default") {
-      filename = _defaultFirmwareFilename();
+      filename = activeDevice.defaultFirmwareFilename();
     } else {
       filename = firmwareFilename;
     }

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -99,7 +99,7 @@ const FirmwareUpdate = (props) => {
   };
 
   const upload = async (options) => {
-    await setFlashSteps(focusDeviceDescriptor.flashSteps(options));
+    setFlashSteps(focusDeviceDescriptor.flashSteps(options));
 
     setConfirmationOpen(false);
     setFactoryConfirmationOpen(false);
@@ -110,7 +110,7 @@ const FirmwareUpdate = (props) => {
     logger().info("Starting to flash");
     try {
       await _flash(options);
-      await setActiveStep(flashSteps.length);
+      setActiveStep(flashSteps.length);
     } catch (e) {
       logger().error("Error while uploading firmware", { error: e });
       setProgress("error");

--- a/src/renderer/screens/FirmwareUpdate/FirmwareChangesDialog.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareChangesDialog.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -39,8 +41,17 @@ const FirmwareChangesDialog = (props) => {
   const [data] = ipcRenderer.sendSync("file.read", file);
 
   return (
-    <Dialog open={props.open} fullWidth maxWidth="md">
-      <DialogTitle>{t("firmwareUpdate.firmwareChangelog.title")}</DialogTitle>
+    <Dialog open={props.open} fullWidth maxWidth="md" onClose={props.onClose}>
+      <DialogTitle sx={{ display: "flex" }}>
+        {t("firmwareUpdate.firmwareChangelog.title")}
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          startIcon={<OpenInNewIcon />}
+          href="https://github.com/keyboardio/Chrysalis-Firmware-Bundle"
+        >
+          {t("firmwareUpdate.firmwareSources")}
+        </Button>
+      </DialogTitle>
       <DialogContent dividers>
         <ReactMarkdown remarkPlugins={[remarkGfm, remarkEmoji]}>
           {data}

--- a/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
@@ -20,6 +20,8 @@ import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormLabel from "@mui/material/FormLabel";
+import Grid from "@mui/material/Grid";
+
 import ListItemText from "@mui/material/ListItemText";
 import ListItem from "@mui/material/ListItem";
 import Radio from "@mui/material/Radio";
@@ -31,6 +33,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import FirmwareChangesDialog from "./FirmwareChangesDialog";
+import Link from "@mui/material/Link";
 
 const FirmwareSelect = (props) => {
   const { t } = useTranslation();
@@ -83,35 +86,48 @@ const FirmwareSelect = (props) => {
             <FormControlLabel
               value="default"
               control={<Radio />}
-              label={
-                <ListItem>
-                  <ListItemText
-                    sx={{ ml: 1 }}
-                    primary={t("firmwareUpdate.firmwareVersion", {
-                      version: version,
-                    })}
-                  />
-                  <Button color="info" onClick={() => setChangelogOpen(true)}>
-                    {t("firmwareUpdate.firmwareChangelog.view")}
-                  </Button>
-                </ListItem>
-              }
+              label={t("firmwareUpdate.defaultFirmwareDescription")}
             />
+            <Typography sx={{ color: "text.secondary", ml: 1 }}>
+              {t("firmwareUpdate.firmwareVersion", {
+                version: version,
+              })}
+            </Typography>
+            <Typography variant="subtitle2" sx={{ ml: 1, mt: 1 }}>
+              {t("firmwareUpdate.defaultFirmwareExplanation")}
+
+              <Grid container justifyContent="flex-end">
+                <Button
+                  sx={{}}
+                  color="info"
+                  onClick={() => setChangelogOpen(true)}
+                >
+                  {t("firmwareUpdate.firmwareChangelog.view", {
+                    version: version,
+                  })}
+                </Button>
+              </Grid>
+            </Typography>
             <FormControlLabel
               value="custom"
               control={<Radio />}
-              label={
-                <ListItem>
-                  <ListItemText
-                    sx={{ ml: 1 }}
-                    primary={t("firmwareUpdate.custom", {
-                      version: version,
-                    })}
-                    secondary={filename}
-                  />
-                </ListItem>
-              }
+              label={t("firmwareUpdate.custom")}
             />
+            <Typography sx={{ color: "text.secondary", ml: 1 }}>
+              {filename}
+            </Typography>
+            <Typography variant="subtitle2" sx={{ ml: 1, mt: 1 }}>
+              {t("firmwareUpdate.customFirmwareExplanation")}
+            </Typography>
+            <Grid container justifyContent="flex-end">
+              <Button
+                href="https://kaleidoscope.readthedocs.io/"
+                color="info"
+                target="_blank"
+              >
+                {t("firmwareUpdate.customFirmwareLinkText")}
+              </Button>
+            </Grid>
           </RadioGroup>
           <Box></Box>
         </Box>

--- a/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormLabel from "@mui/material/FormLabel";
@@ -22,29 +24,19 @@ import ListItemText from "@mui/material/ListItemText";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
-import { GlobalContext } from "@renderer/components/GlobalContext";
-import useEffectOnce from "@renderer/hooks/useEffectOnce";
 import { version } from "@root/package.json";
 import { ipcRenderer } from "electron";
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import FirmwareChangesDialog from "./FirmwareChangesDialog";
 
 const FirmwareSelect = (props) => {
   const { t } = useTranslation();
-  const globalContext = useContext(GlobalContext);
-  const [activeDevice] = globalContext.state.activeDevice;
 
-  const [fwVersion, setFwVersion] = useState(null);
+  const [changelogOpen, setChangelogOpen] = useState(false);
   const [selected, setSelected] = props.selectedFirmware;
   const [firmwareFilename, setFirmwareFilename] = props.firmwareFilename;
-
-  useEffectOnce(() => {
-    const fetchData = async () => {
-      const v = await activeDevice.focus.command("version");
-      if (v) setFwVersion(v);
-    };
-    fetchData();
-  });
 
   const selectFirmware = (event) => {
     setSelected(event.target.value);
@@ -78,56 +70,54 @@ const FirmwareSelect = (props) => {
   }
 
   return (
-    <FormControl fullWidth>
-      <FormLabel>
-        <Typography variant="h6">
-          {t("firmwareUpdate.chooseFirmware")}
-        </Typography>
-      </FormLabel>
-      <RadioGroup sx={{ ml: 2 }} value={selected} onChange={selectFirmware}>
-        <FormControlLabel
-          value="current"
-          control={<Radio />}
-          label={
-            <ListItemText
-              sx={{ ml: 1 }}
-              primary={t("firmwareUpdate.current")}
-              secondary={t("firmwareUpdate.firmwareVersion", {
-                version: fwVersion,
-              })}
-            />
-          }
-        />
-        <FormControlLabel
-          value="default"
-          control={<Radio />}
-          label={
-            <ListItemText
-              sx={{ ml: 1 }}
-              primary={t("firmwareUpdate.defaultFirmwareDescription")}
-              secondary={t("firmwareUpdate.firmwareVersion", {
-                version: version,
-              })}
-            />
-          }
-        />
-        <FormControlLabel
-          value="custom"
-          control={<Radio />}
-          label={
-            <ListItemText
-              sx={{ ml: 1 }}
-              primary={t("firmwareUpdate.custom", {
-                version: version,
-              })}
-              secondary={
-                filename || t("firmwareUpdate.chooseCustomFirmwareFile")
+    <>
+      <FormControl fullWidth>
+        <FormLabel>
+          <Typography variant="h6">
+            {t("firmwareUpdate.chooseFirmware")}
+          </Typography>
+        </FormLabel>
+        <Box sx={{ display: "flex" }}>
+          <RadioGroup sx={{ ml: 2 }} value={selected} onChange={selectFirmware}>
+            <FormControlLabel
+              value="default"
+              control={<Radio />}
+              label={
+                <ListItemText
+                  sx={{ ml: 1 }}
+                  primary={t("firmwareUpdate.defaultFirmwareDescription")}
+                  secondary={t("firmwareUpdate.firmwareVersion", {
+                    version: version,
+                  })}
+                />
               }
             />
-          }
-        />
-      </RadioGroup>
-    </FormControl>
+            <FormControlLabel
+              value="custom"
+              control={<Radio />}
+              label={
+                <ListItemText
+                  sx={{ ml: 1 }}
+                  primary={t("firmwareUpdate.custom", {
+                    version: version,
+                  })}
+                  secondary={filename || t("firmwareUpdate.customChooseFile")}
+                />
+              }
+            />
+          </RadioGroup>
+          <Box>
+            <Button color="info" onClick={() => setChangelogOpen(true)}>
+              {t("firmwareUpdate.firmwareChangelog.view")}
+            </Button>
+          </Box>
+        </Box>
+      </FormControl>
+      <FirmwareChangesDialog
+        open={changelogOpen}
+        onClose={() => setChangelogOpen(false)}
+      />
+    </>
   );
 };
 

--- a/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
@@ -1,0 +1,134 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormLabel from "@mui/material/FormLabel";
+import ListItemText from "@mui/material/ListItemText";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import Typography from "@mui/material/Typography";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+import useEffectOnce from "@renderer/hooks/useEffectOnce";
+import { version } from "@root/package.json";
+import { ipcRenderer } from "electron";
+import React, { useState, useContext } from "react";
+import { useTranslation } from "react-i18next";
+
+const FirmwareSelect = (props) => {
+  const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
+
+  const [fwVersion, setFwVersion] = useState(null);
+  const [selected, setSelected] = props.selectedFirmware;
+  const [firmwareFilename, setFirmwareFilename] = props.firmwareFilename;
+
+  useEffectOnce(() => {
+    const fetchData = async () => {
+      const v = await activeDevice.focus.command("version");
+      if (v) setFwVersion(v);
+    };
+    fetchData();
+  });
+
+  const selectFirmware = (event) => {
+    setSelected(event.target.value);
+    if (event.target.value != "custom") {
+      return setFirmwareFilename("");
+    }
+
+    const [fileName, fileData] = ipcRenderer.sendSync("file.open-with-dialog", {
+      title: t("firmwareUpdate.dialog.selectFirmware"),
+      filters: [
+        {
+          name: t("firmwareUpdate.dialog.firmwareFiles"),
+          extensions: ["hex", "bin"],
+        },
+        {
+          name: t("firmwareUpdate.dialog.allFiles"),
+          extensions: ["*"],
+        },
+      ],
+    });
+
+    if (fileName) {
+      setFirmwareFilename(fileName);
+    }
+  };
+
+  let filename = null;
+  if (firmwareFilename) {
+    filename = firmwareFilename.split(/[\\/]/);
+    filename = filename[filename.length - 1];
+  }
+
+  return (
+    <FormControl fullWidth>
+      <FormLabel>
+        <Typography variant="h6">
+          {t("firmwareUpdate.chooseFirmware")}
+        </Typography>
+      </FormLabel>
+      <RadioGroup sx={{ ml: 2 }} value={selected} onChange={selectFirmware}>
+        <FormControlLabel
+          value="current"
+          control={<Radio />}
+          label={
+            <ListItemText
+              sx={{ ml: 1 }}
+              primary={t("firmwareUpdate.current")}
+              secondary={t("firmwareUpdate.firmwareVersion", {
+                version: fwVersion,
+              })}
+            />
+          }
+        />
+        <FormControlLabel
+          value="default"
+          control={<Radio />}
+          label={
+            <ListItemText
+              sx={{ ml: 1 }}
+              primary={t("firmwareUpdate.defaultFirmwareDescription")}
+              secondary={t("firmwareUpdate.firmwareVersion", {
+                version: version,
+              })}
+            />
+          }
+        />
+        <FormControlLabel
+          value="custom"
+          control={<Radio />}
+          label={
+            <ListItemText
+              sx={{ ml: 1 }}
+              primary={t("firmwareUpdate.custom", {
+                version: version,
+              })}
+              secondary={
+                filename || t("firmwareUpdate.chooseCustomFirmwareFile")
+              }
+            />
+          }
+        />
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+export default FirmwareSelect;

--- a/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
@@ -21,6 +21,7 @@ import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormLabel from "@mui/material/FormLabel";
 import ListItemText from "@mui/material/ListItemText";
+import ListItem from "@mui/material/ListItem";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
@@ -83,34 +84,36 @@ const FirmwareSelect = (props) => {
               value="default"
               control={<Radio />}
               label={
-                <ListItemText
-                  sx={{ ml: 1 }}
-                  primary={t("firmwareUpdate.defaultFirmwareDescription")}
-                  secondary={t("firmwareUpdate.firmwareVersion", {
-                    version: version,
-                  })}
-                />
+                <ListItem>
+                  <ListItemText
+                    sx={{ ml: 1 }}
+                    primary={t("firmwareUpdate.firmwareVersion", {
+                      version: version,
+                    })}
+                  />
+                  <Button color="info" onClick={() => setChangelogOpen(true)}>
+                    {t("firmwareUpdate.firmwareChangelog.view")}
+                  </Button>
+                </ListItem>
               }
             />
             <FormControlLabel
               value="custom"
               control={<Radio />}
               label={
-                <ListItemText
-                  sx={{ ml: 1 }}
-                  primary={t("firmwareUpdate.custom", {
-                    version: version,
-                  })}
-                  secondary={filename || t("firmwareUpdate.customChooseFile")}
-                />
+                <ListItem>
+                  <ListItemText
+                    sx={{ ml: 1 }}
+                    primary={t("firmwareUpdate.custom", {
+                      version: version,
+                    })}
+                    secondary={filename}
+                  />
+                </ListItem>
               }
             />
           </RadioGroup>
-          <Box>
-            <Button color="info" onClick={() => setChangelogOpen(true)}>
-              {t("firmwareUpdate.firmwareChangelog.view")}
-            </Button>
-          </Box>
+          <Box></Box>
         </Box>
       </FormControl>
       <FirmwareChangesDialog

--- a/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
@@ -16,27 +16,37 @@
  */
 
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-
-import React, { useState } from "react";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+import useEffectOnce from "@renderer/hooks/useEffectOnce";
+import React, { useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 
-const UpdateDescription = (props) => {
+const FirmwareVersion = (props) => {
   const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+  const [activeDevice] = globalContext.state.activeDevice;
+
+  const [fwVersion, setFwVersion] = useState(null);
+
+  useEffectOnce(() => {
+    const fetchData = async () => {
+      const v = await activeDevice.focus.command("version");
+      if (v) setFwVersion(v);
+    };
+    fetchData();
+  });
 
   return (
-    <>
-      <Box>
-        <Typography component="p" gutterBottom>
-          {t("firmwareUpdate.description")}
-        </Typography>
-      </Box>
-      <Box sx={{ display: "flex" }}>
-        <Box sx={{ flexGrow: 1 }} />
-      </Box>
-    </>
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="h6">
+        {t("firmwareUpdate.currentFirmwareVersion")}
+      </Typography>
+      <Typography color="secondary" sx={{ ml: 3 }}>
+        {fwVersion}
+      </Typography>
+    </Box>
   );
 };
 
-export default UpdateDescription;
+export default FirmwareVersion;

--- a/src/renderer/screens/FirmwareUpdate/FlashSteps.js
+++ b/src/renderer/screens/FirmwareUpdate/FlashSteps.js
@@ -1,0 +1,49 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Container from "@mui/material/Container";
+import Step from "@mui/material/Step";
+import StepLabel from "@mui/material/StepLabel";
+import Stepper from "@mui/material/Stepper";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+const FlashSteps = (props) => {
+  const { t } = useTranslation();
+
+  if (props.activeStep < 0) return null;
+
+  const steps = props.steps.map((step) => {
+    return t("firmwareUpdate.flashing.steps." + step);
+  });
+
+  return (
+    <Container>
+      <Stepper activeStep={props.activeStep} alternativeLabel>
+        {steps.map((label) => {
+          return (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          );
+        })}
+      </Stepper>
+    </Container>
+  );
+};
+
+export default FlashSteps;

--- a/src/renderer/screens/FirmwareUpdate/UpdateDescription.js
+++ b/src/renderer/screens/FirmwareUpdate/UpdateDescription.js
@@ -1,0 +1,52 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import FirmwareChangesDialog from "./FirmwareChangesDialog";
+
+const UpdateDescription = (props) => {
+  const { t } = useTranslation();
+  const [changelogOpen, setChangelogOpen] = useState(false);
+
+  return (
+    <>
+      <Box>
+        <Typography component="p" gutterBottom>
+          {t("firmwareUpdate.description")}
+        </Typography>
+      </Box>
+      <Box sx={{ display: "flex" }}>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button color="info" onClick={() => setChangelogOpen(true)}>
+          {t("firmwareUpdate.firmwareChangelog.view")}
+        </Button>
+      </Box>
+      <FirmwareChangesDialog
+        open={changelogOpen}
+        onClose={() => setChangelogOpen(false)}
+      />
+    </>
+  );
+};
+
+export default UpdateDescription;


### PR DESCRIPTION
There were multiple complaints against the firmware update screen, and this redesign addresses most of them. The goal was to simplify the screen, reduce the amount of unnecessary information displayed at a time, while also showing useful information we did not show before.

## The main Firmware Update screen

![Screenshot from 2022-06-26 19-19-47](https://user-images.githubusercontent.com/17243/175826149-8f29106a-4032-4d4a-8548-7b8f5574514c.png)

With this redesign, the update instructions are no longer shown directly on the firmware update screen. Instead, when one selects the "Upload" or "Factory reset" actions, the popup dialog will show the instructions instead. Previously, clicking on "Upload" started the process immediately without confirmation - now we ask for confirmation in this case too. Both in order to be able to display the instructions, and to avoid accidentally triggering the process. See below for additional screenshots.

Then, the dropdown that was used to select the firmware to use has been replaced by a group of radio buttons. We only ever have three choices: the current firmware (for which a version is shown now, if available), the firmware Chrysalis ships with, or a custom one. Having all options visible at the same time presents useful information, and is easier to navigate than a dropdown. It also presented a great opportunity to display the running firmware version, which fixes #533.

Another bit of information that wasn't strictly necessary to see all the time is the link to the firmware sources. Since we have a "View firmware changes" button now, the link to the firmware sources was moved to the changelog dialog.

A much smaller - but still important - change is that doing a factory reset as part of the update is now its own button, rather than a checkbox. This way it can simply be clicked, rather than requiring ticking a checkbox and then clicking "Update". It also makes the "Update" button's action straightforward, it always does the same thing: updates the current firmware. It no longer depends on external state to significantly alter its behaviour. It's only important input is the firmware to flash.

## Update

![Screenshot from 2022-06-26 19-19-28](https://user-images.githubusercontent.com/17243/175826232-52f401bb-0cbb-415d-8fe2-2414ac82e7cc.png)

## Factory reset

![Screenshot from 2022-06-26 19-19-34](https://user-images.githubusercontent.com/17243/175826243-73100905-1e76-4eb3-9ad5-ae337fad83ce.png)

## Firmware Changes

![Screenshot from 2022-06-26 19-19-40](https://user-images.githubusercontent.com/17243/175826251-163b5d83-ef40-473f-bb54-45c55f37f7db.png)

# Other notes

Other than an UI overhaul, this PR implements another important change: Moving the Factory Reset handling to `api/flash`, rather than trying to drive it from the frontend. Our factory reset + firmware update combo has been broken for a while, moving it to `api/flash` allowed me to fix it in a sane, and reliable way.

As an added benefit, the steps displayed are now correct in both cases.