### PR TITLE
api/flash: Move the rebooting of keyboards to api/focus

### DIFF
--- a/src/api/flash.js
+++ b/src/api/flash.js
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { logger } from "@api/log";
 import { FocusCommands } from "./flash/FocusCommands";
 import { delay, reportUpdateStatus } from "./flash/utils";
 
@@ -92,8 +93,9 @@ export const flash = async (flasher, board, port, filename, options) => {
 
       try {
         await focusCommands.reboot(deviceInApplicationMode, options.device);
-      } catch (_) {
-        // ignore any errors here
+      } catch (e) {
+        // Log the error, but otherwise ignore it.
+        logger("flash").error("Error during reboot", { error: e });
       }
       // Wait a few seconds to let the device properly reboot into bootloader
       // mode, and enumerate.


### PR DESCRIPTION
api/focus is in a far better position to handle reboots than api/flash - or FlashCommands - is, so move the rebooting there. This makes the code simpler, and fixes a bug where we weren't properly rebooting the keyboard.

We weren't rebooting the keyboard because `focus.request("device.reset")` did not actually run. It did not run, because `supported_commands()` was returning undefined (it happens sometimes, under circumstances I have not dived into yet). Basically, because `focus.request()` does some sanity checking which we do *not* need in this case.

By moving the rebooting to focus, we can use the internal `_request()` method, which doesn't do any of that.

Fixes #1154.