### PR TITLE
ActiveDevice: Add a way to clear the cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "immutability-helper": "^3.1.1",
     "js-yaml": "^4.1.0",
     "json-stringify-pretty-compact": "^3.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "react": "^17.0.2",
     "react-color": "^2.14.1",
     "react-dnd": "^16.0.1",
@@ -157,8 +158,8 @@
     "stylelint-config-standard": "^25.0.0",
     "unraw": "^2.0.0",
     "webpack": "4.46.0",
-    "yarn": "^1.22.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.4.23",
+    "yarn": "^1.22.0"
   },
   "resolutions": {
     "teensy-loader/usb": "^2.5.1",

--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -16,6 +16,7 @@
  */
 
 import Focus from "@api/focus";
+import cloneDeep from "lodash.clonedeep";
 
 export function ActiveDevice() {
   this.port = undefined;
@@ -93,7 +94,7 @@ export function ActiveDevice() {
         "settings.defaultLayer"
       );
     }
-    return this._cache.settings_defaultLayer;
+    return cloneDeep(this._cache.settings_defaultLayer);
   };
 
   this.keymap = async (newValue) => {
@@ -104,7 +105,7 @@ export function ActiveDevice() {
     if (this._cache.keymap === undefined) {
       this._cache.keymap = await this.focus.command("keymap");
     }
-    return this._cache.keymap;
+    return cloneDeep(this._cache.keymap);
   };
 
   this.colormap = async (newValue) => {
@@ -115,7 +116,7 @@ export function ActiveDevice() {
     if (this._cache.colormap === undefined) {
       this._cache.colormap = await this.focus.command("colormap");
     }
-    return this._cache.colormap;
+    return cloneDeep(this._cache.colormap);
   };
 
   this.macros = async (newValue) => {
@@ -126,7 +127,7 @@ export function ActiveDevice() {
     if (this._cache.macros === undefined) {
       this._cache.macros = await this.focus.command("macros");
     }
-    return this._cache.macros;
+    return cloneDeep(this._cache.macros);
   };
 
   this.layernames = async (newValue) => {
@@ -137,7 +138,7 @@ export function ActiveDevice() {
     if (this._cache.layernames === undefined) {
       this._cache.layernames = await this.focus.command("layernames");
     }
-    return this._cache.layernames;
+    return cloneDeep(this._cache.layernames);
   };
 
   this.version = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6817,6 +6817,11 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
Sometimes we want to refresh our knowledge about data stored on the keyboard, such as when discarding changes. In these cases, we explicitly do not want to use the cache. To make that easy, lets introduce a `.clearCache()` method for `ActiveDevice`.

Any code that wants fresh data from the keyboard can clear the entire cache then. All such existing cases were taught to do just that.

Fixes #1130.