### PR TITLE
styles/keymap.css: Disable user-select for the keymap SVGs

### DIFF
--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -23,6 +23,7 @@ button {
   font-family: "Source Code Pro", monospace;
   font-size: 8px;
   font-weight: 700;
+  user-select: none;
 }
 
 .short-legend {


### PR DESCRIPTION
Being able to select text is in general a desirable feature. However, in case of the keymap, being able to do so is distracting, annoying, and not useful at all. This little change disables that, preventing one from selecting the *text* of key labels. It does not prevent selecting the buttons themselves, of course.

This change is to prevent this from happening (the blue selection highlights):
![key-text-highlight-bug](https://user-images.githubusercontent.com/17243/193330204-e4da8d23-1e00-47a2-8043-7d72e7c93902.png)
