### PR TITLE
When using eeprom.erase, return after 10 seconds

### DIFF
--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -90,7 +90,7 @@ const MyKeyboardPreferences = (props) => {
       <KeyboardLayerPreferences onSaveChanges={onSaveChanges} />
       <KeyboardLEDPreferences onSaveChanges={onSaveChanges} />
       <PluginPreferences onSaveChanges={onSaveChanges} />
-      <AdvancedKeyboardPreferences />
+      <AdvancedKeyboardPreferences onDisconnect={props.onDisconnect} />
 
       <SaveChangesButton
         onClick={saveChanges}

--- a/src/renderer/screens/Preferences/keyboard/AdvancedKeyboardPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/AdvancedKeyboardPreferences.js
@@ -43,9 +43,14 @@ const AdvancedKeyboardPreferences = (props) => {
     closeEEPROMResetConfirmation();
 
     await clearEEPROM();
-    await focusCommands.reboot();
+    try {
+      focusCommands.reboot();
+    } catch (_) {
+      /* ignore any errors */
+    }
 
     setWorking(false);
+    props.onDisconnect();
   };
   const openEEPROMResetConfirmation = () => {
     setEEPROMResetConfirmationOpen(true);

--- a/src/renderer/utils/clearEEPROM.js
+++ b/src/renderer/utils/clearEEPROM.js
@@ -22,7 +22,20 @@ const clearEEPROM = async () => {
 
   const commands = await focus.command("help");
   if (commands.includes("eeprom.erase")) {
-    return await focus.command("eeprom.erase");
+    try {
+      focus.command("eeprom.erase");
+    } catch (_) {
+      /* ignore any errors */
+    }
+
+    // Once we sent the eeprom.erase command, the device will eventually reboot.
+    // Wait 10 seconds, and then reboot, to pretend we got something back.
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 10000);
+    });
+    return;
   }
 
   let eeprom = await focus.command("eeprom.contents");


### PR DESCRIPTION
When using `eeprom.erase` to restore factory settings, the keyboard will erase the eeprom and reboot before sending us a reply. We can't await for that to return, as it never will.

While we could - and should - fix the firmware, we still want to handle older firmware, so we need a Chrysalis-side solution too. This solution is  to wait 10 seconds in `clearEEPROM()`, and just return. Ten seconds should be enough to clear the eeprom, even if we're using a pretty large emulated storage where writes are slow. They're not *this* slow.

With this, the factory reset in Preferences will eventually complete. Since we enforce a reboot afterwards, this factory reset will now disconnect from the keyboard as well, and land us back on the Keyboard Selection screen.

Fixes #1056.