### PR TITLE
LayoutCard: Don't use an async function directly with useEffectOnce

### DIFF
--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -72,13 +72,18 @@ const LayoutCard = (props) => {
     }
   };
 
-  useEffectOnce(async () => {
-    await scanKeyboard();
+  useEffectOnce(() => {
+    const initialize = async () => {
+      await scanKeyboard();
 
-    setOneLayerPerPage(settings.get("ui.layoutCards.oneLayerPerPage", false));
+      setOneLayerPerPage(settings.get("ui.layoutCards.oneLayerPerPage", false));
 
-    setLoading(false);
+      setLoading(false);
+    };
+
+    initialize();
   });
+
   if (loading) {
     return <LoadingScreen />;
   }


### PR DESCRIPTION
`useEffectOnce`, just like `useEffect` itself, needs a plain, non-async function. So instead of using doing initialization directly in the effect, push it into an async function called _from_ the effect. The same pattern we use elsewhere.

This gets rid of an error printed on the dev console when leaving the Layout Cards screen.
