### PR TITLE
Enable firmware auto-update by default

### DIFF
--- a/src/main/ipc_firmware.js
+++ b/src/main/ipc_firmware.js
@@ -217,7 +217,7 @@ export const registerFirmwareHandlers = () => {
     const settings = new Store();
 
     let baseDir = __static;
-    if (settings.get("firmwareAutoUpdate.mode", "manual") == "automatic") {
+    if (settings.get("firmwareAutoUpdate.mode", "automatic") == "automatic") {
       try {
         fs.accessSync(path.join(firmwarePath, "build-info.yml"));
         baseDir = firmwarePath;

--- a/src/renderer/hooks/useFirmwareAutoUpdate.js
+++ b/src/renderer/hooks/useFirmwareAutoUpdate.js
@@ -75,7 +75,7 @@ export const useFirmwareAutoUpdate = () => {
 
     ipcRenderer.invoke(
       "firmware-update.check-for-updates",
-      settings.get("firmwareAutoUpdate.mode", "manual")
+      settings.get("firmwareAutoUpdate.mode", "automatic")
     );
 
     ipcRenderer.on("firmware-update.update-available", onUpdateAvailable);

--- a/src/renderer/screens/Preferences/AutoUpdate.js
+++ b/src/renderer/screens/Preferences/AutoUpdate.js
@@ -32,7 +32,7 @@ function AutoUpdatePreferences(props) {
 
   const [autoUpdateMode, setAutoUpdateMode] = useState("manual");
   const [firmwareAutoUpdateMode, setFirmwareAutoUpdateMode] =
-    useState("manual");
+    useState("automatic");
   const [loaded, setLoaded] = useState(false);
 
   const toggleFirmwareAutoUpdateMode = (event) => {
@@ -61,7 +61,7 @@ function AutoUpdatePreferences(props) {
     const initialize = async () => {
       await setAutoUpdateMode(settings.get("autoUpdate.mode", "manual"));
       await setFirmwareAutoUpdateMode(
-        settings.get("firmwareAutoUpdate.mode", "manual")
+        settings.get("firmwareAutoUpdate.mode", "automatic")
       );
       await setLoaded(true);
     };


### PR DESCRIPTION
Unlike the auto-update for Chrysalis itself, firmware auto-update is not destructive, and is considerably more useful, even desirable. As such, turn it on by default.

Existing settings will not be touched, this is for new installs only.
