### PR TITLE
Editor: Show the context bar after pasting a layer

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -402,6 +402,7 @@ const Editor = (props) => {
     });
 
     setModified(true);
+    showContextBar();
   };
 
   if (loading) {


### PR DESCRIPTION
After pasting a layer, show the context bar, too. Setting the `modified` state alone does not display the context bar. Being "in context" allows the user to cancel the changes, and it also prevents exiting Chrysalis and losing changes.

Fixes #1175.