### PR TITLE
Small UI fixes when connected to a keyboard in bootloader mode

### DIFF
--- a/src/renderer/components/MainMenu/MainMenu.js
+++ b/src/renderer/components/MainMenu/MainMenu.js
@@ -123,7 +123,8 @@ function MainMenu({ open, closeMenu, classes }) {
 
               "/editor"
             )}
-          {listItem(<InfoIcon />, t("app.menu.layoutCard"), "/layout-card")}
+          {activeDevice &&
+            listItem(<InfoIcon />, t("app.menu.layoutCard"), "/layout-card")}
 
           {listItem(
             <CloudUploadIcon />,

--- a/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
@@ -32,6 +32,11 @@ const FirmwareVersion = (props) => {
 
   useEffectOnce(() => {
     const fetchData = async () => {
+      if (!activeDevice?.focus) {
+        setFwVersion(t("firmwareUpdate.currentFirmwareVersionUnavailable"));
+        return;
+      }
+
       const v = await activeDevice.focus.command("version");
       if (v) {
         setFwVersion(v);


### PR DESCRIPTION
When Chrysalis is connected to a keyboard that is in bootloader mode, this PR fixes two smaller issues:

- The FirmwareUpdate page will display "Firmware version unavailable" instead of a `<Skeleton>` that is in forever-loading state
- The Layout Cards menu item in the Main Menu is no longer displayed for keyboards in bootloader mode