### PR TITLE
api/focus: Do not close the port when receiving a close event

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -370,7 +370,6 @@ class Focus {
         const [_, reject] = this.callbacks.shift();
         reject("Device disconnected");
       }
-      this.close();
     });
 
     this.resetDeviceState();


### PR DESCRIPTION
Using `this.close()` clears properties that we need elsewhere, in `handleDeviceDisconnect()` in App.js. With those properties cleared, the handler over there can't do its job properly. If it can't do its job properly, then we're not handling the disconnect either, which leaves other parts of Chrysalis in a bad state, where they assume the keyboard is connected while it is not.

Since we do have a way to handle disconnects, at a higher level, lets let it do that, and not close the device at a lower level.

Fixes #1107.
