### PR TITLE
Editor/Sidebar: Explain the layer shift limitations with secondary actions

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -149,6 +149,7 @@
       "secondary": {
         "title": "Secondary action",
         "help": "Lets you assign secondary functionality to a key. When tapping these augmented keys, you'll get the primary function. When holding them, the secondary action will be performed.",
+        "help-layerLimit": "Due to firmware limitations, shifting to layers above \"{{ layer8 }}\" is not supported via secondary actions.",
         "whenHeld": "When held",
         "type": {
           "none": "No secondary action",

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -84,7 +84,10 @@ const SecondaryFunction = (props) => {
   if (props.macroEditorOpen) return null;
 
   const { currentKey: key, keymap } = props;
-  const maxLayer = Math.min(keymap.custom.length, 7);
+  const maxLayer = keymap.custom.length;
+  // Using a secondary action for layer shifts is limited to 8 layers due to
+  // technical reasons.
+  const secondaryActionLayerLimit = 8;
 
   let type = "none",
     targetLayer = -1,
@@ -151,7 +154,12 @@ const SecondaryFunction = (props) => {
           >
             <MenuItem value="-1" disabled></MenuItem>
             {[...Array(maxLayer)].map((x, i) => (
-              <MenuItem key={i} name={i} value={i}>
+              <MenuItem
+                name={i}
+                key={`dualuse-dropdown-${i}`}
+                value={i}
+                disabled={i > secondaryActionLayerLimit}
+              >
                 {props.layerNames?.names[i]}
               </MenuItem>
             ))}
@@ -161,12 +169,19 @@ const SecondaryFunction = (props) => {
     }
   }
 
+  let helpText = t("editor.sidebar.secondary.help");
+  if (maxLayer > secondaryActionLayerLimit) {
+    helpText =
+      helpText +
+      " " +
+      t("editor.sidebar.secondary.help-layerLimit", {
+        layer8: props.layerNames?.names[secondaryActionLayerLimit],
+      });
+  }
+
   return (
     <React.Fragment>
-      <Collapsible
-        title={t("editor.sidebar.secondary.title")}
-        help={t("editor.sidebar.secondary.help")}
-      >
+      <Collapsible title={t("editor.sidebar.secondary.title")} help={helpText}>
         <div>
           <FormControl disabled={!keySupportsSecondaryAction(key)}>
             <FormGroup row>


### PR DESCRIPTION
Due to firmware limitations, it isn't possible to use secondary actions to shift to layers above #8. Rather than silently cutting off the dropdown at the 7th layer (a bug, should've been the 8th), show all available layers, with layers above the cutoff disabled.

If there are more than 8 layers available, show an extra paragraph on the Secondary Action section help text.

Fixes #1179.

![Screenshot from 2022-10-15 09-21-27](https://user-images.githubusercontent.com/17243/195974801-6b32ccfb-96a3-4873-ab6b-34fcaaced75d.png)

The message on the sidebar shows custom layer names, if the additional message is shown. In the screenshot above, the cutoff was set to 5 so I don't have to compile firmware with >8 layers, but the PR sets it correctly to 8.