### PR TITLE
Fix flashing when starting from bootloader mode

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -16,8 +16,6 @@
  */
 
 import Focus from "@api/focus";
-import path from "path";
-import { ipcRenderer } from "electron";
 
 export function ActiveDevice() {
   this.port = undefined;
@@ -67,18 +65,5 @@ export function ActiveDevice() {
     } else {
       return false;
     }
-  };
-  this.defaultFirmwareFilename = () => {
-    const { vendor, product } = this.focus.focusDeviceDescriptor.info;
-    const firmwareType =
-      this.focus.focusDeviceDescriptor.info.firmwareType || "hex";
-    const cVendor = vendor.replace("/", ""),
-      cProduct = product.replace("/", "");
-    return path.join(
-      ipcRenderer.sendSync("firmware.get-base-directory"),
-      cVendor,
-      cProduct,
-      "default." + firmwareType
-    );
   };
 }

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -224,9 +224,11 @@ const App = (props) => {
   };
 
   const onKeyboardDisconnect = async () => {
-    logger().info("Disconnecting from keyboard", {
-      path: await activeDevice.devicePath(),
-    });
+    if (activeDevice) {
+      logger().info("Disconnecting from keyboard", {
+        path: await activeDevice.devicePath(),
+      });
+    }
     await navigate("./");
 
     await focus.close();

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -35,6 +35,8 @@ import checkExternalFlasher from "@renderer/utils/checkExternalFlasher";
 import React, { useState, useContext } from "react";
 import { GlobalContext } from "@renderer/components/GlobalContext";
 
+import { ipcRenderer } from "electron";
+import path from "path";
 import { useTranslation } from "react-i18next";
 
 import FirmwareVersion from "./FirmwareUpdate/FirmwareVersion";
@@ -63,6 +65,18 @@ const FirmwareUpdate = (props) => {
   const focusDeviceDescriptor =
     props.focusDeviceDescriptor || focus.focusDeviceDescriptor;
 
+  const defaultFirmwareFilename = () => {
+    const { vendor, product } = focusDeviceDescriptor.info;
+    const firmwareType = focusDeviceDescriptor.info.firmwareType || "hex";
+    const cVendor = vendor.replace("/", ""),
+      cProduct = product.replace("/", "");
+    return path.join(
+      ipcRenderer.sendSync("firmware.get-base-directory"),
+      cVendor,
+      cProduct,
+      "default." + firmwareType
+    );
+  };
   const _flash = async (options) => {
     const focus = new Focus();
 
@@ -87,7 +101,7 @@ const FirmwareUpdate = (props) => {
     return focusDeviceDescriptor.flash(
       focus._port,
       selectedFirmwareType === "default"
-        ? activeDevice.defaultFirmwareFilename()
+        ? defaultFirmwareFilename()
         : firmwareFilename,
 
       Object.assign({}, options, {


### PR DESCRIPTION
When trying to flash a keyboard that is already in bootloader mode, Chrysalis was bombing out, because it was trying to pull `focusDeviceDescriptor` from `activeDevice.focus` - but when connected to a keyboard in bootloader mode, we do not have an `activeDevice`, let alone `activeDevice.focus`. However, the descriptor is readily available in `FirmwareUpdate` (the sole user of `activeDevice.defaultFirmwareFilename()`), so move the function back there, where we have all the information at hand.

This stops Chrysalis from bombing out there.

Additionally, when trying to disconnect from a keyboard, if there is no `activeDevice`, don't try to use it.

These two changes together fix flashing when started while the keyboard is already in bootloader mode.