### PR TITLE
Display breaking news for Model 100 owners on the keyboard selection screen

### DIFF
--- a/src/renderer/breaking-news.js
+++ b/src/renderer/breaking-news.js
@@ -1,0 +1,18 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { Firmware0_90_1 } from "./breaking-news/firmware-0.90.1";

--- a/src/renderer/breaking-news/firmware-0.90.1.js
+++ b/src/renderer/breaking-news/firmware-0.90.1.js
@@ -1,0 +1,46 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AlertTitle from "@mui/material/AlertTitle";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import openURL from "@renderer/utils/openURL";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const Firmware0_90_1 = () => {
+  const { t } = useTranslation();
+  const trn = (key) => t(`breakingNews.firmware0_90_1.${key}`);
+
+  const openInstructions = () => {
+    openURL(
+      "https://community.keyboard.io/t/model-100-firmware-update-to-fix-corruption-issues/5553"
+    )();
+  };
+
+  return (
+    <>
+      <AlertTitle>{trn("title")}</AlertTitle>
+      <Typography component="p" gutterBottom>
+        {trn("description")}
+      </Typography>
+      <Button variant="contained" color="warning" onClick={openInstructions}>
+        {trn("button")}
+      </Button>
+    </>
+  );
+};

--- a/src/renderer/breaking-news/firmware-0.90.1.js
+++ b/src/renderer/breaking-news/firmware-0.90.1.js
@@ -22,9 +22,19 @@ import openURL from "@renderer/utils/openURL";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-export const Firmware0_90_1 = () => {
+import { BreakingNews } from "@renderer/components/BreakingNews";
+
+export const Firmware0_90_1 = (props) => {
   const { t } = useTranslation();
   const trn = (key) => t(`breakingNews.firmware0_90_1.${key}`);
+
+  const hasModel100 = props?.devices?.some((device) => {
+    const info = device.focusDeviceDescriptor?.info;
+
+    return info?.vendor == "Keyboardio" && info?.product == "Model100";
+  });
+
+  if (!hasModel100) return null;
 
   const openInstructions = () => {
     openURL(
@@ -33,7 +43,7 @@ export const Firmware0_90_1 = () => {
   };
 
   return (
-    <>
+    <BreakingNews tag="firmware.0.90.1">
       <AlertTitle>{trn("title")}</AlertTitle>
       <Typography component="p" gutterBottom>
         {trn("description")}
@@ -41,6 +51,6 @@ export const Firmware0_90_1 = () => {
       <Button variant="contained" color="warning" onClick={openInstructions}>
         {trn("button")}
       </Button>
-    </>
+    </BreakingNews>
   );
 };

--- a/src/renderer/components/BreakingNews.js
+++ b/src/renderer/components/BreakingNews.js
@@ -1,0 +1,39 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Alert from "@mui/material/Alert";
+import React from "react";
+
+const Store = require("electron-store");
+const settings = new Store();
+
+export const BreakingNews = (props) => {
+  const { tag, children } = props;
+
+  const seen = settings.get(`breaking-news.seen.${tag}`, false);
+  if (seen) return null;
+
+  const onClose = () => {
+    settings.set(`breaking-news.seen.${tag}`, true);
+  };
+
+  return (
+    <Alert severity="warning" onClose={onClose}>
+      {children}
+    </Alert>
+  );
+};

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -1,5 +1,12 @@
 {
   "language": "English",
+  "breakingNews": {
+    "firmware0_90_1": {
+      "title": "Attention Keyboardio Model 100 owners!",
+      "description": "Firmware before version 0.90.1 contains a bug that leads to data loss and corrupted data saved on the keyboard. If you're already running newer firmware, you can dismiss this warning with the close button.",
+      "button": "Upgrade instructions"
+    }
+  },
   "errors": {
     "deviceDisconnected": "Keyboard disconnected",
     "saveFile": "Error saving a file: {{ error }}"

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -36,6 +36,9 @@ import { ConnectionButton } from "./KeyboardSelect/ConnectionButton";
 import { DeviceImage } from "./KeyboardSelect/DeviceImage";
 import { KeyboardPortSelector } from "./KeyboardSelect/KeyboardPortSelector";
 import { LinuxPermissionsWarning } from "./KeyboardSelect/LinuxPermissionsWarning";
+import { BreakingNews } from "@renderer/components/BreakingNews";
+
+import { Firmware0_90_1 } from "@renderer/breaking-news";
 
 const { ipcRenderer } = require("electron");
 
@@ -148,6 +151,9 @@ const KeyboardSelect = (props) => {
             }}
           />
         )}
+        <BreakingNews tag="firmware.0.90.1">
+          <Firmware0_90_1 />
+        </BreakingNews>
         <LinuxPermissionsWarning selectedDevicePort={selectedDevicePort} />
         <Card
           sx={{

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -36,7 +36,6 @@ import { ConnectionButton } from "./KeyboardSelect/ConnectionButton";
 import { DeviceImage } from "./KeyboardSelect/DeviceImage";
 import { KeyboardPortSelector } from "./KeyboardSelect/KeyboardPortSelector";
 import { LinuxPermissionsWarning } from "./KeyboardSelect/LinuxPermissionsWarning";
-import { BreakingNews } from "@renderer/components/BreakingNews";
 
 import { Firmware0_90_1 } from "@renderer/breaking-news";
 
@@ -151,9 +150,7 @@ const KeyboardSelect = (props) => {
             }}
           />
         )}
-        <BreakingNews tag="firmware.0.90.1">
-          <Firmware0_90_1 />
-        </BreakingNews>
+        <Firmware0_90_1 devices={devices} />
         <LinuxPermissionsWarning selectedDevicePort={selectedDevicePort} />
         <Card
           sx={{


### PR DESCRIPTION
Due to the importance of the 0.90.1 firmware, display a breaking news section just below the application bar for Model 100 owners, urging them to update their firmware. The news item is dismissable, and if dismissed, will not be shown again (future breaking news will be shown, however). Clicking the button leads to [my post](https://community.keyboard.io/t/model-100-firmware-update-to-fix-corruption-issues/5553) on the forums.

The banner is not displayed if no Model100 is detected.

Improvements to the displayed message would be most appreciated!

![Screenshot from 2022-09-26 00-47-59](https://user-images.githubusercontent.com/17243/192169050-416945ae-68fb-4295-af5b-eb2d4f7f1f3c.png)
