### PR TITLE
Perform some sanity checks during startup

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -47,6 +47,7 @@ import KeyboardSelect from "./screens/KeyboardSelect";
 import LayoutCard from "./screens/LayoutCard";
 import Preferences from "./screens/Preferences";
 import SystemInfo from "./screens/SystemInfo";
+import SanityCheck from "./screens/SanityCheck";
 
 import { useAutoUpdate } from "./hooks/useAutoUpdate";
 import { useFirmwareAutoUpdate } from "./hooks/useFirmwareAutoUpdate";
@@ -269,6 +270,7 @@ const App = (props) => {
                   }}
                 >
                   <Router id="router">
+                    <SanityCheck path="/sanity-check" />
                     <FocusNotDetected
                       path="/focus-not-detected"
                       focusDeviceDescriptor={focusDeviceDescriptor}

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -7,6 +7,12 @@
       "button": "Upgrade instructions"
     }
   },
+  "sanity-check": {
+    "title": "Running environment verification",
+    "header": "Environment verification failed",
+    "message": "Chrysalis has detected that it is running in an unsupported environment, such as with an Electron version other than the one supported upstream. If you are using Chrysalis through a distribution's package repository, please consider using the official builds instead.",
+    "download-latest": "Download the official release"
+  },
   "errors": {
     "deviceDisconnected": "Keyboard disconnected",
     "saveFile": "Error saving a file: {{ error }}"

--- a/src/renderer/routerHistory.js
+++ b/src/renderer/routerHistory.js
@@ -17,7 +17,7 @@
 import { logger } from "@api/log";
 import { createHistory, createMemorySource } from "@gatsbyjs/reach-router";
 
-const source = createMemorySource("/keyboard-select");
+const source = createMemorySource("/sanity-check");
 export const history = createHistory(source);
 export const navigate = (...args) => {
   logger().debug("navigating to location", { args: args });

--- a/src/renderer/screens/SanityCheck.js
+++ b/src/renderer/screens/SanityCheck.js
@@ -1,0 +1,103 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ErrorIcon from "@mui/icons-material/Error";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Typography from "@mui/material/Typography";
+import { PageTitle } from "@renderer/components/PageTitle";
+import { navigate } from "@renderer/routerHistory";
+import openURL from "@renderer/utils/openURL";
+import { devDependencies } from "@root/package.json";
+import fs from "fs";
+import path from "path";
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import semver from "semver";
+import { getStaticPath } from "@renderer/config";
+
+const SanityCheck = (props) => {
+  const { t } = useTranslation();
+  const [sanityChecked, setSanityChecked] = useState(false);
+  const [sanityOk, setSanityOk] = useState(false);
+
+  useEffect(() => {
+    const sanityCheck = async () => {
+      const checkFile = path.join(getStaticPath(), "logo.png");
+      const allOk =
+        semver.satisfies(
+          process.versions.electron,
+          devDependencies["electron"]
+        ) && fs.existsSync(checkFile);
+      setSanityOk(allOk);
+      setSanityChecked(true);
+    };
+
+    sanityCheck();
+  });
+
+  if (!sanityChecked) return null;
+
+  if (sanityOk) {
+    navigate("/keyboard-select");
+    return null;
+  }
+
+  const onClick = () => {
+    openURL("https://github.com/keyboardio/Chrysalis/releases/latest")();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      <PageTitle title={t("sanity-check.title")} />
+      <Card
+        sx={{
+          margin: 4,
+          maxWidth: "50%",
+        }}
+      >
+        <CardHeader
+          avatar={<ErrorIcon color="error" fontSize="large" />}
+          title={t("sanity-check.header")}
+          titleTypographyProps={{ variant: "h6" }}
+        />
+        <CardContent>
+          <Typography component="p" gutterBottom>
+            {t("sanity-check.message")}
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button variant="contained" color="primary" onClick={onClick}>
+            {t("sanity-check.download-latest")}
+          </Button>
+        </CardActions>
+      </Card>
+    </Box>
+  );
+};
+
+export { SanityCheck as default };


### PR DESCRIPTION
When starting up, perform some sanity checks, to verify that Chrysalis is running in an environment that allows it to function correctly. Among other things, we verify that the Electron version we're running against is the expected one, and that static files bundled with the package are accessible.

If any of the sanity checks fail, a message is displayed, urging the user to use an official build. The user can still navigate away, if they choose to do so, the message is only shown once on startup.

This is mostly here to combat the `chrysalis` package in AUR, which is causing a lot of frustration and support requests.

![Screenshot from 2022-09-29 12-13-10](https://user-images.githubusercontent.com/17243/193005865-46313413-5ae7-46d4-b52b-8438c7ced2a0.png)
