### PR TITLE
Fix custom layer name displays on the Overview & non-Model01/100 devices

### DIFF
--- a/src/api/hardware-ez-ergodox/components/Keymap.js
+++ b/src/api/hardware-ez-ergodox/components/Keymap.js
@@ -34,14 +34,15 @@ const Keymap = (props) => {
     return row * 6 + col;
   };
 
-  const Key = (props) => {
+  const Key = (kprops) => {
     if (!keymap) return null;
-    const { x, y, row, col, transform } = props;
-    const width = props.width || 1,
-      height = props.height || 1,
+    const { x, y, row, col, transform } = kprops;
+    const width = kprops.width || 1,
+      height = kprops.height || 1,
       bottom = y + height * 40 - 4;
     const key = keymap[keyIndex(row, col)],
       stroke = selectedKey == keyIndex(row, col) ? "#f3b3b3" : "#b3b3b3";
+    const legend = key && db.format(key, { layerNames: props.layerNames });
     return (
       <g
         transform={transform}
@@ -61,10 +62,10 @@ const Keymap = (props) => {
           fill="#ffffff"
         />
         <text x={x + 3} y={y + 14}>
-          {key && key.label && key.label.hint}
+          {legend?.hint}
         </text>
         <text x={x + 3} y={bottom}>
-          {key && key.label && db.format(key).main}
+          {legend?.main}
         </text>
       </g>
     );

--- a/src/api/hardware-keyboardio-atreus2/components/Keymap.js
+++ b/src/api/hardware-keyboardio-atreus2/components/Keymap.js
@@ -78,7 +78,7 @@ const Keymap = (props) => {
     let textColor = "#ffffff";
     const buttonColor = "transparent";
     let legendClass = "";
-    const legend = key && db.format(key);
+    const legend = key && db.format(key, { layerNames: props.layerNames });
     if (key && (legend.main || "").length <= 1 && !legend.hint)
       legendClass = "short-legend";
     if (key && key.code == 0) textColor = "#888888";
@@ -100,10 +100,10 @@ const Keymap = (props) => {
           fill={buttonColor}
         />
         <text x={x + 5} y={y + 14} fill={textColor} className={legendClass}>
-          {key && db.format(key).hint}
+          {legend?.hint}
         </text>
         <text x={x + 5} y={bottom} fill={textColor} className={legendClass}>
-          {key && db.format(key).main}
+          {legend?.main}
         </text>
       </g>
     );
@@ -124,61 +124,61 @@ const Keymap = (props) => {
     >
       <g transform="translate(80,0)">
         <g transform="rotate(10)">
-          <Key row={0} col={0} />
-          <Key row={0} col={1} />
-          <Key row={0} col={2} />
-          <Key row={0} col={3} />
-          <Key row={0} col={4} />
+          <Key layerNames={props.layerNames} row={0} col={0} />
+          <Key layerNames={props.layerNames} row={0} col={1} />
+          <Key layerNames={props.layerNames} row={0} col={2} />
+          <Key layerNames={props.layerNames} row={0} col={3} />
+          <Key layerNames={props.layerNames} row={0} col={4} />
 
-          <Key row={1} col={0} />
-          <Key row={1} col={1} />
-          <Key row={1} col={2} />
-          <Key row={1} col={3} />
-          <Key row={1} col={4} />
+          <Key layerNames={props.layerNames} row={1} col={0} />
+          <Key layerNames={props.layerNames} row={1} col={1} />
+          <Key layerNames={props.layerNames} row={1} col={2} />
+          <Key layerNames={props.layerNames} row={1} col={3} />
+          <Key layerNames={props.layerNames} row={1} col={4} />
 
-          <Key row={2} col={0} />
-          <Key row={2} col={1} />
-          <Key row={2} col={2} />
-          <Key row={2} col={3} />
-          <Key row={2} col={4} />
-          <Key row={2} col={5} />
+          <Key layerNames={props.layerNames} row={2} col={0} />
+          <Key layerNames={props.layerNames} row={2} col={1} />
+          <Key layerNames={props.layerNames} row={2} col={2} />
+          <Key layerNames={props.layerNames} row={2} col={3} />
+          <Key layerNames={props.layerNames} row={2} col={4} />
+          <Key layerNames={props.layerNames} row={2} col={5} />
 
-          <Key row={3} col={0} />
-          <Key row={3} col={1} />
-          <Key row={3} col={2} />
-          <Key row={3} col={3} />
-          <Key row={3} col={4} />
+          <Key layerNames={props.layerNames} row={3} col={0} />
+          <Key layerNames={props.layerNames} row={3} col={1} />
+          <Key layerNames={props.layerNames} row={3} col={2} />
+          <Key layerNames={props.layerNames} row={3} col={3} />
+          <Key layerNames={props.layerNames} row={3} col={4} />
 
-          <Key row={3} col={5} />
+          <Key layerNames={props.layerNames} row={3} col={5} />
         </g>
 
         <g transform="rotate(-10)">
           <g transform="translate(0, 120.5)">
-            <Key row={0} col={7} />
-            <Key row={0} col={8} />
-            <Key row={0} col={9} />
-            <Key row={0} col={10} />
-            <Key row={0} col={11} />
+            <Key layerNames={props.layerNames} row={0} col={7} />
+            <Key layerNames={props.layerNames} row={0} col={8} />
+            <Key layerNames={props.layerNames} row={0} col={9} />
+            <Key layerNames={props.layerNames} row={0} col={10} />
+            <Key layerNames={props.layerNames} row={0} col={11} />
 
-            <Key row={1} col={7} />
-            <Key row={1} col={8} />
-            <Key row={1} col={9} />
-            <Key row={1} col={10} />
-            <Key row={1} col={11} />
+            <Key layerNames={props.layerNames} row={1} col={7} />
+            <Key layerNames={props.layerNames} row={1} col={8} />
+            <Key layerNames={props.layerNames} row={1} col={9} />
+            <Key layerNames={props.layerNames} row={1} col={10} />
+            <Key layerNames={props.layerNames} row={1} col={11} />
 
-            <Key row={2} col={6} />
-            <Key row={2} col={7} />
-            <Key row={2} col={8} />
-            <Key row={2} col={9} />
-            <Key row={2} col={10} />
-            <Key row={2} col={11} />
+            <Key layerNames={props.layerNames} row={2} col={6} />
+            <Key layerNames={props.layerNames} row={2} col={7} />
+            <Key layerNames={props.layerNames} row={2} col={8} />
+            <Key layerNames={props.layerNames} row={2} col={9} />
+            <Key layerNames={props.layerNames} row={2} col={10} />
+            <Key layerNames={props.layerNames} row={2} col={11} />
 
-            <Key row={3} col={6} />
-            <Key row={3} col={7} />
-            <Key row={3} col={8} />
-            <Key row={3} col={9} />
-            <Key row={3} col={10} />
-            <Key row={3} col={11} />
+            <Key layerNames={props.layerNames} row={3} col={6} />
+            <Key layerNames={props.layerNames} row={3} col={7} />
+            <Key layerNames={props.layerNames} row={3} col={8} />
+            <Key layerNames={props.layerNames} row={3} col={9} />
+            <Key layerNames={props.layerNames} row={3} col={10} />
+            <Key layerNames={props.layerNames} row={3} col={11} />
           </g>
         </g>
       </g>

--- a/src/api/hardware-softhruf-splitography/components/Keymap.js
+++ b/src/api/hardware-softhruf-splitography/components/Keymap.js
@@ -41,6 +41,7 @@ const Keymap = (props) => {
       bottom = y + height * 40 - 4;
     const key = keymap[keyIndex(row, col)],
       stroke = selectedKey == keyIndex(row, col) ? "#f3b3b3" : "#b3b3b3";
+    const legend = key && db.format(key, { layerNames: props.layerNames });
     return (
       <g
         transform={transform}
@@ -60,10 +61,10 @@ const Keymap = (props) => {
           fill="#ffffff"
         />
         <text x={x + 3} y={y + 14}>
-          {key && key.label && key.label.hint}
+          {legend?.hint}
         </text>
         <text x={x + 3} y={bottom}>
-          {key && key.label && db.format(key).main}
+          {legend?.main}
         </text>
       </g>
     );
@@ -76,49 +77,49 @@ const Keymap = (props) => {
       className={props.className || "layer"}
     >
       <g>
-        <Key x={1} y={1} row={0} col={0} />
-        <Key x={55} y={1} row={0} col={1} />
-        <Key x={109} y={1} row={0} col={2} />
-        <Key x={163} y={1} row={0} col={3} />
-        <Key x={217} y={1} row={0} col={4} />
-        <Key x={271} y={1} row={0} col={5} />
-        <Key x={379} y={1} row={0} col={6} />
-        <Key x={433} y={1} row={0} col={7} />
-        <Key x={487} y={1} row={0} col={8} />
-        <Key x={541} y={1} row={0} col={9} />
-        <Key x={595} y={1} row={0} col={10} />
-        <Key x={649} y={1} row={0} col={11} />
+        <Key layerNames={props.layerNames} x={1} y={1} row={0} col={0} />
+        <Key layerNames={props.layerNames} x={55} y={1} row={0} col={1} />
+        <Key layerNames={props.layerNames} x={109} y={1} row={0} col={2} />
+        <Key layerNames={props.layerNames} x={163} y={1} row={0} col={3} />
+        <Key layerNames={props.layerNames} x={217} y={1} row={0} col={4} />
+        <Key layerNames={props.layerNames} x={271} y={1} row={0} col={5} />
+        <Key layerNames={props.layerNames} x={379} y={1} row={0} col={6} />
+        <Key layerNames={props.layerNames} x={433} y={1} row={0} col={7} />
+        <Key layerNames={props.layerNames} x={487} y={1} row={0} col={8} />
+        <Key layerNames={props.layerNames} x={541} y={1} row={0} col={9} />
+        <Key layerNames={props.layerNames} x={595} y={1} row={0} col={10} />
+        <Key layerNames={props.layerNames} x={649} y={1} row={0} col={11} />
 
-        <Key x={1} y={55} row={1} col={0} />
-        <Key x={55} y={55} row={1} col={1} />
-        <Key x={109} y={55} row={1} col={2} />
-        <Key x={163} y={55} row={1} col={3} />
-        <Key x={217} y={55} row={1} col={4} />
-        <Key x={271} y={55} row={1} col={5} />
-        <Key x={379} y={55} row={1} col={6} />
-        <Key x={433} y={55} row={1} col={7} />
-        <Key x={487} y={55} row={1} col={8} />
-        <Key x={541} y={55} row={1} col={9} />
-        <Key x={595} y={55} row={1} col={10} />
-        <Key x={649} y={55} row={1} col={11} />
+        <Key layerNames={props.layerNames} x={1} y={55} row={1} col={0} />
+        <Key layerNames={props.layerNames} x={55} y={55} row={1} col={1} />
+        <Key layerNames={props.layerNames} x={109} y={55} row={1} col={2} />
+        <Key layerNames={props.layerNames} x={163} y={55} row={1} col={3} />
+        <Key layerNames={props.layerNames} x={217} y={55} row={1} col={4} />
+        <Key layerNames={props.layerNames} x={271} y={55} row={1} col={5} />
+        <Key layerNames={props.layerNames} x={379} y={55} row={1} col={6} />
+        <Key layerNames={props.layerNames} x={433} y={55} row={1} col={7} />
+        <Key layerNames={props.layerNames} x={487} y={55} row={1} col={8} />
+        <Key layerNames={props.layerNames} x={541} y={55} row={1} col={9} />
+        <Key layerNames={props.layerNames} x={595} y={55} row={1} col={10} />
+        <Key layerNames={props.layerNames} x={649} y={55} row={1} col={11} />
 
-        <Key x={1} y={109} row={2} col={0} />
-        <Key x={55} y={109} row={2} col={1} />
-        <Key x={109} y={109} row={2} col={2} />
-        <Key x={163} y={109} row={2} col={3} />
-        <Key x={217} y={109} row={2} col={4} />
-        <Key x={271} y={109} row={2} col={5} />
-        <Key x={379} y={109} row={2} col={6} />
-        <Key x={433} y={109} row={2} col={7} />
-        <Key x={487} y={109} row={2} col={8} />
-        <Key x={541} y={109} row={2} col={9} />
-        <Key x={595} y={109} row={2} col={10} />
-        <Key x={649} y={109} row={2} col={11} />
+        <Key layerNames={props.layerNames} x={1} y={109} row={2} col={0} />
+        <Key layerNames={props.layerNames} x={55} y={109} row={2} col={1} />
+        <Key layerNames={props.layerNames} x={109} y={109} row={2} col={2} />
+        <Key layerNames={props.layerNames} x={163} y={109} row={2} col={3} />
+        <Key layerNames={props.layerNames} x={217} y={109} row={2} col={4} />
+        <Key layerNames={props.layerNames} x={271} y={109} row={2} col={5} />
+        <Key layerNames={props.layerNames} x={379} y={109} row={2} col={6} />
+        <Key layerNames={props.layerNames} x={433} y={109} row={2} col={7} />
+        <Key layerNames={props.layerNames} x={487} y={109} row={2} col={8} />
+        <Key layerNames={props.layerNames} x={541} y={109} row={2} col={9} />
+        <Key layerNames={props.layerNames} x={595} y={109} row={2} col={10} />
+        <Key layerNames={props.layerNames} x={649} y={109} row={2} col={11} />
 
-        <Key x={190} y={163} row={3} col={4} />
-        <Key x={244} y={163} row={3} col={5} />
-        <Key x={406} y={163} row={3} col={6} />
-        <Key x={460} y={163} row={3} col={7} />
+        <Key layerNames={props.layerNames} x={190} y={163} row={3} col={4} />
+        <Key layerNames={props.layerNames} x={244} y={163} row={3} col={5} />
+        <Key layerNames={props.layerNames} x={406} y={163} row={3} col={6} />
+        <Key layerNames={props.layerNames} x={460} y={163} row={3} col={7} />
       </g>
     </svg>
   );

--- a/src/api/hardware-technomancy-atreus/components/Keymap.js
+++ b/src/api/hardware-technomancy-atreus/components/Keymap.js
@@ -46,6 +46,7 @@ const Keymap = (props) => {
       <g transform="translate(10,10)">
         <g transform="translate(5,5)">
           <Key
+            layerNames={props.layerNames}
             x={109}
             y={1}
             row={0}
@@ -56,6 +57,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={55}
             y={19.9}
             row={0}
@@ -66,6 +68,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={163}
             y={19.9}
             row={0}
@@ -76,6 +79,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={1}
             y={33.4}
             row={0}
@@ -86,6 +90,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={217}
             y={33.4}
             row={0}
@@ -97,6 +102,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={109}
             y={55}
             row={1}
@@ -107,6 +113,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={55}
             y={73.9}
             row={1}
@@ -117,6 +124,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={163}
             y={73.9}
             row={1}
@@ -127,6 +135,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={1}
             y={87.4}
             row={1}
@@ -137,6 +146,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={217}
             y={87.4}
             row={1}
@@ -148,6 +158,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={109}
             y={109}
             row={2}
@@ -158,6 +169,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={55}
             y={127.9}
             row={2}
@@ -168,6 +180,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={163}
             y={127.9}
             row={2}
@@ -178,6 +191,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={1}
             y={141.4}
             row={2}
@@ -188,6 +202,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={217}
             y={141.4}
             row={2}
@@ -198,6 +213,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={271}
             y={154.9}
             row={2}
@@ -210,6 +226,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={109}
             y={163}
             row={3}
@@ -220,6 +237,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={55}
             y={181.9}
             row={3}
@@ -230,6 +248,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={163}
             y={181.9}
             row={3}
@@ -240,6 +259,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={1}
             y={195.4}
             row={3}
@@ -250,6 +270,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={217}
             y={195.4}
             row={3}
@@ -261,6 +282,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={500.5}
             y={1}
             row={0}
@@ -271,6 +293,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={446.5}
             y={19.9}
             row={0}
@@ -281,6 +304,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={554.5}
             y={19.9}
             row={0}
@@ -291,6 +315,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={392.5}
             y={33.4}
             row={0}
@@ -301,6 +326,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={608.5}
             y={33.4}
             row={0}
@@ -312,6 +338,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={500.5}
             y={55}
             row={1}
@@ -322,6 +349,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={446.5}
             y={73.9}
             row={1}
@@ -332,6 +360,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={554.5}
             y={73.9}
             row={1}
@@ -342,6 +371,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={392.5}
             y={87.4}
             row={1}
@@ -352,6 +382,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={608.5}
             y={87.4}
             row={1}
@@ -363,6 +394,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={500.5}
             y={109}
             row={2}
@@ -373,6 +405,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={446.5}
             y={127.9}
             row={2}
@@ -383,6 +416,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={554.5}
             y={127.9}
             row={2}
@@ -393,6 +427,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={392.5}
             y={141.4}
             row={2}
@@ -403,6 +438,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={608.5}
             y={141.4}
             row={2}
@@ -413,6 +449,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={338.5}
             y={154.9}
             row={3}
@@ -425,6 +462,7 @@ const Keymap = (props) => {
           />
 
           <Key
+            layerNames={props.layerNames}
             x={500.5}
             y={163}
             row={3}
@@ -435,6 +473,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={446.5}
             y={181.9}
             row={3}
@@ -445,6 +484,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={554.5}
             y={181.9}
             row={3}
@@ -455,6 +495,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={392.5}
             y={195.4}
             row={3}
@@ -465,6 +506,7 @@ const Keymap = (props) => {
             onClick={props.onKeySelect}
           />
           <Key
+            layerNames={props.layerNames}
             x={608.5}
             y={195.4}
             row={3}

--- a/src/api/hardware-technomancy-atreus/components/keymap/Key.js
+++ b/src/api/hardware-technomancy-atreus/components/keymap/Key.js
@@ -26,6 +26,7 @@ const Key = (props) => {
   const stroke = props.active ? "#f3b3b3" : "#b3b3b3";
   const height = props.height || 48;
   const bottom = y + height - 16;
+  const legend = keyObj && db.format(keyObj, { layerNames: props.layerNames });
   return (
     <g
       onClick={onClick}
@@ -44,10 +45,10 @@ const Key = (props) => {
         fill="#ffffff"
       />
       <text x={x + 3} y={y + 14}>
-        {keyObj && keyObj.label && keyObj.label.hint}
+        {legend?.hint}
       </text>
       <text x={x + 3} y={bottom}>
-        {keyObj && keyObj.label && db.format(keyObj).main}
+        {legend?.main}
       </text>
     </g>
   );

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -89,7 +89,10 @@ const Overview = (props) => {
   }
 
   const config = usedLayers.map((layerData, index) => {
-    const label = db.format(layerData[selectedKey], { keycapSize: "full" });
+    const label = db.format(layerData[selectedKey], {
+      keycapSize: "full",
+      layerNames: props.layerNames,
+    });
     let colorWidget;
     if (colormap && colormap.palette.length > 0) {
       const colorIndex = colormap.colorMap[index][selectedLed];


### PR DESCRIPTION
When preparing the custom layer names pull request, I seem to have dropped the patch during a rebase that added support for custom layer names to keyboards other than the Model01 and the Model100. The first patch in this series does just that, modifies the keymap renderers to use custom layer names if available.

The second part is a change to the Overview widget on the sidebar, so it renders the label with custom layer names too.

Both together fix #1003.

![Screenshot from 2022-07-25 11-41-01](https://user-images.githubusercontent.com/17243/180747666-4622e4d6-d00b-4e5f-a9aa-70aa639e1412.png)
