### PR TITLE
Couple of fixes for secondary action modifiers

### DIFF
--- a/src/api/focus/keymap/db/base/dualuse.js
+++ b/src/api/focus/keymap/db/base/dualuse.js
@@ -59,9 +59,21 @@ const duMods = {
     index: 3,
     name: GuiLabel.full,
   },
+  rctrl: {
+    index: 4,
+    name: "Right Control",
+  },
+  rshift: {
+    index: 5,
+    name: "Right Shift",
+  },
   altgr: {
     index: 6,
     name: "AltGr",
+  },
+  rgui: {
+    index: 7,
+    name: `Right ${GuiLabel.full}`,
   },
 };
 
@@ -116,6 +128,9 @@ const dualuse = []
   .concat(dum("shift"))
   .concat(dum("alt"))
   .concat(dum("gui"))
-  .concat(dum("altgr"));
+  .concat(dum("rctrl"))
+  .concat(dum("rshift"))
+  .concat(dum("altgr"))
+  .concat(dum("rgui"));
 
 export { dualuse, addDUM, addDUL };

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -88,7 +88,9 @@ const KeyPicker = (props) => {
 
     return (
       <Switch
-        checked={db.isInCategory(key, mod)}
+        checked={
+          db.isInCategory(key, mod) && !db.isInCategory(key.code, "dualuse")
+        }
         color="primary"
         onChange={toggleModifier(mod)}
       />

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -118,8 +118,17 @@ const SecondaryFunction = (props) => {
               <MenuItem value="gui" selected={modifier == "gui"}>
                 {GuiLabel.full}
               </MenuItem>
+              <MenuItem value="rctrl" selected={modifier == "rctrl"}>
+                Right Control
+              </MenuItem>
+              <MenuItem value="rshift" selected={modifier == "rshift"}>
+                Right Shift
+              </MenuItem>
               <MenuItem value="altgr" selected={modifier == "altgr"}>
                 AltGr
+              </MenuItem>
+              <MenuItem value="rgui" selected={modifier == "rgui"}>
+                Right {GuiLabel.full}
               </MenuItem>
             </Select>
           </FormGroup>


### PR DESCRIPTION
Fixes both of the issues mentioned in #1117:

- When a key is set as a dual-use modifier, it is no longer shown as a modifier a few sections above: ![Screenshot from 2022-09-29 21-18-27](https://user-images.githubusercontent.com/17243/193123004-3361ac6e-dd40-48d7-b03d-a7792768341c.png)
- Added the rest of the right-hand side modifiers to dual-use modifiers: ![Screenshot from 2022-09-29 21-18-32](https://user-images.githubusercontent.com/17243/193123274-e67466fe-89e0-4d7e-bae8-477e1411d524.png)

The right-half modifiers do overflow most keycaps, but that's a different issue.