### PR TITLE
Assorted fixes for different whitescreen scenarios

### DIFF
--- a/src/api/focus/colormap.js
+++ b/src/api/focus/colormap.js
@@ -49,6 +49,13 @@ export default class Colormap {
     const paletteData = await s.request("palette");
     const colorMapData = await s.request("colormap.map");
 
+    if (!paletteData || !colorMapData) {
+      return {
+        palette: [],
+        colorMap: [],
+      };
+    }
+
     const palette = this._chunk(
       paletteData
         .split(" ")

--- a/src/renderer/components/Toast.js
+++ b/src/renderer/components/Toast.js
@@ -17,6 +17,7 @@
 
 import React, { useState, useEffect } from "react";
 
+import { logger } from "@api/log";
 import Alert from "@mui/material/Alert";
 import LinearProgress from "@mui/material/LinearProgress";
 import Snackbar from "@mui/material/Snackbar";
@@ -44,6 +45,15 @@ export const toast = {
     toast.toast({ progress: progress });
   },
   toast: async (msg) => {
+    if (!msg.progress) {
+      logger().debug("Toast message received", {
+        msg: {
+          variant: msg.variant,
+          message: msg.message.toString(),
+        },
+        label: "toast",
+      });
+    }
     const channel = new BroadcastChannel("notifications");
     await channel.postMessage(msg);
     channel.close();

--- a/src/renderer/components/Toast.js
+++ b/src/renderer/components/Toast.js
@@ -76,7 +76,7 @@ export default function Toast() {
         );
         setVariant(msg.variant);
         setAutoHideDuration(msg.autoHideDuration);
-        setMessage(msg.message);
+        setMessage(msg.message.toString());
         setProgress(null);
         setOpen(true);
       } else if (event.data.progress) {

--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -50,6 +50,7 @@ const Colormap = (props) => {
 
   if (!colormap || colormap.palette.length == 0) return null;
   if (props.macroEditorOpen) return null;
+  if (layer >= colormap.colorMap.length) return null;
 
   const colorIndex = colormap.colorMap[layer][selectedLed];
   const color = colormap.palette[colorIndex];

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -102,7 +102,11 @@ const Overview = (props) => {
       layerNames: props.layerNames,
     });
     let colorWidget;
-    if (colormap && colormap.palette.length > 0) {
+    if (
+      colormap &&
+      colormap.palette.length > 0 &&
+      colormap.colorMap.length > index
+    ) {
       const colorIndex = colormap.colorMap[index][selectedLed];
       const color = colormap.palette[colorIndex];
 

--- a/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
+++ b/src/renderer/screens/Preferences/keyboard/KeyboardLayerPreferences.js
@@ -60,13 +60,15 @@ const KeyboardLayerPreferences = (props) => {
     });
   };
 
-  const layers = keymap.custom.map((_, index) => {
-    return (
-      <MenuItem value={index} key={index}>
-        {t("components.layer", { index: index })}
-      </MenuItem>
-    );
-  });
+  const layers =
+    loaded &&
+    keymap.custom.map((_, index) => {
+      return (
+        <MenuItem value={index} key={index}>
+          {t("components.layer", { index: index })}
+        </MenuItem>
+      );
+    });
 
   return (
     <PreferenceSection name="keyboard.layers">


### PR DESCRIPTION
This is a small collection of fixes for various scenarios that could result in a white screen. With these fixes applied, I am no longer able to reproduce the bugs I've been seeing before.

The fixes in this PR include:

- A race condition existed in `Preferences / My Keyboard / KeyboardLayerPreferences`, where we tried to use the keymap data before the initialization step for the component finished. This was corrected by not trying to use the keymap data before the component is fully loaded.
  This bug was very hard to actively trigger, but happened fairly often randomly.
- Fixed a problem in `@api/focus/colormap`, where it bombed out when the Colormap plugin was enabled, but no storage was reserved for it. It will now treat that case as not having the plugin enabled. (Fixes #1151)
- Fixed a problem in Toast display, where we could end up with React refusing to render the message, because it ended up looking like a component. We now force messages into a string.
- While there, also changed the Toast component to log the messages it receives (apart from progress updates) at debug level to make it easier to see when and what notifications were displayed during a session. This isn't strictly a bugfix, but felt pretty harmless to put it in here.
- The Sidebar had both the Overview and Colors widgets bomb out into a whitescreen if we had less Colormap layers than Keymap layers. They don't do that anymore: Overview will not display a Color square for layers that have no colormap, and the Colors widget hides itself if we're on a layer without a colormap: ![Screenshot from 2022-10-08 11-02-11](https://user-images.githubusercontent.com/17243/194699463-1881032b-80b3-4493-b529-ab9f54fe5298.png)
  Fixes #831