### PR TITLE
LayoutCard: Use custom layer names for the header too, if available

### DIFF
--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -109,7 +109,7 @@ const LayoutCard = (props) => {
                 marginLeft: 5,
               }}
             >
-              {t("components.layer", { index: i })}
+              {layerNames.names[i] || t("components.layer", { index: i })}
             </Typography>
             <KeymapSVG
               className="layer"


### PR DESCRIPTION
Don't just pass down the custom names for the keymap renderer, use the custom name for the page header too, if a custom name is available.

![Screenshot from 2022-07-23 11-18-04](https://user-images.githubusercontent.com/17243/180598924-cfce8dc4-da60-49dc-8964-45578495296c.png)
