### PR TITLE
cldr: Pull the Colemak layout from the osx set

### DIFF
--- a/tools/precompile/cldr_data.mjs
+++ b/tools/precompile/cldr_data.mjs
@@ -191,7 +191,7 @@ export const loadAllKeymaps = async () => {
   // inconsistent, so we go on a case-by-case basis for now.
   const osxFiles = fs
     .readdirSync(path.join(cldrDir, "keyboards/osx"))
-    .filter((fn) => fn.match("^hr-t-k0"));
+    .filter((fn) => fn.match("^(hr-t-k0|en-t-k0-osx-colemak)"));
   const files = windowsFiles.concat(osxFiles);
 
   // Load the default layout for each language


### PR DESCRIPTION
Unfortunately, the windows set of layouts we use by default does not have a Colemak layout. Fortunately, the macOS (neé osx) set does, so lets pull it from there, along with the Croatian layout we were already pulling.

Fixes #1150.
