### PR TITLE
Editor: Fix the onClick handler of LegacyAlert

### DIFF
--- a/src/renderer/screens/Editor/components/LegacyAlert.js
+++ b/src/renderer/screens/Editor/components/LegacyAlert.js
@@ -21,14 +21,14 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-export const LegacyAlert = (migrateLegacy) => {
+export const LegacyAlert = (props) => {
   const { t } = useTranslation();
 
   return (
     <Alert
       severity="error"
       action={
-        <Button color="primary" onClick={migrateLegacy}>
+        <Button color="primary" onClick={props.migrateLegacy}>
           {t("editor.legacy.migrate")}
         </Button>
       }


### PR DESCRIPTION
When the LegacyAlert component was lifted out, it was lifted out as if it was a function within the renderer, rather than a component. As such, it was expecting to receive the onClick handler directly, rather than a prop.

As it is a component which receives props, lets make it aware of that, and use `props.migrateLegacy`, so the handler actually gets called.

Fixes #988.
