### PR TITLE
Editor: Layer copy & paste should not depend on Colormap

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -319,7 +319,7 @@ const Editor = (props) => {
   };
 
   const hasCopiedLayer = () => {
-    return copiedLayer.keymap.length > 0 && copiedLayer.colorMap.length > 0;
+    return copiedLayer.keymap.length > 0;
   };
 
   useEffect(() => {
@@ -380,7 +380,7 @@ const Editor = (props) => {
   const copyLayer = (index) => {
     setCopiedLayer({
       keymap: keymap.custom[index].slice(0),
-      colorMap: colormap.colorMap[index].slice(0),
+      colorMap: colormap?.colorMap[index]?.slice(0) || [],
     });
   };
 


### PR DESCRIPTION
It is not required for a device to have any colormap-related functionality, whether it has LEDs or not. Copying and pasting layers should function regardless of the presence of colormaps.

As such, make `copyLayer()` handle the case of a missing colormap correctly, and do not require colormap for `hasCopiedLayer()`.

With these fixes, it is now possible to copy & paste layers on an Atreus.

Originally reported on the [forums](https://community.keyboard.io/t/chrysalis-how-to-copy-and-paste-layers/5750/5?u=algernon).