### PR TITLE
Editor/Overview: Make the layer names cell a little shorter

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -160,7 +160,9 @@ const Overview = (props) => {
           <Tooltip title={t("editor.sidebar.overview.help")}>
             <TableHead>
               <TableRow>
-                <TableCell size="small">{t("components.layerRaw")}</TableCell>
+                <TableCell size="small" width="33%">
+                  {t("components.layerRaw")}
+                </TableCell>
                 <TableCell>
                   {t("editor.sidebar.overview.key", {
                     index: selectedKey,


### PR DESCRIPTION
To allow the rest of the cells some more space to display, restrict the layer name column to 33% of the total.

This is most visible on the Atreus:

## Before

![Screenshot from 2022-07-25 12-00-07](https://user-images.githubusercontent.com/17243/180751721-ebcb42d8-8023-4800-9083-d552c67d24c6.png)

## After

![Screenshot from 2022-07-25 12-00-28](https://user-images.githubusercontent.com/17243/180751716-fd5d98f7-5098-4bde-894f-d3998b1d90a4.png)
