### PR TITLE
Preferences: Use the same terminology for "OneShot" as on the Editor

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -356,11 +356,11 @@
       "plugins": {
         "label": "Plugins",
         "escOneShot": {
-          "label": "Let Escape cancel one-shot keys",
-          "help": "When enabled, \"Escape\" will cancel one-shot keys, otherwise a dedicated cancel key can do so."
+          "label": "Let Escape cancel sticky keys",
+          "help": "When enabled, \"Escape\" will cancel sticky keys, otherwise a dedicated cancel key can do so."
         },
         "oneshot": {
-          "label": "OneShot"
+          "label": "Sticky keys"
         },
         "spacecadet": {
           "label": "SpaceCadet",


### PR DESCRIPTION
The Editor screen uses the term "Sticky keys" for OneShot keys, lets use the same for the Preferences screen.

![Screenshot from 2022-09-18 19-52-07](https://user-images.githubusercontent.com/17243/190921609-f284dc48-d84b-4522-bc6d-81fba7dc5924.png)
