### PR TITLE
api/focus/keymap: Sort supported languages the same way we group them

### DIFF
--- a/src/api/focus/keymap/db.js
+++ b/src/api/focus/keymap/db.js
@@ -70,10 +70,12 @@ class KeymapDB {
       this.supported_layouts[i18n.language].sort((a, b) => {
         const l1 = a;
         const l2 = b;
+        const l1g = l1.language || l1.group;
+        const l2g = l2.language || l2.group;
 
         // Sort on group first
-        if (l1.group < l2.group) return -1;
-        if (l1.group > l2.group) return 1;
+        if (l1g < l2g) return -1;
+        if (l1g > l2g) return 1;
 
         // If in the same group, sort the default one higher
         if (l1.default) return -1;


### PR DESCRIPTION
We want to present the list of supported layouts grouped by their language (or if that is unavailable, the language code, or group), and the groups should be alphabetically sorted too.

To achieve this, we need to sort the list the same way we group them.

Addresses another issue identified in #649, namely that Chinese is no longer sorted *after* English, and the groups are alphabetically sorted by language, rather than by language code.