### PR TITLE
ActiveDevice: When removing from the cache, delete the entire key

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -103,7 +103,7 @@ export function ActiveDevice() {
       }
 
       await this.focus.command(command, newValue);
-      this._cache[command] = undefined;
+      delete this._cache[command];
     }
     if (!(command in this._cache)) {
       this._cache[command] = await this.focus.command(command);


### PR DESCRIPTION
When removing data from the cache, we need to delete the entire key, not just set it to undefined. When set to undefined, the key still remains in the cache, so `command in this._cache` will happily return true.

Not properly deleting the whole thing could result in returning `undefined` to callers after a save, instead of pulling the data from the keyboard again.

Fixes #1155, and possibly a number of similar issues we didn't discover yet.
