### PR TITLE
main/ipc_firmware: Only pull pre-releases when running -snapshot

### DIFF
--- a/src/main/ipc_firmware.js
+++ b/src/main/ipc_firmware.js
@@ -104,7 +104,7 @@ export const registerFirmwareHandlers = () => {
   };
 
   const getLatestInfo = async () => {
-    const releases = await ghApi("/releases");
+    let releases = await ghApi("/releases");
     if (!Array.isArray(releases) || releases.length == 0) {
       sendToRenderer(
         "firmware-update.warning",
@@ -112,6 +112,13 @@ export const registerFirmwareHandlers = () => {
       );
       return null;
     }
+
+    // If we're not a snapshot version, then filter out snapshot firmware
+    // releases.
+    if (!version.match(/-snapshot/)) {
+      releases = releases?.filter((rel) => !rel.prerelease);
+    }
+
     const latestTag = releases[0].tag_name;
     if (!releases || !latestTag) {
       sendToRenderer(


### PR DESCRIPTION
To match user expectation (and the behaviour of Chrysalis auto-updates), we should not consider firmware pre-releases as candidates, unless Chrysalis is also a snapshot version.

To this end, if the Chrysalis version does not have a `-snapshot` tag, filter out firmware pre-releases when trying to find the latest version.

Fixes #1163.