### PR TITLE
Hide the Header when printing Layout Cards

### DIFF
--- a/src/renderer/components/GlobalContext.js
+++ b/src/renderer/components/GlobalContext.js
@@ -27,6 +27,7 @@ export const GlobalContextProvider = (props) => {
   const [activeDevice, setActiveDevice] = useState(null);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [firmwareUpdateWarning, setFirmwareUpdateWarning] = useState(false);
+  const [hideHeaderInPrint, setHideHeaderInPrint] = useState(false);
 
   const getDarkMode = () => {
     if (theme == "system") {
@@ -43,6 +44,7 @@ export const GlobalContextProvider = (props) => {
     activeDevice: [activeDevice, setActiveDevice],
     updateAvailable: [updateAvailable, setUpdateAvailable],
     firmwareUpdateWarning: [firmwareUpdateWarning, setFirmwareUpdateWarning],
+    hideHeaderInPrint: [hideHeaderInPrint, setHideHeaderInPrint],
   };
 
   return (

--- a/src/renderer/components/Header.js
+++ b/src/renderer/components/Header.js
@@ -23,9 +23,11 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import ConfirmationDialog from "@renderer/components/ConfirmationDialog";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import { ipcRenderer } from "electron";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import "typeface-roboto/index.css";
 import "typeface-source-code-pro/index.css";
@@ -34,12 +36,16 @@ import { contextBarChangesDiscarded } from "./ContextBar";
 import MainMenu from "./MainMenu/MainMenu";
 
 function Header({ device }) {
+  const globalContext = useContext(GlobalContext);
+  const [hideHeaderInPrint] = globalContext.state.hideHeaderInPrint;
+
   const [mainMenu, setMainMenuOpen] = useState(false);
   const [boardAnchor, setBoardMenuAnchor] = useState(null);
   const [contextBarVisibility, setContextBarVisibility] = useState(false);
   const [discardChangesDialogVisibility, setDiscardChangesDialogVisibility] =
     useState(false);
   const [quitNotifyChannel, setQuitNotifyChannel] = useState(false);
+  const isPrinting = useMediaQuery("print");
 
   const { t } = useTranslation();
 
@@ -120,6 +126,8 @@ function Header({ device }) {
       ipcRenderer.invoke(quitNotifyChannel);
     }
   };
+
+  if (hideHeaderInPrint && isPrinting) return null;
 
   return (
     <>

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -20,11 +20,12 @@ import { logger } from "@api/log";
 import KeymapDB from "@api/focus/keymap/db";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import LoadingScreen from "@renderer/components/LoadingScreen";
 import { PageTitle } from "@renderer/components/PageTitle";
 import { toast } from "@renderer/components/Toast";
 import useEffectOnce from "@renderer/hooks/useEffectOnce";
-import React, { useState } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useTranslation } from "react-i18next";
 const Store = require("electron-store");
 const settings = new Store();
@@ -47,9 +48,21 @@ const LayoutCard = (props) => {
     names: [],
   });
 
+  const globalContext = useContext(GlobalContext);
+
+  const [_, setHideHeaderInPrint] = globalContext.state.hideHeaderInPrint;
   const [loading, setLoading] = useState(true);
   const [oneLayerPerPage, setOneLayerPerPage] = useState(false);
+
   const { t } = useTranslation();
+
+  useEffect(() => {
+    setHideHeaderInPrint(true);
+
+    return function cleanup() {
+      setHideHeaderInPrint(false);
+    };
+  });
 
   const scanKeyboard = async () => {
     try {


### PR DESCRIPTION
When printing layout cards, the header does not add any useful information, but takes up space - and colors - on the first page. Lets not show the header when printing the layout card screen.

We do show it for everything else.

Fixes #943.
