### PR TITLE
After printing, display some kind of feedback

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -15,6 +15,7 @@
  */
 
 import { app, BrowserWindow, Menu } from "electron";
+import { sendToRenderer } from "./utils";
 
 const isMac = process.platform === "darwin";
 export const buildMenu = (mainWindow) => {
@@ -48,10 +49,19 @@ export const buildMenu = (mainWindow) => {
           accelerator: "CmdOrCtrl+P",
 
           click: () => {
-            BrowserWindow.getFocusedWindow().webContents.print({
-              color: true,
-              printBackground: true,
-            });
+            BrowserWindow.getFocusedWindow().webContents.print(
+              {
+                color: true,
+                printBackground: true,
+              },
+              (success, errorType) => {
+                if (success) {
+                  sendToRenderer("print.feedback", "success");
+                } else {
+                  sendToRenderer("print.feedback", errorType);
+                }
+              }
+            );
           },
         },
       ],

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -114,6 +114,17 @@ const App = (props) => {
     setTheme("system");
   };
 
+  const handlePrintFeedback = (event, feedback) => {
+    logger().debug("print feedback received", { feedback });
+    if (feedback === "success") {
+      toast.success(t("print.feedback.success"), {
+        autoHideDuration: 5000,
+      });
+    } else if (feedback !== "canceled") {
+      toast.error(t("print.feedback.error"));
+    }
+  };
+
   useEffect(() => {
     async function setupLayout() {
       const layoutSetting = await settings.get(
@@ -131,11 +142,13 @@ const App = (props) => {
   useEffect(() => {
     ipcRenderer.on("usb.device-disconnected", handleDeviceDisconnect);
     ipcRenderer.on("native-theme.updated", handleNativeThemeUpdate);
+    ipcRenderer.on("print.feedback", handlePrintFeedback);
 
     setTheme(settings.get("ui.theme", "system"));
 
     // Specify how to clean up after this effect:
     return function cleanup() {
+      ipcRenderer.removeListener("print.feedback", handlePrintFeedback);
       ipcRenderer.removeListener(
         "native-theme.updated",
         handleNativeThemeUpdate

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -4,6 +4,12 @@
     "deviceDisconnected": "Keyboard disconnected",
     "saveFile": "Error saving a file: {{ error }}"
   },
+  "print": {
+    "feedback": {
+      "success": "Successfully printed!",
+      "error": "Error encountered while printing."
+    }
+  },
   "components": {
     "layer": "Layer {{index}}",
     "layerRaw": "Layer",


### PR DESCRIPTION
When printing finished (or rather, whenever Electron decides to call our callback), display a notification about whether the print finished, or error'd. No notification is displayed if the print is canceled.

Fixes #996.
