### PR TITLE
FirmwareVersion: Display a default when the firmware version is unavailable

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -410,6 +410,7 @@
     "customChooseFile": "Choose a file...",
     "customFirmwareExplanation": "You can install an alternate firmware build you've downloaded or built locally. As long as it includes support for the 'Focus' keyboard protocol, Chrysalis should work just fine.",
     "currentFirmwareVersion": "Current firmware version",
+    "currentFirmwareVersionUnavailable": "Firmware version unavailable",
     "customFirmwareLinkText": "Learn about building firmware",
     "firmwareVersion": "{{version}}",
     "description": "Updating your keyboard's firmware is how we teach it new tricks. Chrysalis can install the version of the firmware it ships with, or a custom firmware build you provide."

--- a/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
@@ -16,6 +16,7 @@
  */
 
 import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import useEffectOnce from "@renderer/hooks/useEffectOnce";
@@ -32,7 +33,11 @@ const FirmwareVersion = (props) => {
   useEffectOnce(() => {
     const fetchData = async () => {
       const v = await activeDevice.focus.command("version");
-      if (v) setFwVersion(v);
+      if (v) {
+        setFwVersion(v);
+      } else {
+        setFwVersion(t("firmwareUpdate.currentFirmwareVersionUnavailable"));
+      }
     };
     fetchData();
   });
@@ -43,7 +48,7 @@ const FirmwareVersion = (props) => {
         {t("firmwareUpdate.currentFirmwareVersion")}
       </Typography>
       <Typography color="secondary" sx={{ ml: 3 }}>
-        {fwVersion}
+        {fwVersion || <Skeleton variant="rectangle" width={120} height={24} />}
       </Typography>
     </Box>
   );


### PR DESCRIPTION
In case we can't detect the firmware version, display a default saying so, rather than having a bit of empty space. Also display a suitably sized skeleton box while the version is being retrieved.

![Screenshot from 2022-07-25 08-37-36](https://user-images.githubusercontent.com/17243/180713751-7b5793e7-acee-4f37-83f2-b61e7cff5996.png)
