### PR TITLE
Move the initial theme setup into a useEffect

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -47,7 +47,6 @@ import KeyboardSelect from "./screens/KeyboardSelect";
 import LayoutCard from "./screens/LayoutCard";
 import Preferences from "./screens/Preferences";
 import SystemInfo from "./screens/SystemInfo";
-import { migrateDarkModeToTheme } from "./utils/darkMode";
 
 import { useAutoUpdate } from "./hooks/useAutoUpdate";
 
@@ -76,9 +75,6 @@ const App = (props) => {
   const [bgColor, setBgColor] = useState(null);
 
   useAutoUpdate();
-
-  migrateDarkModeToTheme();
-  setTheme(settings.get("ui.theme", "system"));
 
   const handleDeviceDisconnect = async (sender, vid, pid) => {
     if (!focus.focusDeviceDescriptor) return;
@@ -133,6 +129,8 @@ const App = (props) => {
   useEffect(() => {
     ipcRenderer.on("usb.device-disconnected", handleDeviceDisconnect);
     ipcRenderer.on("native-theme.updated", handleNativeThemeUpdate);
+
+    setTheme(settings.get("ui.theme", "system"));
 
     // Specify how to clean up after this effect:
     return function cleanup() {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -22,11 +22,14 @@ import ReactDOM from "react-dom";
 import "../styles/keymap.css";
 import App from "./App";
 import { GlobalContextProvider } from "./components/GlobalContext";
+import { migrateDarkModeToTheme } from "./utils/darkMode";
+
 import { Error } from "./Error";
 import "./i18n"; // to initialize the i18n system
 const { ipcRenderer } = require("electron");
 
 setupLogging();
+migrateDarkModeToTheme();
 
 // Enable Hot Module Reload in dev
 if (module.hot) module.hot.accept();


### PR DESCRIPTION
Because setting the theme modifies state, if we do that from the renderer function, we need to do it from a `useEffect`. While there, move `migrateDarkModeToTheme()` from App's renderer to index.js. We only need to do the migration once, not on every render, so it didn't make sense to have it in App anyway.
