### PR TITLE
CI: Add a workflow to build & publish unsigned pull request artifacts

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,143 @@
+name: Build & publish pull request artifacts
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install udev-dev
+        run: sudo apt update && sudo apt install libudev-dev
+        if: runner.os == 'Linux'
+
+      - name: Set up yarn network timeout
+        run: yarn config set network-timeout 1000000 -g
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Yarn dependencies
+        env:
+          YARN_GPG: no
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: yarn
+
+      - name: Build Chrysalis
+        uses: samuelmeuli/action-electron-builder@v1
+        env:
+          YARN_GPG: no
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # We explicitly do **NOT** want to sign the artifacts made out of pull
+          # requests. We have no control over their content, and we do not want
+          # the Keyboardio signature on things we have no control over. Thus, no
+          # signing here.
+
+          # We supply a build script name, so that we compile the source before
+          # trying to package them up. Without compiling them, we won't have the
+          # files to pack up.
+          build_script_name: build:${{ runner.os }}
+
+          # In this step, we only want to build Chrysalis, and never release. If
+          # we need to release, we do that in a separate step.
+          args: -p=never
+          release: false
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-artifact
+          path: |
+            dist/Chrysalis-*
+            !dist/*.blockmap
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: publish
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Discover the pull-request number
+        id: pullnumber
+        shell: bash
+        run: echo ::set-output name=pr::$(tools/pr-number)
+
+      - name: Prepare the artifacts for upload
+        env:
+          VERSION: pr-${{ steps.pullnumber.outputs.pr }}
+        run: |
+          install -d s3-data
+          cp artifacts/*/Chrysalis-* s3-data/
+          mv s3-data/Chrysalis-*-portable.exe \
+             s3-data/Chrysalis-${VERSION}-portable.exe
+
+      - name: Upload artifacts to S3
+        env:
+          PR: ${{steps.pullnumber.outputs.pr}}
+        uses: hkdobrev/minio-deploy-action@v1
+        with:
+          endpoint: ${{ secrets.MINIO_ENDPOINT }}
+          access_key: ${{ secrets.MINIO_ACCESS_KEY }}
+          secret_key: ${{ secrets.MINIO_SECRET_KEY }}
+          bucket: "chrysalis"
+          source_dir: "s3-data"
+          target_dir: /pr/${{ steps.pullnumber.outputs.pr }}
+
+      - name: Send the links back to the PR
+        uses: mshick/add-pr-comment@v1
+        env:
+          BLOB_PREFIX: ${{ secrets.MINIO_ENDPOINT }}/chrysalis/pr/${{ steps.pullnumber.outputs.pr }}
+          VERSION: pr-${{ steps.pullnumber.outputs.pr }}
+        with:
+          repo-token: ${{ secrets.COMMENT_BOT_TOKEN }}
+          message: |
+            Build artifacts for this pull request are available!
+
+            :warning: These are not official builds!
+            ----------------------------------------
+
+            The build artifacts are provided as-is, for testing and reviewing purposes. They contain code that has not been reviewed or audited by Chrysalis' developers. They are not endorsed by Keyboardio, they are not signed. Install and use them only if you know what you are doing.
+
+            - Windows:
+                - [Installer](${{ env.BLOB_PREFIX }}/Chrysalis-${{ env.VERSION }}.exe)
+                - [Portable](${{ env.BLOB_PREFIX }}/Chrysalis-${{ env.VERSION }}-portable.exe)
+            - macOS:
+                - [zip](${{ env.BLOB_PREFIX }}/Chrysalis-${{ env.VERSION }}.zip)
+                - [dmg](${{ env.BLOB_PREFIX }}/Chrysalis-${{ env.VERSION }}.dmg)
+            - Linux:
+                - [AppImage](${{ env.BLOB_PREFIX }}/Chrysalis-${{ env.VERSION }}.AppImage)

--- a/tools/pr-number
+++ b/tools/pr-number
@@ -1,0 +1,3 @@
+#! /bin/bash
+PR=${GITHUB_REF#refs/pull/}
+echo ${PR%/merge}

--- a/tools/preinstall.js
+++ b/tools/preinstall.js
@@ -1,12 +1,24 @@
 const package = require("../package.json");
 const fs = require("fs");
 
-if (process.env.GITHUB_RUN_NUMBER &&
+if (process.env.GITHUB_REF?.indexOf("refs/pull/") != -1) {
+  const prNumber = process.env.GITHUB_REF.match(/^refs\/pull\/(\d+)\//)[1];
+  const buildNumber = process.env.GITHUB_RUN_NUMBER;
+  const newVersion = package
+        .version
+        .replace(/-.*/, "")
+        + `-pr-${prNumber}.${buildNumber}`;
+  package.version = newVersion;
+  package.build.artifactName = "${productName}-pr-" + prNumber + ".${ext}";
+  console.log("package.version =", package.version);
+
+  fs.writeFileSync("./package.json", JSON.stringify(package, null, 2));
+} else if (process.env.GITHUB_RUN_NUMBER &&
     package.version.indexOf("-snapshot") != -1 &&
     package.version.indexOf("-snapshot.") == -1) {
   package.version = package.version + "." + process.env.GITHUB_RUN_NUMBER;
   package.build.artifactName = "${productName}-" + package.version + ".${ext}";
-  console.log("package.version = ", package.version);
+  console.log("package.version =", package.version);
 
   fs.writeFileSync("./package.json", JSON.stringify(package, null, 2));
 }


### PR DESCRIPTION
Lately, we have been seeing - and creating - pull requests where user testing and feedback would be of incredible value. However, building from source is a barrier we don't want to put in front of potential testers.

For this reason, lets build and publish artifacts for pull requests aswell. They will not be signed - because we have no control over what gets built, really -, and they will not be uploaded to GitHub. They are made available nevertheless, and the workflow is set up so that it posts the URLs after the build to the originating pull request.