### PR TITLE
Editor: Add a toolbox above the keyboard, for various editing tools

### DIFF
--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -58,7 +58,7 @@ const SaveChangesButton = (props) => {
 
   return (
     <Tooltip title={props.children}>
-      <Box sx={{ position: "relative", mt: 2 }}>
+      <Box sx={{ position: "relative", mt: 3 }}>
         <Fab
           disabled={inProgress || (props.disabled && !success)}
           color={success ? "success" : "primary"}

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -58,38 +58,26 @@ const SaveChangesButton = (props) => {
 
   return (
     <Tooltip title={props.children}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "flex-end",
-          position: "fixed",
-          bottom: 32,
-          left: 32,
-          zIndex: (theme) => theme.zIndex.drawer - 1,
-        }}
-      >
-        <Box sx={{ position: "relative" }}>
-          <Fab
-            disabled={inProgress || (props.disabled && !success)}
-            color={success ? "success" : "primary"}
-            onClick={handleButtonClick}
-          >
-            {success ? <CheckIcon /> : icon}
-          </Fab>
-          {inProgress && (
-            <CircularProgress
-              size={68}
-              color="success"
-              sx={{
-                position: "absolute",
-                top: -6,
-                left: -6,
-                zIndex: 1,
-              }}
-            />
-          )}
-        </Box>
+      <Box sx={{ position: "relative", mt: 2 }}>
+        <Fab
+          disabled={inProgress || (props.disabled && !success)}
+          color={success ? "success" : "primary"}
+          onClick={handleButtonClick}
+        >
+          {success ? <CheckIcon /> : icon}
+        </Fab>
+        {inProgress && (
+          <CircularProgress
+            size={68}
+            color="success"
+            sx={{
+              position: "absolute",
+              top: -6,
+              left: -6,
+              zIndex: 1,
+            }}
+          />
+        )}
       </Box>
     </Tooltip>
   );

--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -58,26 +58,38 @@ const SaveChangesButton = (props) => {
 
   return (
     <Tooltip title={props.children}>
-      <Box sx={{ position: "relative", mt: 3 }}>
-        <Fab
-          disabled={inProgress || (props.disabled && !success)}
-          color={success ? "success" : "primary"}
-          onClick={handleButtonClick}
-        >
-          {success ? <CheckIcon /> : icon}
-        </Fab>
-        {inProgress && (
-          <CircularProgress
-            size={68}
-            color="success"
-            sx={{
-              position: "absolute",
-              top: -6,
-              left: -6,
-              zIndex: 1,
-            }}
-          />
-        )}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          position: "fixed",
+          bottom: 32,
+          left: 32,
+          zIndex: (theme) => theme.zIndex.drawer - 1,
+        }}
+      >
+        <Box sx={{ position: "relative" }}>
+          <Fab
+            disabled={inProgress || (props.disabled && !success)}
+            color={success ? "success" : "primary"}
+            onClick={handleButtonClick}
+          >
+            {success ? <CheckIcon /> : icon}
+          </Fab>
+          {inProgress && (
+            <CircularProgress
+              size={68}
+              color="success"
+              sx={{
+                position: "absolute",
+                top: -6,
+                left: -6,
+                zIndex: 1,
+              }}
+            />
+          )}
+        </Box>
       </Box>
     </Tooltip>
   );

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -91,6 +91,9 @@
     "title": "Changelog"
   },
   "editor": {
+    "toolbox": {
+      "eraser": "Erase key"
+    },
     "legacy": {
       "migrate": "Migrate",
       "warning": "We found legacy keys on the keymap that are no longer valid. To migrate to the new codes, please press the Migrate button."

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -542,9 +542,9 @@ const Editor = (props) => {
         />
       )}
       <ToolBox
-        setTool={props.setTool}
-        tool={props.tool}
-        hasColormap={props.hasColormap}
+        setTool={setTool}
+        tool={tool}
+        hasColormap={hasColormap()}
         orientation="vertical"
         onSaveChanges={onApply}
         onSaveChangesError={onApplyError}

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -28,7 +28,6 @@ import {
 import { GlobalContext } from "@renderer/components/GlobalContext";
 import LoadingScreen from "@renderer/components/LoadingScreen";
 import { PageTitle } from "@renderer/components/PageTitle";
-import SaveChangesButton from "@renderer/components/SaveChangesButton";
 import { toast } from "@renderer/components/Toast";
 import useEffectOnce from "@renderer/hooks/useEffectOnce";
 import React, { useEffect, useState } from "react";
@@ -40,6 +39,7 @@ import { LayerNamesStorageAlert } from "./components/LayerNamesStorageAlert";
 import OnlyCustomScreen from "./components/OnlyCustomScreen";
 import MacroEditor from "./Macros/MacroEditor";
 import Sidebar, { sidebarWidth } from "./Sidebar";
+import { ToolBox } from "./ToolBox";
 
 const db = new KeymapDB();
 
@@ -541,13 +541,16 @@ const Editor = (props) => {
           currentKey={currentKey}
         />
       )}
-      <SaveChangesButton
-        onClick={onApply}
-        onError={onApplyError}
-        disabled={saveChangesDisabled}
-      >
-        {t("components.save.saveChanges")}
-      </SaveChangesButton>
+      <ToolBox
+        setTool={props.setTool}
+        tool={props.tool}
+        hasColormap={props.hasColormap}
+        orientation="vertical"
+        onSaveChanges={onApply}
+        onSaveChangesError={onApplyError}
+        saveChangesDisabled={saveChangesDisabled}
+        saveChangesTitle={t("components.save.saveChanges")}
+      />
     </React.Fragment>
   );
 };

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -33,7 +33,6 @@ import { toast } from "@renderer/components/Toast";
 import useEffectOnce from "@renderer/hooks/useEffectOnce";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ToolBox } from "./ToolBox";
 import { FloatingKeyPicker } from "./components/FloatingKeyPicker";
 import { LegacyAlert } from "./components/LegacyAlert";
 import { MacroStorageAlert } from "./components/MacroStorageAlert";
