### PR TITLE
Move a lot more of our focus interaction into an activeDevice caching facade.

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -88,4 +88,15 @@ export function ActiveDevice() {
     }
     return this._settings_defaultLayer;
   };
+
+  this.keymap = async (newValue) => {
+    if (newValue !== undefined) {
+      await this.focus.command("keymap", newValue);
+      this._keymap = undefined;
+    }
+    if (this._keymap === undefined) {
+      this._keymap = await this.focus.command("keymap");
+    }
+    return this._keymap;
+  };
 }

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -75,4 +75,17 @@ export function ActiveDevice() {
       return false;
     }
   };
+
+  this.defaultLayer = async (newValue) => {
+    if (newValue !== undefined) {
+      await this.focus.command("settings.defaultLayer", newValue);
+      this._settings_defaultLayer = undefined;
+    }
+    if (this._settings_defaultLayer === undefined) {
+      this._settings_defaultLayer = await this.focus.command(
+        "settings.defaultLayer"
+      );
+    }
+    return this._settings_defaultLayer;
+  };
 }

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -121,4 +121,11 @@ export function ActiveDevice() {
     }
     return this._macros;
   };
+
+  this.version = async () => {
+    if (this._version === undefined) {
+      this._version = await this.focus.command("version");
+    }
+    return this._version;
+  };
 }

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -99,4 +99,15 @@ export function ActiveDevice() {
     }
     return this._keymap;
   };
+
+  this.colormap = async (newValue) => {
+    if (newValue !== undefined) {
+      await this.focus.command("colormap", newValue);
+      this._colormap = undefined;
+    }
+    if (this._colormap === undefined) {
+      this._colormap = await this.focus.command("colormap");
+    }
+    return this._colormap;
+  };
 }

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -122,6 +122,17 @@ export function ActiveDevice() {
     return this._macros;
   };
 
