### PR TITLE
Improved scaling down to smaller window sizes

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -70,6 +70,8 @@ async function createMainWindow() {
     y: mainWindowState.y,
     width: mainWindowState.width,
     height: mainWindowState.height,
+    minWidth: 800,
+    minHeight: 600,
     resizable: true,
     icon: path.join(getStaticPath(), "/logo.png"),
     autoHideMenuBar: true,

--- a/src/renderer/screens/ChangeLog.js
+++ b/src/renderer/screens/ChangeLog.js
@@ -18,6 +18,7 @@
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
+import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import { PageTitle } from "@renderer/components/PageTitle";
 import { getStaticPath } from "@renderer/config";
@@ -38,9 +39,9 @@ const ChangeLog = (props) => {
   const data = fs.readFileSync(file).toString();
 
   return (
-    <div>
+    <Container>
       <PageTitle title={t("changelog.title")} />
-      <Card sx={{ mx: "auto", my: 2, maxWidth: "50%" }}>
+      <Card sx={{ my: 2 }}>
         <CardHeader
           avatar={<img src={logo} alt={t("components.logo.altText")} />}
           title="Chrysalis"
@@ -66,7 +67,7 @@ const ChangeLog = (props) => {
           </ReactMarkdown>
         </CardContent>
       </Card>
-    </div>
+    </Container>
   );
 };
 

--- a/src/renderer/screens/Preferences/components/PreferenceWithHeading.js
+++ b/src/renderer/screens/Preferences/components/PreferenceWithHeading.js
@@ -22,7 +22,7 @@ import React from "react";
 
 const PreferenceWithHeading = (props) => {
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box sx={{ display: "flex", flexWrap: "wrap" }}>
       <Box>
         <Typography variant="body1">{props.heading}</Typography>
         {props.subheading && (

--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -44,7 +44,7 @@ const LayoutSelect = (props) => {
   return (
     <Autocomplete
       size="small"
-      sx={{ minWidth: "20em" }}
+      sx={{ minWidth: "15em" }}
       value={db.getSupportedLayouts().find((item) => item.name === layout)}
       groupBy={(option) => option.language || option.group}
       onChange={changeLayout}

--- a/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
@@ -93,8 +93,8 @@ const ModeCard = styled(ModeCardBase)((props) => {
     const color = colorToRGBA(theme.palette.primary[theme.palette.mode]);
     return {
       width: 120,
-      marginLeft: `${theme.spacing(2)}`,
-      marginRight: `${theme.spacing(2)}`,
+      minWidth: 120,
+      margin: `${theme.spacing(1)}`,
       boxShadow: `0px 5px 5px -3px rgb(${color[0]} ${color[1]} ${color[2]} / 40%),
                   0px 8px 10px 1px rgb(${color[0]} ${color[1]} ${color[2]} / 28%),
                   0px 3px 14px 2px rgb(${color[0]} ${color[1]} ${color[2]} / 24%)`,
@@ -102,8 +102,8 @@ const ModeCard = styled(ModeCardBase)((props) => {
   } else {
     return {
       width: 120,
-      marginLeft: `${theme.spacing(2)}`,
-      marginRight: `${theme.spacing(2)}`,
+      minWidth: 120,
+      margin: `${theme.spacing(1)}`,
     };
   }
 });

--- a/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LookAndFeelPreferences.js
@@ -172,7 +172,7 @@ function LookAndFeelPreferences(props) {
       <Typography sx={{ my: "auto" }} variant="body1">
         {t("preferences.ui.theme.label")}
       </Typography>
-      <Box sx={{ display: "inline-flex", my: 2 }}>
+      <Box sx={{ display: "inline-flex", my: 2, flexWrap: "wrap" }}>
         <ModeCard
           name="system"
           image={systemSvg}

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -24,6 +24,7 @@ import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
+import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import MuiDialogTitle from "@mui/material/DialogTitle";
@@ -137,14 +138,9 @@ function SystemInfo(props) {
   );
 
   return (
-    <Box sx={{ display: "flex", justifyContent: "center" }}>
+    <Container>
       <PageTitle title={t("systeminfo.title")} />
-      <Card
-        sx={{
-          margin: 4,
-          maxWidth: "50%",
-        }}
-      >
+      <Card sx={{ m: 4 }}>
         <CardHeader
           avatar={<img src={logo} alt={t("components.logo.altText")} />}
           title="Chrysalis"
@@ -177,7 +173,7 @@ function SystemInfo(props) {
         </CardActions>
       </Card>
       {viewDialog}
-    </Box>
+    </Container>
   );
 }
 


### PR DESCRIPTION
This contains a number of small fixes for visual bugs at smaller window sizes. To make our life a little easier, it also sets a minimum window size of 800x600.

Fixes #963.

For comparison, included below are a set of before & after screenshots of affected parts, at 800x600.

## Changelog

### Before

![changelog](https://user-images.githubusercontent.com/17243/176150551-aed46de9-c788-4859-98bd-0b9cffafc2dd.png)

### After

![changelog](https://user-images.githubusercontent.com/17243/176150791-2d84d384-5497-469c-a6f7-8cfbef523b8f.png)

## Report a Problem

### Before

![report-a-problem](https://user-images.githubusercontent.com/17243/176151145-fff97529-27fc-427c-8838-ed3540b8083a.png)

### After

![report-a-problem](https://user-images.githubusercontent.com/17243/176151309-c295c7d8-c0a2-4656-af4e-234b7218ef77.png)

## Preferences: UI

### Before

![preferences-ui](https://user-images.githubusercontent.com/17243/176151142-035df097-df2f-4a9b-8901-ce091036753e.png)

### After

![preferences-ui-1](https://user-images.githubusercontent.com/17243/176151301-dd1ff259-05d3-4c19-a7e1-678745038720.png)
![preferences-ui-2](https://user-images.githubusercontent.com/17243/176151305-5e04f939-329a-4206-add2-c54de3a74ebb.png)

## Preferences: My Keyboard

### Before

![preferences-my-keyboard](https://user-images.githubusercontent.com/17243/176151138-b8fbc8c4-c745-49cc-b4fc-bedad1307d35.png)

### After

![preferences-my-keyboard](https://user-images.githubusercontent.com/17243/176151298-02148210-1893-4f44-8150-3d24fd290fc6.png)
