### PR TITLE
hardware/atreus2: Display the main legend in big letters if it's a single letter

### DIFF
--- a/src/api/hardware-keyboardio-atreus2/components/Keymap.js
+++ b/src/api/hardware-keyboardio-atreus2/components/Keymap.js
@@ -78,9 +78,12 @@ const Keymap = (props) => {
     let textColor = "#ffffff";
     const buttonColor = "transparent";
     let legendClass = "";
+    let mainLegendClass = "";
     const legend = key && db.format(key, { layerNames: props.layerNames });
     if (key && (legend.main || "").length <= 1 && !legend.hint)
       legendClass = "short-legend";
+    if (key && (legend.main || "").length <= 1)
+      mainLegendClass = "short-legend";
     if (key && key.code == 0) textColor = "#888888";
     return (
       <g
@@ -102,7 +105,7 @@ const Keymap = (props) => {
         <text x={x + 5} y={y + 14} fill={textColor} className={legendClass}>
           {legend?.hint}
         </text>
-        <text x={x + 5} y={bottom} fill={textColor} className={legendClass}>
+        <text x={x + 5} y={bottom} fill={textColor} className={mainLegendClass}>
           {legend?.main}
         </text>
       </g>


### PR DESCRIPTION
When deciding whether to display the main legend of a key on the Keyboardio Atreus in a bigger size or not, ignore if there's a `hint` legend, it doesn't matter.

Fixes #1033.

![Screenshot from 2022-09-12 20-03-08](https://user-images.githubusercontent.com/17243/189724646-405e2c67-0906-481a-a194-a2b01d672745.png)

The Keyboardio Atreus is the only device that has this feature. Everywhere else, we do not play with font sizes, so they don't need a similar adjustment, either.