### PR TITLE
make key labels more legible

### DIFF
--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -21,7 +21,7 @@ button {
 
 .layer {
   font-family: "Source Code Pro", monospace;
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 700;
   user-select: none;
 }
@@ -31,7 +31,7 @@ button {
 }
 
 .extra-key {
-  font-size: 10px;
+  font-size: 9.5px;
 }
 
 .key:hover {

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -21,7 +21,7 @@ button {
 
 .layer {
   font-family: "Source Code Pro", monospace;
-  font-size: 8px;
+  font-size: 10px;
   font-weight: 700;
   user-select: none;
 }
@@ -31,7 +31,7 @@ button {
 }
 
 .extra-key {
-  font-size: 8px;
+  font-size: 10px;
 }
 
 .key:hover {


### PR DESCRIPTION
Increase font size for non-short key labels. This increases legibility.

Fixes #1094.