### PR TITLE
api/focus/keymap: Update modifier-augmented key labels too when switching layouts

### DIFF
--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -20,6 +20,7 @@ import cldr_data from "./cldr_data";
 import { Base } from "./db/base";
 import { USQwerty } from "./db/us/qwerty";
 import { constants } from "./db/constants";
+import { withModifiers } from "./db/modifiers";
 
 import enLangMap from "./cldr_languages/en";
 import nlLangMap from "./cldr_languages/nl";
@@ -116,9 +117,9 @@ class KeymapDB {
 
     if (!this._layouts.hasOwnProperty(layout)) return;
 
-    const table = this._layouts[layout];
+    const codeTable = withModifiers(this._layouts[layout].codetable);
 
-    for (const key of table.codetable) {
+    for (const key of codeTable) {
       if (this._codetable[key.code]) {
         const base = this._codetable[key.code];
         this._codetable[key.code].label = Object.assign(

--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -118,88 +118,43 @@ class KeymapDB {
 
     const table = this._layouts[layout];
 
-    if (table.codetable instanceof Promise) {
-      table.codetable.then((data) => {
-        for (const key of data) {
-          if (this._codetable[key.code]) {
-            const base = this._codetable[key.code];
-            this._codetable[key.code].label = Object.assign(
-              {},
-              base.label,
-              key.label
-            );
-          } else {
-            this._codetable[key.code] = Object.assign({}, key);
-          }
-          // If there is no dualuse key for this keycode, continue with the next
-          // one.
-          if (!this._codetable[key.code + 49169]?.baseCode) continue;
-          if (key.code >= 256) continue;
+    for (const key of table.codetable) {
+      if (this._codetable[key.code]) {
+        const base = this._codetable[key.code];
+        this._codetable[key.code].label = Object.assign(
+          {},
+          base.label,
+          key.label
+        );
+      } else {
+        this._codetable[key.code] = Object.assign({}, key);
+      }
+      // If there is no dualuse key for this keycode, continue with the next
+      // one.
+      if (!this._codetable[key.code + 49169]?.baseCode) continue;
+      if (key.code >= 256) continue;
 
-          // dual-use modifiers
-          for (const m of [0, 1, 2, 3, 6]) {
-            const dumCode = key.code + 49169 + m * 256;
-            if (this._codetable[dumCode]) {
-              const base = this._codetable[dumCode];
-              this._codetable[dumCode].label = Object.assign(
-                {},
-                { hint: base.label.hint, base: key.label.base }
-              );
-            }
-          }
-
-          // dual-use layers
-          for (const l of [0, 1, 2, 3, 4, 5, 6, 7]) {
-            const dulCode = key.code + 51218 + l * 256;
-            if (this._codetable[dulCode]) {
-              const base = this._codetable[dulCode];
-              this._codetable[dulCode].label = Object.assign(
-                {},
-                { hint: base.label.hint, base: key.label.base }
-              );
-            }
-          }
-        }
-      });
-    } else {
-      for (const key of table.codetable) {
-        if (this._codetable[key.code]) {
-          const base = this._codetable[key.code];
-          this._codetable[key.code].label = Object.assign(
+      // dual-use modifiers
+      for (const m of [0, 1, 2, 3, 6]) {
+        const dumCode = key.code + 49169 + m * 256;
+        if (this._codetable[dumCode]) {
+          const base = this._codetable[dumCode];
+          this._codetable[dumCode].label = Object.assign(
             {},
-            base.label,
-            key.label
+            { hint: base.label.hint, base: key.label.base }
           );
-        } else {
-          this._codetable[key.code] = Object.assign({}, key);
         }
-        // If there is no dualuse key for this keycode, continue with the next
-        // one.
-        if (!this._codetable[key.code + 49169]?.baseCode) continue;
-        if (key.code >= 256) continue;
+      }
 
-        // dual-use modifiers
-        for (const m of [0, 1, 2, 3, 6]) {
-          const dumCode = key.code + 49169 + m * 256;
-          if (this._codetable[dumCode]) {
-            const base = this._codetable[dumCode];
-            this._codetable[dumCode].label = Object.assign(
-              {},
-              { hint: base.label.hint, base: key.label.base }
-            );
-          }
-        }
-
-        // dual-use layers
-        for (const l of [0, 1, 2, 3, 4, 5, 6, 7]) {
-          const dulCode = key.code + 51218 + l * 256;
-          if (this._codetable[dulCode]) {
-            const base = this._codetable[dulCode];
-            this._codetable[dulCode].label = Object.assign(
-              {},
-              { hint: base.label.hint, base: key.label.base }
-            );
-          }
+      // dual-use layers
+      for (const l of [0, 1, 2, 3, 4, 5, 6, 7]) {
+        const dulCode = key.code + 51218 + l * 256;
+        if (this._codetable[dulCode]) {
+          const base = this._codetable[dulCode];
+          this._codetable[dulCode].label = Object.assign(
+            {},
+            { hint: base.label.hint, base: key.label.base }
+          );
         }
       }
     }


### PR DESCRIPTION
When switching layouts, wrap the new code table with `withModifiers()`, to add modifier augmented keycodes to it, too. This, in turn, will make the code following this update these modifier-augmented keycodes according to the new table.

In practice, this means that if the host layout is set to, say, US Dvorak, then keys like `Ctrl+Y` will render as `Ctrl+Y`, rather than `Ctrl+T` (`T` is the same keycode on Qwerty as `Y` is on Dvorak).

Fixes #993.

The PR also removes a bit of code rendered obsolete by pre-processing the CLDR files. Without removing that branch, we'd have to do the same thing there, too, while it would never be called.