### PR TITLE
FirmwareUpdate: Change the confirmation dialog's confirmation label to Continue

### DIFF
--- a/src/renderer/components/ConfirmationDialog.js
+++ b/src/renderer/components/ConfirmationDialog.js
@@ -36,10 +36,10 @@ const ConfirmationDialog = (props) => {
       <DialogContent>{props.children}</DialogContent>
       <DialogActions>
         <Button onClick={props.onCancel} color="primary">
-          {t("dialog.cancel")}
+          {props.cancelLabel || t("dialog.cancel")}
         </Button>
         <Button onClick={props.onConfirm} color="primary">
-          {t("dialog.ok")}
+          {props.confirmLabel || t("dialog.ok")}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -36,7 +36,8 @@
   "dialog": {
     "ok": "Ok",
     "cancel": "Cancel",
-    "close": "Close"
+    "close": "Close",
+    "continue": "Continue"
   },
   "app": {
     "menu": {

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -229,6 +229,7 @@ const FirmwareUpdate = (props) => {
         open={confirmationOpen}
         onConfirm={() => upload()}
         onCancel={() => setConfirmationOpen(false)}
+        confirmLabel={t("dialog.continue")}
       >
         <Typography component="p" sx={{ mb: 2 }}>
           {t("firmwareUpdate.confirmDialog.description")}


### PR DESCRIPTION
With the combination of our current flashing instructions, the "Cancel / Ok" pair of buttons aren't exactly clear, they do not accurately convey what will happen if either of them is pressed.

Changing them to "Abort / Continue" makes it clearer - I hope - what they are for: one to abort the whole flashing operation, the other acknowledges the instructions, and tells Chrysalis to proceed.

I intentionally avoided using "Upload" for the confirmation label, because that'd just repeat what's on the button that popped this dialog up in the first place.

Fixes #1023.

![Screenshot from 2022-07-31 12-12-52](https://user-images.githubusercontent.com/17243/182021869-d43d7977-511d-48c8-aacb-c8a8c8cb2721.png)
