### PR TITLE
Prevent saving & display an alert when layernames take too much space

### DIFF
--- a/src/api/focus/layernames.js
+++ b/src/api/focus/layernames.js
@@ -37,10 +37,17 @@ export default class LayerNames {
     };
   }
 
+  _serialize(data) {
+    return data.names.flatMap((n) => [n.length, n]).join(" ") + " 0";
+  }
+
   async _push(s, data) {
-    const serialized =
-      data.names.flatMap((n) => [n.length, n]).join(" ") + " 0";
+    const serialized = this._serialize(data);
     await s.request("keymap.layerNames", serialized);
+  }
+
+  getStoredSize(data) {
+    return this._serialize(data).length;
   }
 
   async focus(s, data) {

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -223,6 +223,9 @@
       "fixItButton": "Switch to custom layers only",
       "openFR": "Open a feature request"
     },
+    "layernames": {
+      "out_of_space": "Your layer names are {{ overflow }} bytes too long to save to your keyboard."
+    },
     "macros": {
       "title": "Macro #{{ index }}",
       "edit": "Edit macro",

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -19,6 +19,7 @@ import Focus from "@api/focus";
 import Keymap from "@api/focus/keymap";
 import KeymapDB from "@api/focus/keymap/db";
 import Macros, { Step as MacroStep } from "@api/focus/macros";
+import LayerNames from "@api/focus/layernames";
 import { logger } from "@api/log";
 import Box from "@mui/material/Box";
 import {
@@ -35,6 +36,7 @@ import { useTranslation } from "react-i18next";
 import { FloatingKeyPicker } from "./components/FloatingKeyPicker";
 import { LegacyAlert } from "./components/LegacyAlert";
 import { MacroStorageAlert } from "./components/MacroStorageAlert";
+import { LayerNamesStorageAlert } from "./components/LayerNamesStorageAlert";
 import OnlyCustomScreen from "./components/OnlyCustomScreen";
 import MacroEditor from "./Macros/MacroEditor";
 import Sidebar, { sidebarWidth } from "./Sidebar";
@@ -412,8 +414,11 @@ const Editor = (props) => {
   }
 
   const M = new Macros();
+  const L = new LayerNames();
   const saveChangesDisabled =
-    !modified || M.getStoredSize(macros) > macros.storageSize;
+    !modified ||
+    M.getStoredSize(macros) > macros.storageSize ||
+    L.getStoredSize(layerNames) > layerNames.storageSize;
 
   return (
     <React.Fragment>
@@ -427,6 +432,9 @@ const Editor = (props) => {
           width: `calc(100% - ${sidebarWidth}px)`,
         }}
       >
+        {layerNames.storageSize > 0 && (
+          <LayerNamesStorageAlert layerNames={layerNames} />
+        )}
         {mainWidget}
       </Box>
       <Sidebar

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -287,7 +287,7 @@ const Editor = (props) => {
           .fill()
           .map((_, i) => deviceLayerNames.names[i] || `#${i}`);
         setLayerNames({
-          storageSize: deviceLayerNames.storage,
+          storageSize: deviceLayerNames.storageSize,
           names: names,
         });
       }

--- a/src/renderer/screens/Editor/components/LayerNamesStorageAlert.js
+++ b/src/renderer/screens/Editor/components/LayerNamesStorageAlert.js
@@ -1,0 +1,53 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Alert from "@mui/material/Alert";
+import Button from "@mui/material/Button";
+import DiscFullIcon from "@mui/icons-material/DiscFull";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import LayerNames from "@api/focus/layernames";
+
+export const LayerNamesStorageAlert = (props) => {
+  const { t } = useTranslation();
+
+  if (props.layerNames.storageSize == 0) return null;
+
+  const L = new LayerNames();
+  const used = L.getStoredSize(props.layerNames);
+
+  if (used <= props.layerNames.storageSize) return null;
+
+  return (
+    <Alert
+      severity="error"
+      icon={<DiscFullIcon fontSize="inherit" />}
+      sx={{
+        zIndex: "modal",
+        position: "relative",
+      }}
+    >
+      <Typography component="p">
+        {t("editor.layernames.out_of_space", {
+          overflow: used - props.layerNames.storageSize,
+        })}
+      </Typography>
+    </Alert>
+  );
+};


### PR DESCRIPTION
![Screenshot from 2022-09-27 23-08-19](https://user-images.githubusercontent.com/17243/192635791-45885e82-584c-482d-816d-0c96c0058f9b.png)

Fixes #1095.