### PR TITLE
App: Set a better secondary color

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -168,7 +168,7 @@ const App = (props) => {
         main: "#EF5022",
       },
       secondary: {
-        main: "#939597",
+        main: darkMode() ? "#ed91f3" : "#ab0edd",
       },
       background: {
         default: darkMode() ? "#353535" : "#f5f5f5",


### PR DESCRIPTION
Instead of setting a grey-ish color as the secondary, which makes it hard to distinguish components using it from disabled ones, use a non-grey color instead.

The colors were chosen using https://www.canva.com/colors/color-wheel/, using the primary color as the basis. I wanted to choose a secondary that does not clash with the various alert colors.

So for light mode, I chose a blue-ish/purple-ish, darker color, and for dark mode, a more cyan-ish. They both feel okay with the primary keyboardio-orange.

Fixes #1089.

## Old

![Screenshot from 2022-10-01 15-08-20](https://user-images.githubusercontent.com/17243/193411054-4367b180-6e37-4bb5-a9e6-b6d5e0a8fd40.png) 
![Screenshot from 2022-10-01 15-08-04](https://user-images.githubusercontent.com/17243/193411055-dc4ebaec-df40-4e7c-8057-22264e65f219.png)

## New

![Screenshot from 2022-10-01 15-07-20](https://user-images.githubusercontent.com/17243/193411057-b4015a8b-5e7f-453a-90dd-5c1d1db67592.png)
![Screenshot from 2022-10-01 15-07-41](https://user-images.githubusercontent.com/17243/193411056-7cbfb1de-7717-4415-bfa0-c48e6310371d.png)