+  this.layernames = async (newValue) => {
+    if (newValue !== undefined) {
+      await this.focus.command("layernames", newValue);
+      this._layernames = undefined;
+    }
+    if (this._layernames === undefined) {
+      this._layernames = await this.focus.command("layernames");
+    }
+    return this._layernames;
+  };
+
   this.version = async () => {
     if (this._version === undefined) {
       this._version = await this.focus.command("version");

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -110,4 +110,15 @@ export function ActiveDevice() {
     }
     return this._colormap;
   };
+
+  this.macros = async (newValue) => {
+    if (newValue !== undefined) {
+      await this.focus.command("macros", newValue);
+      this._macros = undefined;
+    }
+    if (this._macros === undefined) {
+      this._macros = await this.focus.command("macros");
+    }
+    return this._macros;
+  };
 }

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -273,7 +273,7 @@ const Editor = (props) => {
     try {
       let deviceKeymap = await activeDevice.keymap();
       deviceKeymap = await updateEmptyKeymap(deviceKeymap);
-      const deviceColormap = await focus.command("colormap");
+      const deviceColormap = await activeDevice.colormap();
       const k = new Keymap();
       setHasLegacy(k.hasLegacyCodes(deviceKeymap.custom));
       setKeymap(deviceKeymap);
@@ -342,7 +342,7 @@ const Editor = (props) => {
 
   const onApply = async () => {
     await activeDevice.keymap(keymap);
-    await focus.command("colormap", colormap);
+    await activeDevice.colormap(colormap);
     await focus.command("macros", macros);
     await focus.command("layernames", layerNames);
 

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -264,14 +264,14 @@ const Editor = (props) => {
         deviceKeymap.custom[i] = deviceKeymap.default[i].slice();
       }
       deviceKeymap.onlyCustom = true;
-      await focus.command("keymap", deviceKeymap);
+      await activeDevice.keymap(deviceKeymap);
     }
     return deviceKeymap;
   };
 
   const scanKeyboard = async () => {
     try {
-      let deviceKeymap = await focus.command("keymap");
+      let deviceKeymap = await activeDevice.keymap();
       deviceKeymap = await updateEmptyKeymap(deviceKeymap);
       const deviceColormap = await focus.command("colormap");
       const k = new Keymap();
@@ -341,7 +341,7 @@ const Editor = (props) => {
   };
 
   const onApply = async () => {
-    await focus.command("keymap", keymap);
+    await activeDevice.keymap(keymap);
     await focus.command("colormap", colormap);
     await focus.command("macros", macros);
     await focus.command("layernames", layerNames);

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -26,6 +26,7 @@ import {
   hideContextBar,
   showContextBar,
 } from "@renderer/components/ContextBar";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import LoadingScreen from "@renderer/components/LoadingScreen";
 import { PageTitle } from "@renderer/components/PageTitle";
 import SaveChangesButton from "@renderer/components/SaveChangesButton";
@@ -45,9 +46,13 @@ const Store = require("electron-store");
 const settings = new Store();
 
 const db = new KeymapDB();
-const focus = new Focus();
 
 const Editor = (props) => {
+  const globalContext = React.useContext(GlobalContext);
+  const [activeDevice, _] = globalContext.state.activeDevice;
+
+  const focus = activeDevice.focus;
+
   const [colormap, setColormap] = useState({
     palette: [],
     colorMap: [],
@@ -277,7 +282,7 @@ const Editor = (props) => {
       const deviceMacros = await focus.command("macros");
       setMacros(deviceMacros);
 
-      const defLayer = await focus.command("settings.defaultLayer");
+      const defLayer = await activeDevice.defaultLayer();
       if (defLayer <= deviceKeymap.custom.length) setCurrentLayer(defLayer);
 
       const deviceLayerNames = await focus.command("layernames");

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -279,7 +279,7 @@ const Editor = (props) => {
       setKeymap(deviceKeymap);
       setColormap(deviceColormap);
 
-      const deviceMacros = await focus.command("macros");
+      const deviceMacros = await activeDevice.macros();
       setMacros(deviceMacros);
 
       const defLayer = await activeDevice.defaultLayer();
@@ -343,7 +343,7 @@ const Editor = (props) => {
   const onApply = async () => {
     await activeDevice.keymap(keymap);
     await activeDevice.colormap(colormap);
-    await focus.command("macros", macros);
+    await activeDevice.macros(macros);
     await focus.command("layernames", layerNames);
 
     setModified(false);

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -285,7 +285,7 @@ const Editor = (props) => {
       const defLayer = await activeDevice.defaultLayer();
       if (defLayer <= deviceKeymap.custom.length) setCurrentLayer(defLayer);
 
-      const deviceLayerNames = await focus.command("layernames");
+      const deviceLayerNames = await activeDevice.layernames();
       if (deviceLayerNames) {
         // We set up default names for the layers here, so that they're easily
         // editable, without having to keep track of whether it is a default
@@ -344,7 +344,7 @@ const Editor = (props) => {
     await activeDevice.keymap(keymap);
     await activeDevice.colormap(colormap);
     await activeDevice.macros(macros);
-    await focus.command("layernames", layerNames);
+    await activeDevice.layernames(layerNames);
 
     setModified(false);
     logger().info("Changes saved.");

--- a/src/renderer/screens/Editor/components/OnlyCustomScreen.js
+++ b/src/renderer/screens/Editor/components/OnlyCustomScreen.js
@@ -23,19 +23,27 @@ import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import { PageTitle } from "@renderer/components/PageTitle";
 import { navigate } from "@renderer/routerHistory";
 import openURL from "@renderer/utils/openURL";
 import React from "react";
+
 import { useTranslation } from "react-i18next";
 
 const OnlyCustomScreen = (props) => {
+  const globalContext = React.useContext(GlobalContext);
+  const [activeDevice, _] = globalContext.state.activeDevice;
+
+  const focus = activeDevice.focus;
+
   const { t } = useTranslation();
 
   const enableOnlyCustom = async () => {
-    const focus = new Focus();
+    const focus = activeDevice.focus;
     await focus.command("keymap.onlyCustom", true);
-    await focus.command("settings.defaultLayer", 0);
+    await activeDevice.defaultLayer(0);
+
     await navigate("/editor");
   };
 

--- a/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
+++ b/src/renderer/screens/FirmwareUpdate/FirmwareVersion.js
@@ -37,7 +37,7 @@ const FirmwareVersion = (props) => {
         return;
       }
 
-      const v = await activeDevice.focus.command("version");
+      const v = await activeDevice.version();
       if (v) {
         setFwVersion(v);
       } else {

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -53,6 +53,9 @@ const LayoutCard = (props) => {
   const [_, setHideHeaderInPrint] = globalContext.state.hideHeaderInPrint;
   const [loading, setLoading] = useState(true);
   const [oneLayerPerPage, setOneLayerPerPage] = useState(false);
+  const [activeDevice, __] = globalContext.state.activeDevice;
+
+  const focus = activeDevice.focus;
 
   const { t } = useTranslation();
 
@@ -66,7 +69,7 @@ const LayoutCard = (props) => {
 
   const scanKeyboard = async () => {
     try {
-      const deviceKeymap = await focus.command("keymap");
+      const deviceKeymap = await activeDevice.keymap();
       setKeymap(deviceKeymap);
 
       const deviceLayerNames = await focus.command("layernames");

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -72,7 +72,7 @@ const LayoutCard = (props) => {
       const deviceKeymap = await activeDevice.keymap();
       setKeymap(deviceKeymap);
 
-      const deviceLayerNames = await focus.command("layernames");
+      const deviceLayerNames = await activeDevice.layernames();
       if (deviceLayerNames) setLayerNames(deviceLayerNames);
 
       if (settings.get("ui.layoutCards.colored")) {

--- a/src/renderer/screens/LayoutCard.js
+++ b/src/renderer/screens/LayoutCard.js
@@ -76,7 +76,7 @@ const LayoutCard = (props) => {
       if (deviceLayerNames) setLayerNames(deviceLayerNames);
 
       if (settings.get("ui.layoutCards.colored")) {
-        const deviceColormap = await focus.command("colormap");
+        const deviceColormap = await activeDevice.colormap();
         setColormap(deviceColormap);
       }
     } catch (e) {

--- a/src/renderer/screens/Preferences/MyKeyboard.js
+++ b/src/renderer/screens/Preferences/MyKeyboard.js
@@ -61,8 +61,14 @@ const MyKeyboardPreferences = (props) => {
 
   const saveChanges = async () => {
     for (const cmd of Object.keys(changes)) {
-      const args = changes[cmd];
-      await activeDevice.focus.command(cmd, args);
+      const content = changes[cmd];
+      // If the change was a function, run the function
+      // otherwise assume it's a focus command
+      if (content instanceof Function) {
+        await content();
+      } else {
+        await activeDevice.focus.command(cmd, content);
+      }
     }
     setChanges({});
 

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -21,6 +21,7 @@ import Select from "@mui/material/Select";
 import Skeleton from "@mui/material/Skeleton";
 
 import usePluginEffect from "@renderer/hooks/usePluginEffect";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import React, { useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -31,6 +32,11 @@ const KeyboardLayerPreferences = (props) => {
   const { t } = useTranslation();
   const { onSaveChanges } = props;
 
+  const globalContext = React.useContext(GlobalContext);
+  const [activeDevice, _] = globalContext.state.activeDevice;
+
+  const focus = activeDevice.focus;
+
   const [keymap, setKeymap] = useState({
     custom: [],
     default: [],
@@ -38,10 +44,11 @@ const KeyboardLayerPreferences = (props) => {
   });
   const [defaultLayer, setDefaultLayer] = useState(126);
 
-  const initialize = async (focus) => {
+  const initialize = async () => {
     setKeymap(await focus.command("keymap"));
 
-    let layer = await focus.command("settings.defaultLayer");
+    let layer = await activeDevice.defaultLayer();
+
     layer = layer ? parseInt(layer) : 126;
     setDefaultLayer(layer <= 126 ? layer : layer);
   };

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -45,7 +45,7 @@ const KeyboardLayerPreferences = (props) => {
   const [defaultLayer, setDefaultLayer] = useState(126);
 
   const initialize = async () => {
-    setKeymap(await focus.command("keymap"));
+    setKeymap(await activeDevice.keymap());
 
     let layer = await activeDevice.defaultLayer();
 

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -57,7 +57,9 @@ const KeyboardLayerPreferences = (props) => {
   const selectDefaultLayer = async (event) => {
     const layer = event.target.value;
     await setDefaultLayer(layer);
-    await onSaveChanges("settings.defaultLayer", layer);
+    await onSaveChanges("default layer", function () {
+      return activeDevice.defaultLayer(layer);
+    });
   };
 
   const layers = keymap.custom.map((_, index) => {

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -86,6 +86,7 @@ function SystemInfo(props) {
         commands: await activeDevice.supported_commands(),
         keymap: await activeDevice.keymap(),
         colormap: await activeDevice.colormap(),
+        version: await activeDevice.version(),
       };
     }
 

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -85,7 +85,7 @@ function SystemInfo(props) {
         path: focus._port.path,
         commands: await activeDevice.supported_commands(),
         keymap: await activeDevice.keymap(),
-        colormap: await focus.command("colormap"),
+        colormap: await activeDevice.colormap(),
       };
     }
 

--- a/src/renderer/screens/SystemInfo.js
+++ b/src/renderer/screens/SystemInfo.js
@@ -15,7 +15,6 @@
  * along with  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Focus from "@api/focus";
 import { collectLogs, logger } from "@api/log";
 import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
@@ -32,6 +31,7 @@ import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import { GlobalContext } from "@renderer/components/GlobalContext";
 import { PageTitle } from "@renderer/components/PageTitle";
 import { toast } from "@renderer/components/Toast";
 import logo from "@renderer/logo-small.png";
@@ -42,6 +42,11 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 function SystemInfo(props) {
+  const globalContext = React.useContext(GlobalContext);
+  const [activeDevice, _] = globalContext.state.activeDevice;
+
+  const focus = activeDevice.focus;
+
   const [collecting, setCollecting] = useState(false);
   const [collected, setCollected] = useState(false);
   const [info, setInfo] = useState({});
@@ -72,15 +77,14 @@ function SystemInfo(props) {
 
   const createBundle = async () => {
     setCollecting(true);
-    const focus = new Focus();
 
     const sysInfo = ipcRenderer.sendSync("system-info.get");
     if (focus.focusDeviceDescriptor) {
       sysInfo.device = {
         info: focus.focusDeviceDescriptor.info,
         path: focus._port.path,
-        commands: await focus.command("help"),
-        keymap: await focus.command("keymap"),
+        commands: await activeDevice.supported_commands(),
+        keymap: await activeDevice.keymap(),
         colormap: await focus.command("colormap"),
       };
     }


### PR DESCRIPTION
This isn't done, but it's a start.

besides moving the rest of the focus data management commands into these patterns, we can also start not updating data on the keyboard when it hasn't changed.

To do that, I'd need to figure out how to do a deep object comparison.