### PR TITLE
Preferences: Make it possible to turn off chunked writes

### DIFF
--- a/src/renderer/ActiveDevice.js
+++ b/src/renderer/ActiveDevice.js
@@ -36,6 +36,13 @@ export function ActiveDevice() {
     return await this.focus.plugins();
   };
 
+  this.chunked_writes = (newValue) => {
+    if (newValue !== undefined) {
+      this.focus.chunked_writes = Boolean(newValue);
+    }
+    return this.focus.chunked_writes;
+  };
+
   // This method is called when the device is connected.
   // it probes for help and plugins using focus, which lets us cache
   // that information, reducing repeated calls for the same data from the device

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -209,6 +209,8 @@ const App = (props) => {
     const newActiveDevice = new ActiveDevice();
     setActiveDevice(newActiveDevice);
 
+    newActiveDevice.chunked_writes(settings.get("focus.chunked_writes", true));
+
     if (!port.focusDeviceDescriptor.bootloader) {
       logger().info("Probing for focus support...");
       focus.setLayerSize(focus.focusDeviceDescriptor);

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -266,6 +266,12 @@
     "printTooltip": "Print"
   },
   "preferences": {
+    "focus": {
+      "chunked_writes": {
+        "label": "Send data in small chunks",
+        "help": "As a possible remedy to various communication issues, Chrysalis can send data to the keyboard in smaller chunks. For historical reasons, this is enabled by default. Only turn it off if you know what you're doing, or were asked to by the Chrysalis developers."
+      }
+    },
     "interface": "User Interface",
     "devtools": {
       "main": {


### PR DESCRIPTION
Chrysalis has been using chunked writes on macOS since about forever, and we switched to using those globally with the launch of the Model 100, as a possible remedy for communication issues (it did not help much).

Since then, we fixed the Model100 firmware, and we don't really support the buggy firmware in any shape or form, except for connecting and eventually landing on the Firmware Update screen. As such, half the reason for using chunked writes is gone.

Chunked writes, however, are slow. Very slow. It's not a great user experience. We also discovered that even on macOS, they may not be needed anymore.

However, we do not want to just disable them, and hope for the best, so for now, offer it as an option, hidden in Preferences / Developer Tools. There, because we don't want people to fiddle with it without care. It's mostly there for developers, to make it easier to test turning chunked writes off, without having to recompile and re-launch Chrysalis.

This is a strictly temporary option, which will go away as soon as we learned whether to keep chunked writes, or remove them completely.

----
![Screenshot from 2022-10-12 09-21-32](https://user-images.githubusercontent.com/17243/195279463-8aa13a3c-c1a4-490e-9713-4d935184ca00.png)