@@ -507,7 +506,6 @@ const Editor = (props) => {
         {layerNames.storageSize > 0 && (
           <LayerNamesStorageAlert layerNames={layerNames} />
         )}
-        <ToolBox setTool={setTool} tool={tool} hasColormap={hasColormap()} />
         {mainWidget}
       </Box>
       <Sidebar
@@ -531,6 +529,9 @@ const Editor = (props) => {
         onLedChange={onLedChange}
         setOpenMacroEditor={maybeOpenMacroEditor}
         currentKey={currentKey}
+        tool={tool}
+        setTool={setTool}
+        hasColormap={hasColormap()}
       />
       {tool == "select" && (
         <FloatingKeyPicker

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -507,7 +507,7 @@ const Editor = (props) => {
         {layerNames.storageSize > 0 && (
           <LayerNamesStorageAlert layerNames={layerNames} />
         )}
-        <ToolBox setTool={setTool} tool={tool} />
+        <ToolBox setTool={setTool} tool={tool} hasColormap={hasColormap()} />
         {mainWidget}
       </Box>
       <Sidebar

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -72,6 +72,7 @@ const Editor = (props) => {
   const [macros, setMacros] = useState(null);
   const [currentLedIndex, setCurrentLedIndex] = useState(0);
   const [currentKeyIndex, setCurrentKeyIndex] = useState(0);
+  const [currentPaletteIndex, setCurrentPaletteIndex] = useState(15);
   const [modified, setModified] = useState(false);
   const [loading, setLoading] = useState(true);
   const [currentLayer, setCurrentLayer] = useState(0);
@@ -160,6 +161,13 @@ const Editor = (props) => {
 
       setModified(true);
       showContextBar();
+    } else if (tool == "color-paint") {
+      const newColormap = { ...colormap };
+      newColormap.colorMap[currentLayer][ledIndex] = currentPaletteIndex;
+      setModified(true);
+      setColormap(newColormap);
+
+      showContextBar();
     }
   };
 
@@ -238,6 +246,7 @@ const Editor = (props) => {
   const onLedChange = (index) => {
     const newColormap = { ...colormap };
     newColormap.colorMap[currentLayer][currentLedIndex] = index;
+    setCurrentPaletteIndex(index);
     setModified(true);
     setColormap(newColormap);
 

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -541,16 +541,6 @@ const Editor = (props) => {
           currentKey={currentKey}
         />
       )}
-      <ToolBox
-        setTool={setTool}
-        tool={tool}
-        hasColormap={hasColormap()}
-        orientation="vertical"
-        onSaveChanges={onApply}
-        onSaveChangesError={onApplyError}
-        saveChangesDisabled={saveChangesDisabled}
-        saveChangesTitle={t("components.save.saveChanges")}
-      />
     </React.Fragment>
   );
 };

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -48,19 +48,11 @@ import IconButton from "@mui/material/IconButton";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
 
-import { ToolBox } from "./ToolBox";
-
 const sidebarWidth = 360;
 
 const Sidebar = (props) => {
   const { keymap, selectedKey, selectedLed, layer, colormap, macroEditorOpen } =
     props;
-
-  const [toolsOpen, setToolsOpen] = useState(false);
-
-  const toggleToolbox = () => {
-    setToolsOpen(!toolsOpen);
-  };
 
   const widgets = [
     KeyPicker,
@@ -122,19 +114,15 @@ const Sidebar = (props) => {
         },
       }}
     >
-      <Box sx={{ display: "flex", mt: "48px" }}>
-        <ToolBox open={toolsOpen} />
+      <Toolbar />
+      <Box sx={{ display: "flex" }}>
         <Box
           sx={{
             px: 1,
             mb: 2,
-            width: toolsOpen ? 260 : 360,
             transition: "all 2s ease-out",
           }}
         >
-          <IconButton onClick={toggleToolbox} variant="outlined">
-            <KeyboardArrowLeftIcon />
-          </IconButton>
           <Overview
             macroEditorOpen={macroEditorOpen}
             keymap={keymap}

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -132,7 +132,25 @@ const Sidebar = (props) => {
           tool={props.tool}
           hasColormap={props.hasColormap}
         />
-        {categories}
+        {props.tool == "select" && categories}
+        {props.tool == "color-paint" && (
+          <Colormap
+            macroEditorOpen={macroEditorOpen}
+            keymap={keymap}
+            colormap={colormap}
+            selectedKey={selectedKey}
+            selectedLed={selectedLed}
+            layer={layer}
+            layerNames={props.layerNames}
+            onKeyChange={props.onKeyChange}
+            onLedChange={props.onLedChange}
+            onPaletteChange={props.onPaletteChange}
+            macros={props.macros}
+            setOpenMacroEditor={props.setOpenMacroEditor}
+            currentKey={props.currentKey}
+            sx={{ p: 2 }}
+          />
+        )}
       </Box>
     </Drawer>
   );

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -19,7 +19,6 @@ import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import Toolbar from "@mui/material/Toolbar";
 import React from "react";
-import { ToolBox } from "./ToolBox";
 import BlankKeys from "./Sidebar/BlankKeys";
 import BrightnessKeys from "./Sidebar/BrightnessKeys";
 import Colormap from "./Sidebar/Colormap";
@@ -126,11 +125,6 @@ const Sidebar = (props) => {
           onKeymapChange={props.onKeymapChange}
           onPaletteChange={props.onPaletteChange}
           onColormapChange={props.onColormapChange}
-        />
-        <ToolBox
-          setTool={props.setTool}
-          tool={props.tool}
-          hasColormap={props.hasColormap}
         />
         {props.tool == "select" && categories}
         {props.tool == "color-paint" && (

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -19,6 +19,7 @@ import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import Toolbar from "@mui/material/Toolbar";
 import React from "react";
+import { ToolBox } from "./ToolBox";
 import BlankKeys from "./Sidebar/BlankKeys";
 import BrightnessKeys from "./Sidebar/BrightnessKeys";
 import Colormap from "./Sidebar/Colormap";
@@ -125,6 +126,11 @@ const Sidebar = (props) => {
           onKeymapChange={props.onKeymapChange}
           onPaletteChange={props.onPaletteChange}
           onColormapChange={props.onColormapChange}
+        />
+        <ToolBox
+          setTool={props.setTool}
+          tool={props.tool}
+          hasColormap={props.hasColormap}
         />
         {categories}
       </Box>

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -16,9 +16,10 @@
  */
 
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Drawer from "@mui/material/Drawer";
 import Toolbar from "@mui/material/Toolbar";
-import React from "react";
+import React, { useState } from "react";
 import BlankKeys from "./Sidebar/BlankKeys";
 import BrightnessKeys from "./Sidebar/BrightnessKeys";
 import Colormap from "./Sidebar/Colormap";
@@ -41,11 +42,25 @@ import TapDanceKeys from "./Sidebar/TapDanceKeys";
 import VolumeKeys from "./Sidebar/VolumeKeys";
 import PlatformAppleKeys from "./Sidebar/PlatformAppleKeys";
 
+import Collapse from "@mui/material/Collapse";
+import IconButton from "@mui/material/IconButton";
+
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+
+import { ToolBox } from "./ToolBox";
+
 const sidebarWidth = 360;
 
 const Sidebar = (props) => {
   const { keymap, selectedKey, selectedLed, layer, colormap, macroEditorOpen } =
     props;
+
+  const [toolsOpen, setToolsOpen] = useState(false);
+
+  const toggleToolbox = () => {
+    setToolsOpen(!toolsOpen);
+  };
 
   const widgets = [
     KeyPicker,
@@ -107,44 +122,56 @@ const Sidebar = (props) => {
         },
       }}
     >
-      <Toolbar />
-      <Box sx={{ px: 1, mb: 2 }}>
-        <Overview
-          macroEditorOpen={macroEditorOpen}
-          keymap={keymap}
-          colormap={colormap}
-          selectedKey={selectedKey}
-          selectedLed={selectedLed}
-          layer={layer}
-          setLayer={props.setLayer}
-          copyLayer={props.copyLayer}
-          hasCopiedLayer={props.hasCopiedLayer}
-          pasteLayer={props.pasteLayer}
-          layerNames={props.layerNames}
-          setLayerName={props.setLayerName}
-          onKeymapChange={props.onKeymapChange}
-          onPaletteChange={props.onPaletteChange}
-          onColormapChange={props.onColormapChange}
-        />
-        {props.tool == "select" && categories}
-        {props.tool == "color-paint" && (
-          <Colormap
+      <Box sx={{ display: "flex", mt: "48px" }}>
+        <ToolBox open={toolsOpen} />
+        <Box
+          sx={{
+            px: 1,
+            mb: 2,
+            width: toolsOpen ? 260 : 360,
+            transition: "all 2s ease-out",
+          }}
+        >
+          <IconButton onClick={toggleToolbox} variant="outlined">
+            <KeyboardArrowLeftIcon />
+          </IconButton>
+          <Overview
             macroEditorOpen={macroEditorOpen}
             keymap={keymap}
             colormap={colormap}
             selectedKey={selectedKey}
             selectedLed={selectedLed}
             layer={layer}
+            setLayer={props.setLayer}
+            copyLayer={props.copyLayer}
+            hasCopiedLayer={props.hasCopiedLayer}
+            pasteLayer={props.pasteLayer}
             layerNames={props.layerNames}
-            onKeyChange={props.onKeyChange}
-            onLedChange={props.onLedChange}
+            setLayerName={props.setLayerName}
+            onKeymapChange={props.onKeymapChange}
             onPaletteChange={props.onPaletteChange}
-            macros={props.macros}
-            setOpenMacroEditor={props.setOpenMacroEditor}
-            currentKey={props.currentKey}
-            sx={{ p: 2 }}
+            onColormapChange={props.onColormapChange}
           />
-        )}
+          {props.tool == "select" && categories}
+          {props.tool == "color-paint" && (
+            <Colormap
+              macroEditorOpen={macroEditorOpen}
+              keymap={keymap}
+              colormap={colormap}
+              selectedKey={selectedKey}
+              selectedLed={selectedLed}
+              layer={layer}
+              layerNames={props.layerNames}
+              onKeyChange={props.onKeyChange}
+              onLedChange={props.onLedChange}
+              onPaletteChange={props.onPaletteChange}
+              macros={props.macros}
+              setOpenMacroEditor={props.setOpenMacroEditor}
+              currentKey={props.currentKey}
+              sx={{ p: 2 }}
+            />
+          )}
+        </Box>
       </Box>
     </Drawer>
   );

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -15,15 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import FormatColorResetIcon from "@mui/icons-material/FormatColorReset";
 import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import Box from "@mui/material/Box";
+import SvgIcon from "@mui/material/SvgIcon";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+// Sourced from: https://materialdesignicons.com/icon/eraser
+const EraserIcon = (props) => {
+  return (
+    <SvgIcon {...props}>
+      <path d="M16.24,3.56L21.19,8.5C21.97,9.29 21.97,10.55 21.19,11.34L12,20.53C10.44,22.09 7.91,22.09 6.34,20.53L2.81,17C2.03,16.21 2.03,14.95 2.81,14.16L13.41,3.56C14.2,2.78 15.46,2.78 16.24,3.56M4.22,15.58L7.76,19.11C8.54,19.9 9.8,19.9 10.59,19.11L14.12,15.58L9.17,10.63L4.22,15.58Z" />
+    </SvgIcon>
+  );
+};
 
 export const ToolBox = (props) => {
   const { t } = useTranslation();
@@ -43,7 +52,7 @@ export const ToolBox = (props) => {
       >
         <ToggleButton value="eraser">
           <Tooltip title={t("editor.toolbox.eraser")}>
-            <FormatColorResetIcon />
+            <EraserIcon />
           </Tooltip>
         </ToggleButton>
         <ToggleButton value="color-paint">

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -16,6 +16,7 @@
  */
 
 import FormatColorResetIcon from "@mui/icons-material/FormatColorReset";
+import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import Box from "@mui/material/Box";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
@@ -43,6 +44,11 @@ export const ToolBox = (props) => {
         <ToggleButton value="eraser">
           <Tooltip title={t("editor.toolbox.eraser")}>
             <FormatColorResetIcon />
+          </Tooltip>
+        </ToggleButton>
+        <ToggleButton value="color-paint">
+          <Tooltip title={t("editor.toolbox.color-paint")}>
+            <FormatPaintIcon />
           </Tooltip>
         </ToggleButton>
       </ToggleButtonGroup>

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -1,0 +1,51 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2020-2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FormatColorResetIcon from "@mui/icons-material/FormatColorReset";
+import Box from "@mui/material/Box";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Tooltip from "@mui/material/Tooltip";
+
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export const ToolBox = (props) => {
+  const { t } = useTranslation();
+
+  const onChange = (_, newTool) => {
+    props.setTool(newTool || "select");
+  };
+
+  return (
+    <Box sx={{ textAlign: "right", p: 1 }}>
+      <ToggleButtonGroup
+        color="primary"
+        exclusive
+        size="small"
+        value={props.tool}
+        onChange={onChange}
+      >
+        <ToggleButton value="eraser">
+          <Tooltip title={t("editor.toolbox.eraser")}>
+            <FormatColorResetIcon />
+          </Tooltip>
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+};

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -26,13 +26,12 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 // Sourced from: https://materialdesignicons.com/icon/eraser
-const EraserIcon = (props) => {
-  return (
-    <SvgIcon {...props}>
-      <path d="M16.24,3.56L21.19,8.5C21.97,9.29 21.97,10.55 21.19,11.34L12,20.53C10.44,22.09 7.91,22.09 6.34,20.53L2.81,17C2.03,16.21 2.03,14.95 2.81,14.16L13.41,3.56C14.2,2.78 15.46,2.78 16.24,3.56M4.22,15.58L7.76,19.11C8.54,19.9 9.8,19.9 10.59,19.11L14.12,15.58L9.17,10.63L4.22,15.58Z" />
-    </SvgIcon>
-  );
-};
+const EraserIcon = React.forwardRef((props, ref) => (
+  <SvgIcon {...props} ref={ref}>
+    <path d="M16.24,3.56L21.19,8.5C21.97,9.29 21.97,10.55 21.19,11.34L12,20.53C10.44,22.09 7.91,22.09 6.34,20.53L2.81,17C2.03,16.21 2.03,14.95 2.81,14.16L13.41,3.56C14.2,2.78 15.46,2.78 16.24,3.56M4.22,15.58L7.76,19.11C8.54,19.9 9.8,19.9 10.59,19.11L14.12,15.58L9.17,10.63L4.22,15.58Z" />
+  </SvgIcon>
+));
+EraserIcon.displayName = "EraserIcon";
 
 export const ToolBox = (props) => {
   const { t } = useTranslation();

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -55,11 +55,13 @@ export const ToolBox = (props) => {
             <EraserIcon />
           </Tooltip>
         </ToggleButton>
-        <ToggleButton value="color-paint">
-          <Tooltip title={t("editor.toolbox.color-paint")}>
-            <FormatPaintIcon />
-          </Tooltip>
-        </ToggleButton>
+        {props.hasColormap && (
+          <ToggleButton value="color-paint">
+            <Tooltip title={t("editor.toolbox.color-paint")}>
+              <FormatPaintIcon />
+            </Tooltip>
+          </ToggleButton>
+        )}
       </ToggleButtonGroup>
     </Box>
   );

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import Box from "@mui/material/Box";
+import Menu from "@mui/material/Menu";
 import SpeedDial from "@mui/material/SpeedDial";
 import SpeedDialIcon from "@mui/material/SpeedDialIcon";
 import SpeedDialAction from "@mui/material/SpeedDialAction";
@@ -28,7 +28,9 @@ import SaveChangesButton from "@renderer/components/SaveChangesButton";
 
 import CopyAllIcon from "@mui/icons-material/CopyAll";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
+import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import LayersIcon from "@mui/icons-material/Layers";
+import SmartButtonIcon from "@mui/icons-material/SmartButton";
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,16 +46,43 @@ EraserIcon.displayName = "EraserIcon";
 export const ToolBox = (props) => {
   const { t } = useTranslation();
 
-  const onChange = (_, newTool) => {
+  const [layerOpsOpen, setLayerOpsOpen] = useState(false);
+  const [buttonOpsOpen, setButtonOpsOpen] = useState(false);
+
+  const onLayerOpsToggle = () => {
+    if (layerOpsOpen) {
+      setLayerOpsOpen(false);
+    } else {
+      setButtonOpsOpen(false);
+      setLayerOpsOpen(true);
+    }
+  };
+  const onButtonOpsToggle = () => {
+    if (buttonOpsOpen) {
+      setButtonOpsOpen(false);
+    } else {
+      setLayerOpsOpen(false);
+      setButtonOpsOpen(true);
+    }
+  };
+
+  const onChange = (event, newTool) => {
     props.setTool(newTool || "select");
+    /*
+    if (newTool == "layers") {
+      if (layerMenuOpen) {
+        onLayerMenuClose();
+      } else {
+        onLayerMenuOpen(event);
+      }
+    }
+    */
   };
 
   return (
     <Box
-      boxShadow={3}
       sx={{
         p: 1,
-        bgcolor: "background.paper",
         alignItems: "center",
         justifyContent: "flex-end",
         position: "fixed",
@@ -62,46 +91,58 @@ export const ToolBox = (props) => {
         zIndex: (theme) => theme.zIndex.drawer - 1,
       }}
     >
-      <SpeedDial
-        icon={<LayersIcon />}
-        ariaLabel="foo"
-        direction="right"
-        sx={{ mb: 2 }}
-      >
-        <SpeedDialAction icon={<CopyAllIcon />} tooltipTitle="Copy layer" />
-        <SpeedDialAction
-          icon={<ContentPasteIcon />}
-          tooltipTitle="Paste layer"
-        />
-      </SpeedDial>
-      <ToggleButtonGroup
-        color="primary"
-        exclusive
-        size="small"
-        value={props.tool}
-        onChange={onChange}
-        orientation={props.orientation}
-      >
-        <ToggleButton value="eraser">
-          <Tooltip title={t("editor.toolbox.eraser")}>
-            <EraserIcon />
-          </Tooltip>
-        </ToggleButton>
-        {props.hasColormap && (
-          <ToggleButton value="color-paint">
-            <Tooltip title={t("editor.toolbox.color-paint")}>
-              <FormatPaintIcon />
-            </Tooltip>
-          </ToggleButton>
-        )}
-        <SaveChangesButton
-          onClick={props.onSaveChanges}
-          onError={props.onSaveChangesError}
-          disabled={props.saveChangesDisabled}
+      <Box sx={{ ml: 1 }}>
+        <SpeedDial
+          direction="right"
+          ariaLabel="layer operations"
+          icon={<LayersIcon />}
+          onClose={() => {}}
+          onOpen={() => {}}
+          onClick={onLayerOpsToggle}
+          open={layerOpsOpen}
+          FabProps={{
+            size: "small",
+            color: layerOpsOpen ? "success" : "info",
+          }}
+          sx={{
+            mt: 0,
+            mb: -1,
+          }}
         >
-          {props.saveChangesTitle}
-        </SaveChangesButton>
-      </ToggleButtonGroup>
+          <SpeedDialAction icon={<CopyAllIcon />} tooltipTitle="Copy layer" />
+          <SpeedDialAction
+            icon={<ContentPasteIcon />}
+            tooltipTitle="Paste layer"
+          />
+        </SpeedDial>
+        <SpeedDial
+          direction="right"
+          ariaLabel="button operations"
+          icon={<SmartButtonIcon />}
+          onClose={() => {}}
+          onOpen={() => {}}
+          onClick={onButtonOpsToggle}
+          open={buttonOpsOpen}
+          FabProps={{
+            size: "small",
+            color: buttonOpsOpen ? "success" : "info",
+          }}
+          sx={{
+            mt: 0,
+            mb: -1,
+          }}
+        >
+          <SpeedDialAction icon={<EraserIcon />} tooltipTitle="Erase" />
+          <SpeedDialAction icon={<FormatPaintIcon />} tooltipTitle="Paint" />
+        </SpeedDial>
+      </Box>
+      <SaveChangesButton
+        onClick={props.onSaveChanges}
+        onError={props.onSaveChangesError}
+        disabled={props.saveChangesDisabled}
+      >
+        {props.saveChangesTitle}
+      </SaveChangesButton>
     </Box>
   );
 };

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -16,6 +16,10 @@
  */
 
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Collapse from "@mui/material/Collapse";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import SpeedDial from "@mui/material/SpeedDial";
 import SpeedDialIcon from "@mui/material/SpeedDialIcon";
@@ -24,12 +28,17 @@ import SvgIcon from "@mui/material/SvgIcon";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import SaveChangesButton from "@renderer/components/SaveChangesButton";
 
 import CopyAllIcon from "@mui/icons-material/CopyAll";
+import ConstructionIcon from "@mui/icons-material/Construction";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import FormatPaintIcon from "@mui/icons-material/FormatPaint";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import LayersIcon from "@mui/icons-material/Layers";
+import LayersClearIcon from "@mui/icons-material/LayersClear";
+import MenuIcon from "@mui/icons-material/Menu";
 import SmartButtonIcon from "@mui/icons-material/SmartButton";
 
 import React, { useState } from "react";
@@ -46,24 +55,10 @@ EraserIcon.displayName = "EraserIcon";
 export const ToolBox = (props) => {
   const { t } = useTranslation();
 
-  const [layerOpsOpen, setLayerOpsOpen] = useState(false);
-  const [buttonOpsOpen, setButtonOpsOpen] = useState(false);
+  const [toolsOpen, setToolsOpen] = useState(false);
 
-  const onLayerOpsToggle = () => {
-    if (layerOpsOpen) {
-      setLayerOpsOpen(false);
-    } else {
-      setButtonOpsOpen(false);
-      setLayerOpsOpen(true);
-    }
-  };
-  const onButtonOpsToggle = () => {
-    if (buttonOpsOpen) {
-      setButtonOpsOpen(false);
-    } else {
-      setLayerOpsOpen(false);
-      setButtonOpsOpen(true);
-    }
+  const toggleTools = () => {
+    setToolsOpen(!toolsOpen);
   };
 
   const onChange = (event, newTool) => {
@@ -80,61 +75,94 @@ export const ToolBox = (props) => {
   };
 
   return (
-    <Box
-      sx={{
-        p: 1,
-        alignItems: "center",
-        justifyContent: "flex-end",
-        position: "fixed",
-        bottom: 32,
-        left: 32,
-        zIndex: (theme) => theme.zIndex.drawer - 1,
-      }}
-    >
-      <Box sx={{ ml: 1 }}>
-        <SpeedDial
-          direction="right"
-          ariaLabel="layer operations"
-          icon={<LayersIcon />}
-          onClose={() => {}}
-          onOpen={() => {}}
-          onClick={onLayerOpsToggle}
-          open={layerOpsOpen}
-          FabProps={{
-            size: "small",
-            color: layerOpsOpen ? "success" : "info",
-          }}
-          sx={{
-            mt: 0,
-            mb: -1,
-          }}
+    <>
+      <Box
+        boxShadow={3}
+        sx={{
+          maxWidth: 104,
+          bgcolor: "background.paper",
+          borderRadius: "4px",
+          position: "fixed",
+          bottom: 108,
+          left: 10,
+          zIndex: (theme) => theme.zIndex.drawer - 1,
+          display: "flex",
+          flexDirection: "column",
+          p: 1,
+        }}
+      >
+        <Collapse in={toolsOpen}>
+          <Typography
+            variant="body2"
+            sx={{
+              opacity: 0.75,
+              mx: -1,
+              py: 0.5,
+              mt: -1,
+              mb: 0.75,
+              bgcolor: (theme) =>
+                theme.palette.mode == "dark" ? "grey.700" : "grey.200",
+              textAlign: "center",
+            }}
+          >
+            Layer tools
+          </Typography>
+          <Box sx={{ textAlign: "center" }}>
+            <ToggleButton size="small" sx={{ m: 0.25 }}>
+              <Tooltip title="Copy layer" arrow>
+                <CopyAllIcon />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton size="small" sx={{ m: 0.25 }}>
+              <Tooltip title="Paste layer" arrow>
+                <ContentPasteIcon />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton size="small" sx={{ m: 0.25 }}>
+              <Tooltip title="Clear layer" arrow>
+                <LayersClearIcon />
+              </Tooltip>
+            </ToggleButton>
+          </Box>
+          <Typography
+            variant="body2"
+            sx={{
+              opacity: 0.75,
+              mx: -1,
+              py: 0.5,
+              my: 1,
+              bgcolor: (theme) =>
+                theme.palette.mode == "dark" ? "grey.700" : "grey.200",
+              textAlign: "center",
+            }}
+          >
+            Button tools
+          </Typography>
+          <Box>
+            <ToggleButton size="small" sx={{ mx: 0.25 }}>
+              <Tooltip title="Eraser" arrow>
+                <EraserIcon />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton size="small" sx={{ mx: 0.25 }}>
+              <Tooltip title="Paint" arrow>
+                <FormatPaintIcon />
+              </Tooltip>
+            </ToggleButton>
+          </Box>
+          <Divider sx={{ my: 1, mx: -1 }} />
+        </Collapse>
+        <ToggleButton
+          size="small"
+          value="tools"
+          sx={{ border: 0 }}
+          selected={toolsOpen}
+          onClick={toggleTools}
         >
-          <SpeedDialAction icon={<CopyAllIcon />} tooltipTitle="Copy layer" />
-          <SpeedDialAction
-            icon={<ContentPasteIcon />}
-            tooltipTitle="Paste layer"
-          />
-        </SpeedDial>
-        <SpeedDial
-          direction="right"
-          ariaLabel="button operations"
-          icon={<SmartButtonIcon />}
-          onClose={() => {}}
-          onOpen={() => {}}
-          onClick={onButtonOpsToggle}
-          open={buttonOpsOpen}
-          FabProps={{
-            size: "small",
-            color: buttonOpsOpen ? "success" : "info",
-          }}
-          sx={{
-            mt: 0,
-            mb: -1,
-          }}
-        >
-          <SpeedDialAction icon={<EraserIcon />} tooltipTitle="Erase" />
-          <SpeedDialAction icon={<FormatPaintIcon />} tooltipTitle="Paint" />
-        </SpeedDial>
+          <Tooltip title="Toggle tools" arrow>
+            {toolsOpen ? <KeyboardArrowDownIcon /> : <ConstructionIcon />}
+          </Tooltip>
+        </ToggleButton>
       </Box>
       <SaveChangesButton
         onClick={props.onSaveChanges}
@@ -143,6 +171,6 @@ export const ToolBox = (props) => {
       >
         {props.saveChangesTitle}
       </SaveChangesButton>
-    </Box>
+    </>
   );
 };

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -113,7 +113,7 @@ export const ToolBox = (props) => {
                 <CopyAllIcon />
               </Tooltip>
             </ToggleButton>
-            <ToggleButton size="small" sx={{ m: 0.25 }}>
+            <ToggleButton size="small" sx={{ m: 0.25 }} disabled>
               <Tooltip title="Paste layer" arrow>
                 <ContentPasteIcon />
               </Tooltip>

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -21,6 +21,7 @@ import SvgIcon from "@mui/material/SvgIcon";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
+import SaveChangesButton from "@renderer/components/SaveChangesButton";
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -41,13 +42,27 @@ export const ToolBox = (props) => {
   };
 
   return (
-    <Box sx={{ textAlign: "right", p: 1 }}>
+    <Box
+      boxShadow={3}
+      sx={{
+        p: 1,
+        bgcolor: "background.paper",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        position: "fixed",
+        bottom: 32,
+        left: 32,
+        zIndex: (theme) => theme.zIndex.drawer - 1,
+      }}
+    >
       <ToggleButtonGroup
         color="primary"
         exclusive
         size="small"
         value={props.tool}
         onChange={onChange}
+        orientation={props.orientation}
       >
         <ToggleButton value="eraser">
           <Tooltip title={t("editor.toolbox.eraser")}>
@@ -61,6 +76,13 @@ export const ToolBox = (props) => {
             </Tooltip>
           </ToggleButton>
         )}
+        <SaveChangesButton
+          onClick={props.onSaveChanges}
+          onError={props.onSaveChangesError}
+          disabled={props.saveChangesDisabled}
+        >
+          {props.saveChangesTitle}
+        </SaveChangesButton>
       </ToggleButtonGroup>
     </Box>
   );

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -79,12 +79,13 @@ export const ToolBox = (props) => {
   return (
     <>
       <Box
+        boxShadow={1}
         sx={{
-          borderRight: "1px solid #888",
           bgcolor: "background.paper",
           display: "flex",
           flexDirection: "column",
           p: 1,
+          ml: 2,
         }}
       >
         <Typography

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -152,17 +152,17 @@ export const ToolBox = (props) => {
           </Box>
           <Divider sx={{ my: 1, mx: -1 }} />
         </Collapse>
-        <ToggleButton
-          size="small"
-          value="tools"
-          sx={{ border: 0 }}
-          selected={toolsOpen}
-          onClick={toggleTools}
-        >
-          <Tooltip title="Toggle tools" arrow>
+        <Tooltip title="Toggle tools" arrow>
+          <ToggleButton
+            size="small"
+            value="tools"
+            sx={{ border: 0 }}
+            selected={toolsOpen}
+            onClick={toggleTools}
+          >
             {toolsOpen ? <KeyboardArrowDownIcon /> : <ConstructionIcon />}
-          </Tooltip>
-        </ToggleButton>
+          </ToggleButton>
+        </Tooltip>
       </Box>
       <SaveChangesButton
         onClick={props.onSaveChanges}

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -35,6 +35,8 @@ import CopyAllIcon from "@mui/icons-material/CopyAll";
 import ConstructionIcon from "@mui/icons-material/Construction";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import FormatPaintIcon from "@mui/icons-material/FormatPaint";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import LayersIcon from "@mui/icons-material/Layers";
 import LayersClearIcon from "@mui/icons-material/LayersClear";
@@ -74,103 +76,79 @@ export const ToolBox = (props) => {
     */
   };
 
+  if (!props.open) return null;
+
   return (
     <>
       <Box
-        boxShadow={3}
         sx={{
-          maxWidth: 104,
+          borderRight: "1px solid #888",
+          width: props.open ? 100 : 0,
           bgcolor: "background.paper",
-          borderRadius: "4px",
-          position: "fixed",
-          bottom: 108,
-          left: 10,
-          zIndex: (theme) => theme.zIndex.drawer - 1,
           display: "flex",
           flexDirection: "column",
           p: 1,
         }}
       >
-        <Collapse in={toolsOpen}>
-          <Typography
-            variant="body2"
-            sx={{
-              opacity: 0.75,
-              mx: -1,
-              py: 0.5,
-              mt: -1,
-              mb: 0.75,
-              bgcolor: (theme) =>
-                theme.palette.mode == "dark" ? "grey.700" : "grey.200",
-              textAlign: "center",
-            }}
-          >
-            Layer tools
-          </Typography>
-          <Box sx={{ textAlign: "center" }}>
-            <ToggleButton size="small" sx={{ m: 0.25 }}>
-              <Tooltip title="Copy layer" arrow>
-                <CopyAllIcon />
-              </Tooltip>
-            </ToggleButton>
-            <ToggleButton size="small" sx={{ m: 0.25 }} disabled>
-              <Tooltip title="Paste layer" arrow>
-                <ContentPasteIcon />
-              </Tooltip>
-            </ToggleButton>
-            <ToggleButton size="small" sx={{ m: 0.25 }}>
-              <Tooltip title="Clear layer" arrow>
-                <LayersClearIcon />
-              </Tooltip>
-            </ToggleButton>
-          </Box>
-          <Typography
-            variant="body2"
-            sx={{
-              opacity: 0.75,
-              mx: -1,
-              py: 0.5,
-              my: 1,
-              bgcolor: (theme) =>
-                theme.palette.mode == "dark" ? "grey.700" : "grey.200",
-              textAlign: "center",
-            }}
-          >
-            Button tools
-          </Typography>
-          <Box>
-            <ToggleButton size="small" sx={{ mx: 0.25 }}>
-              <Tooltip title="Eraser" arrow>
-                <EraserIcon />
-              </Tooltip>
-            </ToggleButton>
-            <ToggleButton size="small" sx={{ mx: 0.25 }}>
-              <Tooltip title="Paint" arrow>
-                <FormatPaintIcon />
-              </Tooltip>
-            </ToggleButton>
-          </Box>
-          <Divider sx={{ my: 1, mx: -1 }} />
-        </Collapse>
-        <Tooltip title="Toggle tools" arrow>
-          <ToggleButton
-            size="small"
-            value="tools"
-            sx={{ border: 0 }}
-            selected={toolsOpen}
-            onClick={toggleTools}
-          >
-            {toolsOpen ? <KeyboardArrowDownIcon /> : <ConstructionIcon />}
+        <Typography
+          variant="body2"
+          sx={{
+            opacity: 0.75,
+            mx: -1,
+            py: 0.5,
+            mt: -1,
+            mb: 0.75,
+            bgcolor: (theme) =>
+              theme.palette.mode == "dark" ? "grey.700" : "grey.200",
+            textAlign: "center",
+          }}
+        >
+          Layer tools
+        </Typography>
+        <Box sx={{ textAlign: "center" }}>
+          <ToggleButton size="small" sx={{ m: 0.25 }}>
+            <Tooltip title="Copy layer" arrow placement="left">
+              <CopyAllIcon />
+            </Tooltip>
           </ToggleButton>
-        </Tooltip>
+          <ToggleButton size="small" sx={{ m: 0.25 }} disabled>
+            <Tooltip title="Paste layer" arrow placement="left">
+              <ContentPasteIcon />
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton size="small" sx={{ m: 0.25 }}>
+            <Tooltip title="Clear layer" arrow placement="left">
+              <LayersClearIcon />
+            </Tooltip>
+          </ToggleButton>
+        </Box>
+        <Typography
+          variant="body2"
+          sx={{
+            opacity: 0.75,
+            mx: -1,
+            py: 0.5,
+            my: 1,
+            bgcolor: (theme) =>
+              theme.palette.mode == "dark" ? "grey.700" : "grey.200",
+            textAlign: "center",
+          }}
+        >
+          Button tools
+        </Typography>
+        <Box sx={{ textAlign: "center" }}>
+          <ToggleButton size="small" sx={{ m: 0.25 }}>
+            <Tooltip title="Eraser" arrow placement="left">
+              <EraserIcon />
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton size="small" sx={{ m: 0.25 }}>
+            <Tooltip title="Paint" arrow placement="left">
+              <FormatPaintIcon />
+            </Tooltip>
+          </ToggleButton>
+        </Box>
       </Box>
-      <SaveChangesButton
-        onClick={props.onSaveChanges}
-        onError={props.onSaveChangesError}
-        disabled={props.saveChangesDisabled}
-      >
-        {props.saveChangesTitle}
-      </SaveChangesButton>
     </>
   );
 };

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -17,11 +17,18 @@
 
 import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import Box from "@mui/material/Box";
+import SpeedDial from "@mui/material/SpeedDial";
+import SpeedDialIcon from "@mui/material/SpeedDialIcon";
+import SpeedDialAction from "@mui/material/SpeedDialAction";
 import SvgIcon from "@mui/material/SvgIcon";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import SaveChangesButton from "@renderer/components/SaveChangesButton";
+
+import CopyAllIcon from "@mui/icons-material/CopyAll";
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
+import LayersIcon from "@mui/icons-material/Layers";
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -47,7 +54,6 @@ export const ToolBox = (props) => {
       sx={{
         p: 1,
         bgcolor: "background.paper",
-        display: "flex",
         alignItems: "center",
         justifyContent: "flex-end",
         position: "fixed",
@@ -56,6 +62,18 @@ export const ToolBox = (props) => {
         zIndex: (theme) => theme.zIndex.drawer - 1,
       }}
     >
+      <SpeedDial
+        icon={<LayersIcon />}
+        ariaLabel="foo"
+        direction="right"
+        sx={{ mb: 2 }}
+      >
+        <SpeedDialAction icon={<CopyAllIcon />} tooltipTitle="Copy layer" />
+        <SpeedDialAction
+          icon={<ContentPasteIcon />}
+          tooltipTitle="Paste layer"
+        />
+      </SpeedDial>
       <ToggleButtonGroup
         color="primary"
         exclusive

--- a/src/renderer/screens/Editor/ToolBox.js
+++ b/src/renderer/screens/Editor/ToolBox.js
@@ -76,14 +76,11 @@ export const ToolBox = (props) => {
     */
   };
 
-  if (!props.open) return null;
-
   return (
     <>
       <Box
         sx={{
           borderRight: "1px solid #888",
-          width: props.open ? 100 : 0,
           bgcolor: "background.paper",
           display: "flex",
           flexDirection: "column",

--- a/src/renderer/screens/Editor/components/FloatingKeyPicker.js
+++ b/src/renderer/screens/Editor/components/FloatingKeyPicker.js
@@ -84,16 +84,16 @@ export const FloatingKeyPicker = (props) => {
       lockAspectRatio={true}
       bounds="window"
     >
-      <Box sx={{ display: "flex" }}>
-        <Box
-          boxShadow={3}
-          sx={{
-            bgcolor: "background.paper",
-            p: 1,
-            m: 1,
-            width: "100%",
-          }}
-        >
+      <Box
+        boxShadow={3}
+        sx={{
+          bgcolor: "background.paper",
+          p: 1,
+          m: 1,
+          display: "flex",
+        }}
+      >
+        <Box sx={{ width: "100%" }}>
           <Keyboard104
             onKeySelect={onKeyChange}
             currentKeyCode={key.baseCode || key.code}

--- a/src/renderer/screens/Editor/components/FloatingKeyPicker.js
+++ b/src/renderer/screens/Editor/components/FloatingKeyPicker.js
@@ -22,6 +22,8 @@ import React, { useState, useEffect } from "react";
 import { Rnd } from "react-rnd";
 import Keyboard104 from "../Keyboard104";
 
+import { ToolBox } from "../ToolBox";
+
 const fkp_channel = new BroadcastChannel("floating-key-picker");
 
 export const FloatingKeyPicker = (props) => {
@@ -82,19 +84,23 @@ export const FloatingKeyPicker = (props) => {
       lockAspectRatio={true}
       bounds="window"
     >
-      <Box
-        boxShadow={3}
-        sx={{
-          bgcolor: "background.paper",
-          p: 1,
-          m: 1,
-        }}
-      >
-        <Keyboard104
-          onKeySelect={onKeyChange}
-          currentKeyCode={key.baseCode || key.code}
-          keymap={keymap}
-        />
+      <Box sx={{ display: "flex" }}>
+        <Box
+          boxShadow={3}
+          sx={{
+            bgcolor: "background.paper",
+            p: 1,
+            m: 1,
+            width: "100%",
+          }}
+        >
+          <Keyboard104
+            onKeySelect={onKeyChange}
+            currentKeyCode={key.baseCode || key.code}
+            keymap={keymap}
+          />
+        </Box>
+        <ToolBox />
       </Box>
     </Rnd>
   );


### PR DESCRIPTION
The ToolBox is intended to hold a small selection of tools to aid working with the keymap, such as an eraser (the only one currently implemented). To make these tools easily accessible, they're placed above the keyboard, rather than at the sidebar.

https://user-images.githubusercontent.com/17243/193250475-67251b05-25e9-4bfe-94e6-103f22445e61.mp4

Still trying to find a proper icon. I'd love to show an eraser, but Material Icons do not have an icon like that. Other tools we could add to the toolbox include: full layer clear, layer copy, layer paste. Might be able to move the "Backup & Restore" stuff here, too, in some form.

For now, only an Eraser is implemented, and it's still a work in progress, but opening a draft to seek feedback about the idea.