### PR TITLE
Editor: When changing layers, ensure that the selected key is in sync

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -120,6 +120,13 @@ const Editor = (props) => {
     setLoading(false);
   };
 
+  const onLayerChange = async (layer) => {
+    await setCurrentLayer(layer);
+
+    const key = keymap.custom[layer][currentKeyIndex];
+    await setSelectorKey(key);
+  };
+
   const onKeySelect = async (event) => {
     const target = event.currentTarget;
     const keyIndex = parseInt(target.getAttribute("data-key-index"));
@@ -451,7 +458,7 @@ const Editor = (props) => {
         selectedKey={currentKeyIndex}
         selectedLed={currentLedIndex}
         layer={currentLayer}
-        setLayer={setCurrentLayer}
+        setLayer={onLayerChange}
         layerNames={layerNames}
         setLayerName={setLayerName}
         onKeyChange={onKeyChange}


### PR DESCRIPTION
When changing layers, we need to set the selected key again, to point to the same index on the target layer, otherwise the keymap will show the correct data, but the sidebar will not.

Fixes #1122.
