### PR TITLE
FirmwareAutoUpdate: Do not pretend an app update is available

### DIFF
--- a/src/renderer/hooks/useFirmwareAutoUpdate.js
+++ b/src/renderer/hooks/useFirmwareAutoUpdate.js
@@ -28,8 +28,6 @@ export const useFirmwareAutoUpdate = () => {
   const { t } = useTranslation();
   const globalContext = useContext(GlobalContext);
 
-  const [updateAvailable, setUpdateAvailable] =
-    globalContext.state.updateAvailable;
   const [_, setFirmwareUpdateWarning] =
     globalContext.state.firmwareUpdateWarning;
   const [updateInfo, setUpdateInfo] = useState(null);
@@ -47,7 +45,6 @@ export const useFirmwareAutoUpdate = () => {
       ipcRenderer.invoke("firmware-update.download");
     };
     const onDownloadProgress = (event, progress) => {
-      console.log("download-progress", progress);
       toast.progress(progress.percent);
     };
     const onUpdateDownloaded = (event, info) => {
@@ -58,7 +55,6 @@ export const useFirmwareAutoUpdate = () => {
       toast.success(
         t("firmwareAutoUpdate.downloaded", { version: info.version })
       );
-      setUpdateAvailable(true);
       setFirmwareUpdateWarning(false);
     };
     const onUpdateError = (event, error) => {
@@ -67,7 +63,6 @@ export const useFirmwareAutoUpdate = () => {
         label: "firmware-update",
       });
       toast.error(t("firmwareAutoUpdate.error"));
-      setUpdateAvailable(false);
       setFirmwareUpdateWarning(true);
     };
     const onUpdateWarning = (event, error) => {
@@ -75,7 +70,6 @@ export const useFirmwareAutoUpdate = () => {
         warning: error,
         label: "firmware-update",
       });
-      setUpdateAvailable(false);
       setFirmwareUpdateWarning(true);
     };
 
@@ -106,7 +100,7 @@ export const useFirmwareAutoUpdate = () => {
       ipcRenderer.removeListener("firmware-update.error", onUpdateError);
       ipcRenderer.removeListener("firmware-update.warning", onUpdateWarning);
     };
-  }, [setUpdateAvailable, t]);
+  }, [setFirmwareUpdateWarning, t]);
 
   return updateInfo;
 };


### PR DESCRIPTION
The `useFirmwareAutoUpdate` hook was initially copied from `useAutoUpdate`, and as part of the process, it set the `updateAvailable` state on the global context. That's unrelated to firmware auto-updates, and the hook should not touch it at all, so this patch removes that.

The result of the mistake was that whenever there was a firmware update, Chrysalis' main sidebar also showed an "Apply update & restart" menu item by mistake. With the hook not fiddling with state it has no business with, this is no longer the case.