### PR TITLE
Implement a firmware file auto-update mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "i18next": "^21.6.14",
     "i18next-electron-language-detector": "^0.0.10",
     "immutability-helper": "^3.1.1",
+    "js-yaml": "^4.1.0",
     "json-stringify-pretty-compact": "^3.0.0",
     "react": "^17.0.2",
     "react-color": "^2.14.1",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -33,6 +33,7 @@ import {
 import { registerDevtoolsHandlers } from "./ipc_devtools";
 import { registerExitHandlers } from "./ipc_exit";
 import { registerFileIoHandlers } from "./ipc_file_io";
+import { registerFirmwareHandlers } from "./ipc_firmware";
 import { registerLoggingHandlers } from "./ipc_logging";
 import { registerNativeThemeHandlers } from "./ipc_nativetheme";
 import { registerSystemInfoHandlers } from "./ipc_system_info";
@@ -194,6 +195,7 @@ registerBackupHandlers();
 registerDeviceDiscoveryHandlers();
 registerDevtoolsHandlers();
 registerFileIoHandlers();
+registerFirmwareHandlers();
 registerLoggingHandlers();
 registerNativeThemeHandlers();
 registerSystemInfoHandlers();

--- a/src/main/ipc_firmware.js
+++ b/src/main/ipc_firmware.js
@@ -1,0 +1,252 @@
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { app, ipcMain, net } from "electron";
+import { version } from "../../package.json";
+import { sendToRenderer } from "./utils";
+
+import Store from "electron-store";
+import fs from "fs";
+import path from "path";
+import semver from "semver";
+import tar from "tar";
+import yaml from "js-yaml";
+
+export const registerFirmwareHandlers = () => {
+  const slug = "keyboardio/Chrysalis-Firmware-Bundle";
+  const firmwarePath = path.join(app.getPath("userData"), "latest-firmware");
+
+  const gh = async (url, headers, cb) => {
+    const options = {
+      method: "GET",
+      headers: Object.assign({ "User-Agent": `Chrysalis/${version}` }, headers),
+      url: url,
+    };
+
+    return new Promise((resolve) => {
+      const request = net.request(options);
+      let data = "";
+      request.on("error", async (error) => {
+        cb && cb("error", error);
+        resolve(null);
+      });
+      request.on("response", async (response) => {
+        if (response.statusCode != 200) {
+          cb &&
+            cb("error", {
+              statusCode: response.statusCode,
+              url: url,
+            });
+          resolve(null);
+          return;
+        }
+        const total = parseInt(response.headers["content-length"]);
+        let size = 0;
+        response.on("data", (chunk) => {
+          size += chunk.length;
+          data += chunk;
+
+          if (cb) {
+            if (total) {
+              sendToRenderer("firmware-update.download-progress", {
+                total,
+                size,
+                percent: (size / total) * 100,
+              });
+            }
+            cb("data", chunk);
+          }
+        });
+        response.on("end", () => {
+          resolve(data);
+          cb && cb("end");
+        });
+        response.on("error", () => {
+          resolve(null);
+          cb && cb("error");
+        });
+      });
+      request.end();
+    });
+  };
+
+  const ghApi = async (path) => {
+    const data = await gh(`https://api.github.com/repos/${slug}${path}`, {
+      Accept: "application/vnd.github.v3+json",
+    });
+
+    try {
+      return JSON.parse(data);
+    } catch (_) {
+      return null;
+    }
+  };
+
+  const ghDL = (tag, asset, cb) => {
+    return gh(
+      `https://github.com/${slug}/releases/download/${tag}/${asset}`,
+      {},
+      cb
+    );
+  };
+
+  const getLatestInfo = async () => {
+    const releases = await ghApi("/releases");
+    if (!Array.isArray(releases) || releases.length == 0) {
+      sendToRenderer(
+        "firmware-update.warning",
+        "Unable to fetch latest release"
+      );
+      return null;
+    }
+    const latestTag = releases[0].tag_name;
+    if (!releases || !latestTag) {
+      sendToRenderer(
+        "firmware-update.warning",
+        "Unable to fetch latest release"
+      );
+      return null;
+    }
+    const latestYaml = await ghDL(latestTag, "build-info.yml");
+    if (!latestYaml) {
+      sendToRenderer(
+        "firmware-update.warning",
+        `Unable to fetch ${latestTag}/build-info.yml`
+      );
+      return null;
+    }
+
+    let buildInfo;
+    try {
+      buildInfo = yaml.load(latestYaml);
+    } catch (e) {
+      sendToRenderer(
+        "firmware-update.warning",
+        `Unable to parse ${latestTag}/build-info.yml: ${e}`
+      );
+      return null;
+    }
+
+    return { latestTag, buildInfo };
+  };
+
+  const checkForUpdates = async () => {
+    const info = await getLatestInfo();
+    if (!info) return;
+
+    let localBuildInfo;
+    try {
+      const data = fs.readFileSync(path.join(firmwarePath, "build-info.yml"));
+      localBuildInfo = yaml.load(data);
+    } catch (_) {
+      // Ignore errors
+    }
+
+    if (
+      (localBuildInfo &&
+        semver.gt(info.buildInfo.version, localBuildInfo.version)) ||
+      (!localBuildInfo && semver.gt(info.buildInfo.version, version))
+    ) {
+      sendToRenderer("firmware-update.update-available", info.buildInfo);
+    }
+  };
+
+  const updateFirmware = async () => {
+    const info = await getLatestInfo();
+    if (!info) {
+      sendToRenderer(
+        "firmware-update.error",
+        "getLatestInfo() failed, after checkForUpdates() succeeded"
+      );
+      return;
+    }
+
+    fs.mkdirSync(firmwarePath, { recursive: true });
+
+    const t = tar.x({
+      strip: 1,
+      gzip: true,
+      cwd: firmwarePath,
+      onwarn: (warn) => {
+        sendToRenderer("firmware-update.error", warn);
+      },
+    });
+
+    const r = await ghDL(
+      info.latestTag,
+      "firmware-files.tar.gz",
+      (event, chunk) => {
+        if (event == "data") {
+          t.write(chunk);
+        } else if (event == "end") {
+          t.end();
+        } else if (event == "error") {
+          sendToRenderer("firmware-update.error", chunk);
+        }
+      }
+    );
+    if (r) {
+      sendToRenderer("firmware-update.update-downloaded", info.buildInfo);
+    }
+  };
+
+  ipcMain.handle("firmware-update.check-for-updates", (event, mode) => {
+    if (mode != "automatic") return;
+
+    checkForUpdates();
+  });
+
+  ipcMain.handle("firmware-update.download", (event) => {
+    updateFirmware();
+  });
+
+  const getFirmwareBaseDirectory = () => {
+    const settings = new Store();
+
+    let baseDir = __static;
+    if (settings.get("firmwareAutoUpdate.mode", "manual") == "automatic") {
+      try {
+        fs.accessSync(path.join(firmwarePath, "build-info.yml"));
+        baseDir = firmwarePath;
+      } catch (_) {
+        // Ignore, we'll use the default __static return value
+      }
+    }
+
+    return baseDir;
+  };
+
+  ipcMain.on("firmware.get-changelog", (event) => {
+    const baseDir = getFirmwareBaseDirectory();
+    const changelog = fs.readFileSync(
+      path.join(baseDir, "firmware-changelog.md")
+    );
+
+    event.returnValue = new TextDecoder().decode(changelog);
+  });
+
+  ipcMain.on("firmware.get-version", (event) => {
+    const baseDir = getFirmwareBaseDirectory();
+    const data = fs.readFileSync(path.join(baseDir, "build-info.yml"));
+    const buildInfo = yaml.load(data);
+
+    event.returnValue = buildInfo.version.match(/[^+]*/)[0];
+  });
+
+  ipcMain.on("firmware.get-base-directory", (event) => {
+    event.returnValue = getFirmwareBaseDirectory();
+  });
+};

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -17,7 +17,7 @@
 
 import Focus from "@api/focus";
 import path from "path";
-import { getStaticPath } from "@renderer/config";
+import { ipcRenderer } from "electron";
 
 export function ActiveDevice() {
   this.port = undefined;
@@ -75,7 +75,7 @@ export function ActiveDevice() {
     const cVendor = vendor.replace("/", ""),
       cProduct = product.replace("/", "");
     return path.join(
-      getStaticPath(),
+      ipcRenderer.sendSync("firmware.get-base-directory"),
       cVendor,
       cProduct,
       "default." + firmwareType

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -49,6 +49,7 @@ import Preferences from "./screens/Preferences";
 import SystemInfo from "./screens/SystemInfo";
 
 import { useAutoUpdate } from "./hooks/useAutoUpdate";
+import { useFirmwareAutoUpdate } from "./hooks/useFirmwareAutoUpdate";
 
 const { ipcRenderer } = require("electron");
 const Store = require("electron-store");
@@ -75,6 +76,7 @@ const App = (props) => {
   const [bgColor, setBgColor] = useState(null);
 
   useAutoUpdate();
+  useFirmwareAutoUpdate();
 
   const handleDeviceDisconnect = async (sender, vid, pid) => {
     if (!focus.focusDeviceDescriptor) return;

--- a/src/renderer/components/GlobalContext.js
+++ b/src/renderer/components/GlobalContext.js
@@ -26,6 +26,7 @@ export const GlobalContextProvider = (props) => {
   const [focusDeviceDescriptor, setFocusDeviceDescriptor] = useState(null);
   const [activeDevice, setActiveDevice] = useState(null);
   const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [firmwareUpdateWarning, setFirmwareUpdateWarning] = useState(false);
 
   const getDarkMode = () => {
     if (theme == "system") {
@@ -41,6 +42,7 @@ export const GlobalContextProvider = (props) => {
     focusDeviceDescriptor: [focusDeviceDescriptor, setFocusDeviceDescriptor],
     activeDevice: [activeDevice, setActiveDevice],
     updateAvailable: [updateAvailable, setUpdateAvailable],
+    firmwareUpdateWarning: [firmwareUpdateWarning, setFirmwareUpdateWarning],
   };
 
   return (

--- a/src/renderer/hooks/useFirmwareAutoUpdate.js
+++ b/src/renderer/hooks/useFirmwareAutoUpdate.js
@@ -30,6 +30,8 @@ export const useFirmwareAutoUpdate = () => {
 
   const [updateAvailable, setUpdateAvailable] =
     globalContext.state.updateAvailable;
+  const [_, setFirmwareUpdateWarning] =
+    globalContext.state.firmwareUpdateWarning;
   const [updateInfo, setUpdateInfo] = useState(null);
 
   useEffect(() => {
@@ -57,6 +59,7 @@ export const useFirmwareAutoUpdate = () => {
         t("firmwareAutoUpdate.downloaded", { version: info.version })
       );
       setUpdateAvailable(true);
+      setFirmwareUpdateWarning(false);
     };
     const onUpdateError = (event, error) => {
       logger().error("Update error", {
@@ -65,6 +68,7 @@ export const useFirmwareAutoUpdate = () => {
       });
       toast.error(t("firmwareAutoUpdate.error"));
       setUpdateAvailable(false);
+      setFirmwareUpdateWarning(true);
     };
     const onUpdateWarning = (event, error) => {
       logger().warn("Update warning", {
@@ -72,6 +76,7 @@ export const useFirmwareAutoUpdate = () => {
         label: "firmware-update",
       });
       setUpdateAvailable(false);
+      setFirmwareUpdateWarning(true);
     };
 
     ipcRenderer.invoke(

--- a/src/renderer/hooks/useFirmwareAutoUpdate.js
+++ b/src/renderer/hooks/useFirmwareAutoUpdate.js
@@ -1,0 +1,107 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ipcRenderer } from "electron";
+import Store from "electron-store";
+import React, { useEffect, useState, useContext } from "react";
+import { useTranslation } from "react-i18next";
+
+import { logger } from "@api/log";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+import { toast } from "@renderer/components/Toast";
+
+export const useFirmwareAutoUpdate = () => {
+  const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+
+  const [updateAvailable, setUpdateAvailable] =
+    globalContext.state.updateAvailable;
+  const [updateInfo, setUpdateInfo] = useState(null);
+
+  useEffect(() => {
+    const settings = new Store();
+
+    const onUpdateAvailable = (event, info) => {
+      logger().verbose("Update available", {
+        updateInfo: info,
+        label: "firmware-update",
+      });
+      setUpdateInfo(info);
+      toast.info(t("firmwareAutoUpdate.available", { version: info.version }));
+      ipcRenderer.invoke("firmware-update.download");
+    };
+    const onDownloadProgress = (event, progress) => {
+      console.log("download-progress", progress);
+      toast.progress(progress.percent);
+    };
+    const onUpdateDownloaded = (event, info) => {
+      logger().verbose("Update downloaded", {
+        updateInfo: info,
+        label: "firmware-update",
+      });
+      toast.success(
+        t("firmwareAutoUpdate.downloaded", { version: info.version })
+      );
+      setUpdateAvailable(true);
+    };
+    const onUpdateError = (event, error) => {
+      logger().error("Update error", {
+        error: error,
+        label: "firmware-update",
+      });
+      toast.error(t("firmwareAutoUpdate.error"));
+      setUpdateAvailable(false);
+    };
+    const onUpdateWarning = (event, error) => {
+      logger().warn("Update warning", {
+        warning: error,
+        label: "firmware-update",
+      });
+      setUpdateAvailable(false);
+    };
+
+    ipcRenderer.invoke(
+      "firmware-update.check-for-updates",
+      settings.get("firmwareAutoUpdate.mode", "manual")
+    );
+
+    ipcRenderer.on("firmware-update.update-available", onUpdateAvailable);
+    ipcRenderer.on("firmware-update.download-progress", onDownloadProgress);
+    ipcRenderer.on("firmware-update.update-downloaded", onUpdateDownloaded);
+    ipcRenderer.on("firmware-update.error", onUpdateError);
+    ipcRenderer.on("firmware-update.warning", onUpdateWarning);
+
+    return function cleanup() {
+      ipcRenderer.removeListener(
+        "firmware-update.update-available",
+        onUpdateAvailable
+      );
+      ipcRenderer.removeListener(
+        "firmware-update.download-progress",
+        onDownloadProgress
+      );
+      ipcRenderer.removeListener(
+        "firmware-update.update-downloaded",
+        onUpdateDownloaded
+      );
+      ipcRenderer.removeListener("firmware-update.error", onUpdateError);
+      ipcRenderer.removeListener("firmware-update.warning", onUpdateWarning);
+    };
+  }, [setUpdateAvailable, t]);
+
+  return updateInfo;
+};

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -21,6 +21,11 @@
     "downloaded": "Version {{ version }} downloaded, restart Chrysalis to finish installing",
     "error": "Error during update: {{ error }}"
   },
+  "firmwareAutoUpdate": {
+    "available": "New firmware version available: {{ version }}",
+    "downloaded": "Firmware version {{ version }} downloaded, and is available for flashing",
+    "error": "Error while downloading the new firmware version."
+  },
   "dialog": {
     "ok": "Ok",
     "cancel": "Cancel",
@@ -242,6 +247,10 @@
         "mode": {
           "label": "Enable automatic upgrades",
           "help": "When enabled, Chrysalis will check for updates on startup, and automatically download new versions."
+        },
+        "firmwareMode": {
+          "label": "Enable automatic firmware file updates",
+          "help": "When enabled, Chrysalis will check for updated firmware files on startup, and automatically download new versions."
         }
       },
       "layoutEditor": {
@@ -396,7 +405,6 @@
     "chooseFirmware": "Update firmware:",
     "defaultFirmwareDescription": "Latest version",
     "defaultFirmwareExplanation": "This is the latest version of the firmware for your keyboard.",
-    
     "custom": "Choose a local firmware build",
     "customChooseFile": "Choose a file...",
     "customFirmwareExplanation": "You can install an alternate firmware build you've downloaded or built locally. As long as it includes support for the 'Focus' keyboard protocol, Chrysalis should work just fine.",

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -24,7 +24,8 @@
   "firmwareAutoUpdate": {
     "available": "New firmware version available: {{ version }}",
     "downloaded": "Firmware version {{ version }} downloaded, and is available for flashing",
-    "error": "Error while downloading the new firmware version."
+    "error": "Error while downloading the new firmware version.",
+    "warning": "Chrysalis was unable to check for a new firmware version. A newer version may be available online."
   },
   "dialog": {
     "ok": "Ok",

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -39,6 +39,7 @@ import { useTranslation } from "react-i18next";
 
 import FirmwareVersion from "./FirmwareUpdate/FirmwareVersion";
 import FirmwareSelect from "./FirmwareUpdate/FirmwareSelect";
+import FirmwareUpdateWarning from "./FirmwareUpdate/FirmwareUpdateWarning";
 import FlashSteps from "./FirmwareUpdate/FlashSteps";
 import UpdateDescription from "./FirmwareUpdate/UpdateDescription";
 
@@ -151,6 +152,7 @@ const FirmwareUpdate = (props) => {
   return (
     <>
       <PageTitle title={t("app.menu.firmwareUpdate")} />
+      <FirmwareUpdateWarning />
       <Container sx={{ my: 4, width: "50%" }}>
         <Typography variant="h6" gutterBottom>
           {t("firmwareUpdate.yourFirmware")}

--- a/src/renderer/screens/FirmwareUpdate/FirmwareChangesDialog.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareChangesDialog.js
@@ -34,11 +34,7 @@ import remarkGfm from "remark-gfm";
 
 const FirmwareChangesDialog = (props) => {
   const { classes } = props;
-
   const { t } = useTranslation();
-
-  const file = path.join(getStaticPath(), "firmware-changelog.md");
-  const [data] = ipcRenderer.sendSync("file.read", file);
 
   return (
     <Dialog open={props.open} fullWidth maxWidth="md" onClose={props.onClose}>
@@ -54,7 +50,7 @@ const FirmwareChangesDialog = (props) => {
       </DialogTitle>
       <DialogContent dividers>
         <ReactMarkdown remarkPlugins={[remarkGfm, remarkEmoji]}>
-          {data}
+          {props.changelog}
         </ReactMarkdown>
       </DialogContent>
       <DialogActions>

--- a/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareSelect.js
@@ -29,7 +29,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
 import { version } from "@root/package.json";
 import { ipcRenderer } from "electron";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import FirmwareChangesDialog from "./FirmwareChangesDialog";
@@ -41,6 +41,19 @@ const FirmwareSelect = (props) => {
   const [changelogOpen, setChangelogOpen] = useState(false);
   const [selected, setSelected] = props.selectedFirmware;
   const [firmwareFilename, setFirmwareFilename] = props.firmwareFilename;
+  const [firmwareVersion, setFirmwareVersion] = useState(version);
+  const [firmwareChangelog, setFirmwareChangelog] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const v = await ipcRenderer.sendSync("firmware.get-version");
+      setFirmwareVersion(v);
+
+      const c = await ipcRenderer.sendSync("firmware.get-changelog");
+      setFirmwareChangelog(c);
+    };
+    fetchData();
+  }, []);
 
   const selectFirmware = (event) => {
     setSelected(event.target.value);
@@ -90,7 +103,7 @@ const FirmwareSelect = (props) => {
             />
             <Typography sx={{ color: "text.secondary", ml: 1 }}>
               {t("firmwareUpdate.firmwareVersion", {
-                version: version,
+                version: firmwareVersion,
               })}
             </Typography>
             <Typography variant="subtitle2" sx={{ ml: 1, mt: 1 }}>
@@ -103,7 +116,7 @@ const FirmwareSelect = (props) => {
                   onClick={() => setChangelogOpen(true)}
                 >
                   {t("firmwareUpdate.firmwareChangelog.view", {
-                    version: version,
+                    version: firmwareVersion,
                   })}
                 </Button>
               </Grid>
@@ -134,6 +147,7 @@ const FirmwareSelect = (props) => {
       </FormControl>
       <FirmwareChangesDialog
         open={changelogOpen}
+        changelog={firmwareChangelog}
         onClose={() => setChangelogOpen(false)}
       />
     </>

--- a/src/renderer/screens/FirmwareUpdate/FirmwareUpdateWarning.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareUpdateWarning.js
@@ -1,0 +1,43 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2018-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Alert from "@mui/material/Alert";
+import Typography from "@mui/material/Typography";
+import React, { useContext } from "react";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
+import { useTranslation } from "react-i18next";
+
+const Store = require("electron-store");
+const settings = new Store();
+
+const FirmwareUpdateWarning = (props) => {
+  const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+  const [firmwareUpdateWarning] = globalContext.state.firmwareUpdateWarning;
+
+  if (!firmwareUpdateWarning) return null;
+  if (settings.get("firmwareAutoUpdate.mode") !== "automatic") return null;
+
+  return (
+    <Alert severity="warning">
+      <Typography component="p">{t("firmwareAutoUpdate.warning")}</Typography>
+    </Alert>
+  );
+};
+
+export default FirmwareUpdateWarning;

--- a/src/renderer/screens/Preferences/ui/AutoUpdatePreferences.js
+++ b/src/renderer/screens/Preferences/ui/AutoUpdatePreferences.js
@@ -29,7 +29,20 @@ function AutoUpdatePreferences(props) {
   const { t, i18n } = useTranslation();
 
   const [autoUpdateMode, setAutoUpdateMode] = useState("manual");
+  const [firmwareAutoUpdateMode, setFirmwareAutoUpdateMode] =
+    useState("manual");
   const [loaded, setLoaded] = useState(false);
+
+  const toggleFirmwareAutoUpdateMode = (event) => {
+    const mode = event.target.checked ? "automatic" : "manual";
+
+    settings.set("firmwareAutoUpdate.mode", mode);
+    setFirmwareAutoUpdateMode(mode);
+
+    if (mode == "automatic") {
+      ipcRenderer.invoke("firmware-update.check-for-updates", mode);
+    }
+  };
 
   const toggleAutoUpdateMode = (event) => {
     const mode = event.target.checked ? "automatic" : "manual";
@@ -45,6 +58,9 @@ function AutoUpdatePreferences(props) {
   useEffect(() => {
     const initialize = async () => {
       await setAutoUpdateMode(settings.get("autoUpdate.mode", "manual"));
+      await setFirmwareAutoUpdateMode(
+        settings.get("firmwareAutoUpdate.mode", "manual")
+      );
       await setLoaded(true);
     };
 
@@ -58,6 +74,12 @@ function AutoUpdatePreferences(props) {
         option="ui.autoUpdate.mode"
         checked={autoUpdateMode == "automatic"}
         onChange={toggleAutoUpdateMode}
+      />
+      <PreferenceSwitch
+        loaded={loaded}
+        option="ui.autoUpdate.firmwareMode"
+        checked={firmwareAutoUpdateMode == "automatic"}
+        onChange={toggleFirmwareAutoUpdateMode}
       />
     </PreferenceSection>
   );

--- a/static/build-info.yml
+++ b/static/build-info.yml
@@ -1,0 +1,146 @@
+---
+build: 5
+version: 0.10.4+5
+
+dependencies:
+  cores:
+    avr: keyboardio/Kaleidoscope-Bundle-Keyboardio@a9165613d1aab35d8be365b54976460165d790f9
+    gd32: keyboardio/ArduinoCore-GD32-Keyboardio@3de303acb1bc2b5e70db745232611112ba2261bc
+  libraries:
+    avr:
+      - keyboardio/KeyboardioHID@b274575c3f3adb529df409d3f5b10a4ae2e3eb53
+    gd32:
+      - keyboardio/KeyboardioHID@35cb0a704f51953512222334396b58fedef039fe
+    common:
+      - keyboardio/Kaleidoscope@dde7caeee9e82f4398b165ca21879751677b10b3
+      - keyboardio/Chrysalis-Firmware-Bundle@b4d7f560e229807ce2ecebb3b73ad2a4787b784b
+
+firmware:
+  Keyboardio:
+    Atreus:
+      plugins:
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - EscapeOneShot
+        - EscapeOneShotConfig
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - Macros
+        - MouseKeys
+        - OneShot
+        - Qukeys
+        - SpaceCadet
+    Model100:
+      plugins:
+        - AlphaSquareEffect
+        - BootGreetingEffect
+        - ColormapEffect
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - EscapeOneShot
+        - EscapeOneShotConfig
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - HardwareTestMode
+        - HostPowerManagement
+        - IdleLEDs
+        - LEDBreatheEffect
+        - LEDChaseEffect
+        - LEDControl
+        - LEDOff
+        - LEDPaletteTheme
+        - LEDRainbowEffect
+        - LEDRainbowWaveEffect
+        - Macros
+        - MagicCombo
+        - MouseKeys
+        - NumPad
+        - OneShot
+        - PersistentIdleLEDs
+        - Qukeys
+        - SpaceCadet
+        - StalkerEffect
+        - USBQuirks
+    Model01:
+      plugins:
+        - BootGreetingEffect
+        - ColormapEffect
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - HardwareTestMode
+        - HostPowerManagement
+        - LEDBreatheEffect
+        - LEDChaseEffect
+        - LEDControl
+        - LEDOff
+        - LEDPaletteTheme
+        - LEDRainbowEffect
+        - LEDRainbowWaveEffect
+        - Macros
+        - MagicCombo
+        - MouseKeys
+        - NumPad
+        - Qukeys
+        - USBQuirks
+  EZ:
+    ErgoDox:
+      plugins:
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - EscapeOneShot
+        - EscapeOneShotConfig
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - MouseKeys
+        - OneShot
+        - Qukeys
+        - SpaceCadet
+  Technomancy:
+    Atreus:
+      plugins:
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - EscapeOneShot
+        - EscapeOneShotConfig
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - Macros
+        - MouseKeys
+        - OneShot
+        - Qukeys
+        - SpaceCadet
+  SOFTHRUF:
+    Splitography:
+      plugins:
+        - DynamicMacros
+        - EEPROMKeymap
+        - EEPROMSettings
+        - EscapeOneShot
+        - EscapeOneShotConfig
+        - FirmwareVersion
+        - Focus
+        - FocusEEPROMCommand
+        - FocusSettingsCommand
+        - GeminiPR
+        - MouseKeys
+        - MultiSwitcher
+        - OneShot
+        - Qukeys
+        - SpaceCadet


### PR DESCRIPTION
Modeled after the application update mechanism, the firmware file auto-update works in a similar way: if the feature is enabled (it is disabled by default), it will check what's the latest version of the firmware on GitHub, and if it's more recent than the version we ship with, and more recent than whatever we have previously downloaded (if anything), then it will download the new bundle and extract it.

The Firmware Update screen will ask the main process for the version, changelog, and base directory to use for the default firmware. If firmware auto-update is enabled, the main process will check first try the downloaded files, and only fall back to the shipped version if we have nothing downloaded yet.

If firmware auto-update is disabled, then we won't even check if there's a new version, because we'll almost always have an update, and we do not want to spam notifications on every single startup.

Fixes #952.

## Screenshots

### Preferences

![Screenshot from 2022-07-10 12-54-49](https://user-images.githubusercontent.com/17243/178141996-467d6dc6-f539-47f7-9a77-df0be04ad8ec.png)

### Firmware Update screen

![Screenshot from 2022-07-10 12-55-02](https://user-images.githubusercontent.com/17243/178141995-033c6766-5dfe-49cf-8cb7-e3b14374d842.png)

### Firmware Changelog

![Screenshot from 2022-07-10 12-55-07](https://user-images.githubusercontent.com/17243/178141992-47f7bb86-a507-4411-9625-dfdb99e35ef0.png)

## Notes

Firmware bundles are downloaded at app start time (if the feature is enabled), or whenever the setting is toggled on. Once downloaded, Chrysalis will not hit the network again, and will use the local files instead. Thus, the FirmwareUpdate screen renders as fast as previously, because all the data is available locally by that time.

I intentionally made it so that when firmware auto-update is enabled and the bundle has been downloaded, the shipped version is not shown anywhere. I originally showed both (+ custom), but that made the screen very crowded, and it felt unnecessary. Disabling the firmware auto-update will result in the shipped firmware being shown again, so one can downgrade to that, if need be, with little extra work.