### PR TITLE
Preferences: SpaceCadet support

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -569,6 +569,8 @@ class Focus {
     "typingbreaks.lockLength",
     "typingbreaks.leftMaxKeys",
     "typingbreaks.rightMaxKeys",
+    "spacecadet.mode",
+    "spacecadet.timeout",
   ];
 
   eepromBackupCommands = [

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -4,6 +4,9 @@
     "deviceDisconnected": "Keyboard disconnected",
     "saveFile": "Error saving a file: {{ error }}"
   },
+  "units": {
+    "in_ms": "ms"
+  },
   "print": {
     "feedback": {
       "success": "Successfully printed!",
@@ -355,6 +358,23 @@
         "escOneShot": {
           "label": "Let Escape cancel one-shot keys",
           "help": "When enabled, \"Escape\" will cancel one-shot keys, otherwise a dedicated cancel key can do so."
+        },
+        "oneshot": {
+          "label": "OneShot"
+        },
+        "spacecadet": {
+          "label": "SpaceCadet",
+          "mode": {
+            "label": "Enable SpaceCadet shifts",
+            "help": "When enabled, the left and right shifts on your keyboard will turn into parens when tapped, but remain shifts when held.",
+            "enabled": "Enabled",
+            "disabled": "Disabled",
+            "enabled_without_delay": "Enabled (without delay)"
+          },
+          "timeout": {
+            "label": "Timeout",
+            "help": "The number of milliseconds to wait before considering a held SpaceCadet key as shift on its own."
+          }
         }
       }
     }

--- a/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/PluginPreferences.js
@@ -22,23 +22,47 @@ import { useTranslation } from "react-i18next";
 
 import PreferenceSection from "../components/PreferenceSection";
 import EscapeOneShotPreferences from "./plugins/EscapeOneShot";
+import SpaceCadetPreferences from "./plugins/SpaceCadet";
 
 const PluginPreferences = (props) => {
   const { t } = useTranslation();
   const { onSaveChanges } = props;
 
-  const [loaded, plugins] = useCheckDeviceSupportsPlugins(["EscapeOneShot"]);
+  const [loaded, plugins] = useCheckDeviceSupportsPlugins([
+    "EscapeOneShot",
+    "spacecadet.mode",
+  ]);
 
   const foundSomePlugins = Object.values(plugins).some((v) => v);
   if (loaded && !foundSomePlugins) return null;
 
-  return (
-    <PreferenceSection name="keyboard.plugins" loaded={loaded}>
-      {plugins["EscapeOneShot"] && (
-        <EscapeOneShotPreferences onSaveChanges={onSaveChanges} />
-      )}
-    </PreferenceSection>
-  );
+  const sections = [
+    {
+      name: "oneshot",
+      plugin: "EscapeOneShot",
+      Component: EscapeOneShotPreferences,
+    },
+    {
+      name: "spacecadet",
+      plugin: "spacecadet.mode",
+      Component: SpaceCadetPreferences,
+    },
+  ];
+  return sections.map(({ name, plugin, Component }, index) => {
+    if (!plugins[plugin]) return null;
+
+    const key = `preferences.plugins.${name}`;
+
+    return (
+      <PreferenceSection
+        name={`keyboard.plugins.${name}`}
+        loaded={loaded}
+        key={`${key}/${index}`}
+      >
+        <Component onSaveChanges={onSaveChanges} />
+      </PreferenceSection>
+    );
+  });
 };
 
 export { PluginPreferences as default };

--- a/src/renderer/screens/Preferences/keyboard/plugins/SpaceCadet.js
+++ b/src/renderer/screens/Preferences/keyboard/plugins/SpaceCadet.js
@@ -1,0 +1,102 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FormControl from "@mui/material/FormControl";
+import FormHelperText from "@mui/material/FormHelperText";
+import InputAdornment from "@mui/material/InputAdornment";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Skeleton from "@mui/material/Skeleton";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
+import usePluginEffect from "@renderer/hooks/usePluginEffect";
+import PreferenceSwitch from "../../components/PreferenceSwitch";
+import PreferenceWithHeading from "../../components/PreferenceWithHeading";
+
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const SpaceCadetPreferences = (props) => {
+  const { t } = useTranslation();
+  const { onSaveChanges } = props;
+
+  const [scMode, setScMode] = useState(0);
+  const [scTimeOut, setScTimeOut] = useState(200);
+
+  const initialize = async (focus) => {
+    const timeout = await focus.command("spacecadet.timeout");
+    const mode = await focus.command("spacecadet.mode");
+
+    setScTimeOut(parseInt(timeout));
+    setScMode(parseInt(mode));
+  };
+
+  const loaded = usePluginEffect(initialize);
+
+  const onModeChange = async (event) => {
+    const mode = event.target.checked ? 0 : 1;
+    setScMode(mode);
+    onSaveChanges("spacecadet.mode", mode);
+  };
+
+  const onTimeOutChange = async (event) => {
+    setScTimeOut(parseInt(event.target.value));
+    onSaveChanges("spacecadet.timeout", event.target.value);
+  };
+
+  return (
+    <>
+      <PreferenceSwitch
+        option="keyboard.plugins.spacecadet.mode"
+        loaded={loaded}
+        checked={scMode != 1}
+        onChange={onModeChange}
+      />
+      <PreferenceWithHeading
+        heading={t("preferences.keyboard.plugins.spacecadet.timeout.label")}
+        subheading={t("preferences.keyboard.plugins.spacecadet.timeout.help")}
+      >
+        {loaded ? (
+          <TextField
+            sx={{ width: "8em" }}
+            size="small"
+            type="number"
+            min={0}
+            max={65535}
+            value={scTimeOut}
+            onChange={onTimeOutChange}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {t("units.in_ms")}
+                </InputAdornment>
+              ),
+            }}
+          />
+        ) : (
+          <Skeleton variant="rectangle" width="8em" height={40} />
+        )}
+      </PreferenceWithHeading>
+    </>
+  );
+};
+
+export { SpaceCadetPreferences as default };


### PR DESCRIPTION
This adds support for toggling SpaceCadet on and off (and saving that setting), and setting the global timeout. Requires the `SpaceCadetConfig` plugin from keyboardio/Kaleidoscope#1234.

While both SpaceCadet and SpaceCadetConfig support a "no delay" mode, Chrysalis does not, and will display the "no delay" mode the same as the normal active mode.

![Screenshot from 2022-09-15 19-07-34](https://user-images.githubusercontent.com/17243/190468453-9c8f9007-a6cb-45e9-959f-03e5ef6af172.png)
