### PR TITLE
api/focus/keymap: withModifiers() should not apply mods to non-standard keys

### DIFF
--- a/src/api/focus/keymap/db/modifiers.js
+++ b/src/api/focus/keymap/db/modifiers.js
@@ -356,7 +356,10 @@ const withModifiers = (keys) => {
   ];
 
   for (const key of keys) {
-    newKeys.push(key);
+    if (newKeys[key.code]) continue;
+    newKeys[key.code] = Object.assign({}, key);
+
+    if (key.code > 255) continue;
 
     for (const mod of mods) {
       const newKey = Object.assign({}, key, {
@@ -365,11 +368,11 @@ const withModifiers = (keys) => {
         baseCode: key.code,
         label: mod.label(key),
       });
-      newKeys.push(newKey);
+      newKeys[key.code + mod.offset] = newKey;
     }
   }
 
-  return newKeys;
+  return newKeys.filter((x) => x !== null);
 };
 
 export { addModifier, removeModifier, withModifiers };


### PR DESCRIPTION
Originally, `withModifiers()` was only called internally by the keymap db, so it could safely assume that the list of keys it receives will fall within the standard HID range, and can have modifiers applied safely.

However, with 62f6ba5034abcd31d71d38ff9a4f2f40be39f433, that is no longer the case, and `withModifiers()` will be called with a keylist that can potentially include already augmented keys.

It should only augment keycodes in the base HID range, and if it encounters a keycode in the source list that is an augmented key, that should be ignored in favour of the newly augmented ones.

Fixes #1026.
