### PR TITLE
A temporary workaround for the Model 100 getting wedged

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -477,7 +477,9 @@ class Focus {
          */
         this._write_parts(request);
       } else {
-        this._port.write(request);
+        //        this._port.write(request);
+        // Temporary hack to deal with the Model 100 getting wedged on Linux and Windows when we write large amounts of data at once.
+        this._write_parts(request);
       }
     });
   }


### PR DESCRIPTION
on windows and linux when we send more data than it can handle.

@algernon if this behaves basically ok for you on linux, let's get it pushed out asap for folks