### PR TITLE
FirmwareUpdate: Change the factory reset confirmation label to Continue

### DIFF
--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -217,6 +217,7 @@ const FirmwareUpdate = (props) => {
         open={factoryConfirmationOpen}
         onConfirm={() => upload({ factoryReset: true })}
         onCancel={() => setFactoryConfirmationOpen(false)}
+        confirmLabel={t("dialog.continue")}
       >
         <Typography component="p" sx={{ mb: 2 }}>
           {t("firmwareUpdate.factoryConfirmDialog.contents")}


### PR DESCRIPTION
This is a followup for 577dee8678a124bfe3343e79adca83ec6b6518e3, where we changed the label of the firmware update confirmation dialog from "Ok" to "Continue". This does the same for the "Update with factory reset" case too.
