### PR TITLE
api/focus: Make waitForDFUBootloader actually perform a check

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -159,18 +159,23 @@ class Focus {
     const bootloader = focusDeviceDescriptor.usb.bootloader;
 
     for (let attempt = 0; attempt < 10; attempt++) {
-      const found = await ipcRenderer.invoke(
+      const deviceList = await ipcRenderer.invoke(
         "usb.scan-for-devices",
         bootloader.productId,
         bootloader.vendorId
       );
-      if (found) {
-        logger("focus").info("bootloader found", {
-          vid: bootloader.vendorId,
-          pid: bootloader.productId,
-          function: "waitForDFUBootloader",
-        });
-        return true;
+
+      for (const device of deviceList) {
+        const pid = device.deviceDescriptor.idProduct,
+          vid = device.deviceDescriptor.idVendor;
+
+        if (pid == bootloader.productId && vid == bootloader.vendorId) {
+          logger("focus").info("bootloader found", {
+            device: bootloader,
+            function: "waitForDFUBootloader",
+          });
+          return true;
+        }
       }
 
       logger("focus").debug("bootloader not found, waiting 2s", {


### PR DESCRIPTION
As long as this function existed, it was practically a no-op, it succeeded as long as there was at least one USB device connected, of any kind. It did not perform adequate checks to see if the requested VID/PID pair is among them.

This worked, because the flashing process rebooted the keyboard before checking for the presence of a bootloader, so by the time we went to check, it was always there anyway.

Things fell apart as soon as the function was supposed to do a real check. This patch makes it do what it was always supposed to do: iterate over the devices found, and only return success if the desired one is among them.
