### PR TITLE
Preferences: Add a preview of the selected keyboard layout

### DIFF
--- a/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
+++ b/src/renderer/screens/Preferences/ui/LayoutEditorPreferences.js
@@ -19,12 +19,14 @@ import KeymapDB from "@api/focus/keymap/db";
 
 import Autocomplete from "@mui/material/Autocomplete";
 import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
 import Skeleton from "@mui/material/Skeleton";
 import TextField from "@mui/material/TextField";
 
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
+import Keyboard104 from "@renderer/screens/Editor/Keyboard104";
 import PreferenceSection from "../components/PreferenceSection";
 import PreferenceSwitch from "../components/PreferenceSwitch";
 import PreferenceWithHeading from "../components/PreferenceWithHeading";
@@ -111,6 +113,9 @@ function LayoutEditorPreferences(props) {
           <Skeleton variant="rectangular" />
         )}
       </PreferenceWithHeading>
+      <Paper variant="outlined" square sx={{ p: 2, mt: 1 }}>
+        <Keyboard104 onKeySelect={() => null} layout={layout} />
+      </Paper>
       <Divider sx={{ my: 2, mx: -2 }} />
       <PreferenceSwitch
         loaded={loaded}


### PR DESCRIPTION
![Screenshot from 2022-07-27 11-52-48](https://user-images.githubusercontent.com/17243/181219011-279e5c61-6851-4e95-ba75-759cae3d1737.png)

![Screenshot from 2022-07-27 11-53-11](https://user-images.githubusercontent.com/17243/181219003-99e9bf46-6a53-485b-b879-52c2e3d9eebf.png)

The preview updates when a layout is chosen. It does not auto-update while the dropdown is open, only when a selection is made. Mostly for technical reasons, and because updating with the dropdown open would be a *lot* of small changes quickly rendered, which I find annoyingly distracting.

This still allows one to preview the layout without having to go visit the layout editor screen.