### PR TITLE
@api/focus: Do not drain the serial port while writing request parts

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -426,7 +426,6 @@ class Focus {
     for (let index = 0; index < request.length; index += 32) {
       this._port.write(request.slice(index, index + 32));
       await new Promise((timeout) => setTimeout(timeout, 50));
-      await this._port.drain();
     }
   }
 


### PR DESCRIPTION
When we're writing request parts, we want the firmware to expect more data, so we should not try to drain it, because that signals to the firmware that we're done writing, while we really aren't.

If we signal we're done writing, the firmware may end up terminating the processing of an in-flight command, or even misparse the data it receives.

One of the problems observed was that when saving a keymap, we ended up with seemingly random corruption in various places. Research confirmed that this happened due to Chrysalis splitting a keycode halfway through, and due to the drain, the firmware interpreted that as two distinct keycodes. Thus, the key where the split occurred, and the one after were wrong, and the keys after were shifted one key.

Without the drain, the firmware will expect more data, and will not finish processing the in-flight command too early.

Fixes #1057.

Tested on Linux (Debian Stable), Windows 10, and macOS, they all worked as expected: no corruption, proper splitting at 32 bytes, no sign of the stall we introduced the chunking for in the first place, either.