### PR TITLE
Clean up how we render the edges on Model 100 keys

### DIFF
--- a/src/api/hardware-keyboardio-model01/components/keymap/Key.js
+++ b/src/api/hardware-keyboardio-model01/components/keymap/Key.js
@@ -34,7 +34,7 @@ const Key = (props) => {
       <ellipse
         fill={props.color}
         stroke={stroke}
-        strokeWidth="2.73"
+        strokeWidth="3"
         cx="610.765"
         cy="953.469"
         rx="75.6"
@@ -47,7 +47,7 @@ const Key = (props) => {
       <path
         fill={props.color}
         stroke={stroke}
-        strokeWidth="1.55"
+        strokeWidth="3"
         d={props.shape}
       />
     );

--- a/src/api/hardware-keyboardio-model01/components/keymap/Key.js
+++ b/src/api/hardware-keyboardio-model01/components/keymap/Key.js
@@ -17,18 +17,17 @@
 
 import KeymapDB from "@api/focus/keymap/db";
 import React from "react";
+import useTheme from "@mui/material/styles/useTheme";
 
 const db = new KeymapDB();
 
 const Key = (props) => {
-  let shape,
-    stroke = "#b3b3b3";
+  const theme = useTheme();
 
-  if (props.active) {
-    stroke = "#f3b3b3";
-  }
-
-  const { getContrastText } = props;
+  let shape;
+  const stroke = props.active
+    ? theme.palette.primary.light
+    : theme.palette.grey[500];
 
   if (props.palmKey) {
     shape = (
@@ -66,7 +65,7 @@ const Key = (props) => {
           x={props.x}
           y={props.y - 3}
           className="extra-key"
-          fill={getContrastText(props.color)}
+          fill={theme.palette.getContrastText(props.color)}
         >
           {label.hint}
         </text>
@@ -84,7 +83,11 @@ const Key = (props) => {
     >
       {shape}
       <g transform={props.primaryLabelTransform}>
-        <text x={props.x} y={props.y} fill={getContrastText(props.color)}>
+        <text
+          x={props.x}
+          y={props.y}
+          fill={theme.palette.getContrastText(props.color)}
+        >
           {label && label.main}
         </text>
       </g>


### PR DESCRIPTION
It's not good, but it's better than the status quo ante.
![image](https://user-images.githubusercontent.com/45416/192633759-b856431e-a635-429c-b9fc-ff0fff5e8f4e.png)
![image](https://user-images.githubusercontent.com/45416/192633795-f9eca7a8-d52f-4079-b50d-933398689062.png)
