### PR TITLE
Editor: Do not disable saving if LayerNames is not in use

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -418,7 +418,8 @@ const Editor = (props) => {
   const saveChangesDisabled =
     !modified ||
     M.getStoredSize(macros) > macros.storageSize ||
-    L.getStoredSize(layerNames) > layerNames.storageSize;
+    (layerNames.storageSize > 0 &&
+      L.getStoredSize(layerNames) > layerNames.storageSize);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
In case the `LayerNames` plugin is not enabled firmware-side, getting the stored size of the layer names still returns a non-zero value. We need to check if there is *any* storage size, before comparing the serialized length, otherwise we mistakenly disable saving (and don't even show a warning, because the warning correctly checks for the presence of the plugin).

Fixes #1119.
