### PR TITLE
Editor/Sidebar: Remove the auto-close/auto-open behaviour

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/BlankKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/BlankKeys.js
@@ -44,7 +44,6 @@ const BlankKeys = (props) => {
 
   return (
     <Collapsible
-      expanded={db.isInCategory(props.currentKey.code, "blanks")}
       title={t("editor.sidebar.blanks.title")}
       help={t("editor.sidebar.blanks.help")}
     >

--- a/src/renderer/screens/Editor/Sidebar/BrightnessKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/BrightnessKeys.js
@@ -43,10 +43,7 @@ const BrightnessKeys = (props) => {
   });
 
   return (
-    <Collapsible
-      expanded={db.isInCategory(props.currentKey.code, "consumer")}
-      title={t("editor.sidebar.consumer.brightness")}
-    >
+    <Collapsible title={t("editor.sidebar.consumer.brightness")}>
       {keyButtons}
     </Collapsible>
   );

--- a/src/renderer/screens/Editor/Sidebar/Colormap.js
+++ b/src/renderer/screens/Editor/Sidebar/Colormap.js
@@ -59,7 +59,6 @@ const Colormap = (props) => {
     <Collapsible
       title={t("editor.sidebar.colors.title")}
       help={t("editor.sidebar.colors.help")}
-      expanded={false}
     >
       <PalettePicker
         color={colorIndex}

--- a/src/renderer/screens/Editor/Sidebar/CustomKey.js
+++ b/src/renderer/screens/Editor/Sidebar/CustomKey.js
@@ -43,7 +43,6 @@ const CustomKey = (props) => {
       <Collapsible
         title={t("editor.sidebar.custom.title")}
         help={t("editor.sidebar.custom.help")}
-        expanded={db.isInCategory(key.code, "unknown")}
       >
         <div>
           <TextField

--- a/src/renderer/screens/Editor/Sidebar/LayerKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/LayerKeys.js
@@ -21,14 +21,13 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import usePluginVisibility from "@renderer/hooks/usePluginVisibility";
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import Collapsible from "../components/Collapsible";
 
 const db = new KeymapDB();
 
 const LayerKeys = (props) => {
-  const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation();
   const oneShotVisible = usePluginVisibility("OneShot");
 
@@ -41,13 +40,6 @@ const LayerKeys = (props) => {
       return Math.min(max, 8);
     }
     return max;
-  };
-  const updateExpandedBasedOnKey = (props) => {
-    if (db.isInCategory(props.currentKey.code, "layer")) {
-      setExpanded(true);
-    } else {
-      setExpanded(false);
-    }
   };
 
   const onKeyChange = (keyCode) => {
@@ -88,7 +80,6 @@ const LayerKeys = (props) => {
       <Collapsible
         title={t("editor.sidebar.layer.title")}
         help={t("editor.sidebar.layer.help")}
-        expanded={db.isInCategory(key.code, "layer")}
       >
         <div>
           <FormControl>

--- a/src/renderer/screens/Editor/Sidebar/MediaKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MediaKeys.js
@@ -45,10 +45,7 @@ const MediaKeys = (props) => {
   });
 
   return (
-    <Collapsible
-      expanded={db.isInCategory(props.currentKey.code, "consumer")}
-      title={t("editor.sidebar.consumer.media")}
-    >
+    <Collapsible title={t("editor.sidebar.consumer.media")}>
       {keyButtons}
     </Collapsible>
   );

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -136,7 +136,6 @@ const KeyPicker = (props) => {
 
   return (
     <Collapsible
-      expanded={isStandardKey(props) || isOSM() || isDualUse()}
       title={t("editor.sidebar.keypicker.mods")}
       help={t("editor.sidebar.keypicker.modsHelp")}
     >

--- a/src/renderer/screens/Editor/Sidebar/MouseKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/MouseKeys.js
@@ -233,7 +233,6 @@ const MouseKeys = (props) => {
 
   return (
     <Collapsible
-      expanded={db.isInCategory(props.currentKey.code, "mousekeys")}
       title={t("editor.sidebar.mousekeys.title")}
       help={t("editor.sidebar.mousekeys.help")}
     >

--- a/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/OneShotKeys.js
@@ -36,7 +36,6 @@ const OneShotKeys = (props) => {
   return (
     <React.Fragment>
       <Collapsible
-        expanded={key.code == c.ONESHOT_CANCEL || key.code == c.ESCAPE}
         title={t("editor.sidebar.oneshot.title")}
         help={t("editor.sidebar.oneshot.help")}
       >

--- a/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
+++ b/src/renderer/screens/Editor/Sidebar/SecondaryFunction.js
@@ -166,7 +166,6 @@ const SecondaryFunction = (props) => {
       <Collapsible
         title={t("editor.sidebar.secondary.title")}
         help={t("editor.sidebar.secondary.help")}
-        expanded={keySupportsSecondaryAction(key)}
       >
         <div>
           <FormControl disabled={!keySupportsSecondaryAction(key)}>

--- a/src/renderer/screens/Editor/Sidebar/VolumeKeys.js
+++ b/src/renderer/screens/Editor/Sidebar/VolumeKeys.js
@@ -44,10 +44,7 @@ const VolumeKeys = (props) => {
   });
 
   return (
-    <Collapsible
-      expanded={db.isInCategory(props.currentKey.code, "consumer")}
-      title={t("editor.sidebar.consumer.volume")}
-    >
+    <Collapsible title={t("editor.sidebar.consumer.volume")}>
       {keyButtons}
     </Collapsible>
   );

--- a/src/renderer/screens/Editor/components/CategorySelector.js
+++ b/src/renderer/screens/Editor/components/CategorySelector.js
@@ -29,11 +29,7 @@ const CategorySelector = (props) => {
 
   return (
     <React.Fragment>
-      <Collapsible
-        expanded={db.isInCategory(props.currentKey.code, props.category)}
-        title={props.title}
-        help={props.help}
-      >
+      <Collapsible title={props.title} help={props.help}>
         {props.children}
         <KeyButtonList
           keys={db.selectCategory(props.category)}

--- a/src/renderer/screens/Editor/components/Collapsible.js
+++ b/src/renderer/screens/Editor/components/Collapsible.js
@@ -23,12 +23,10 @@ import Typography from "@mui/material/Typography";
 import React, { useState } from "react";
 
 const Collapsible = (props) => {
-  const [expanded, setExpanded] = useState(undefined);
-
-  const show_expanded = expanded !== undefined ? expanded : props.expanded;
+  const [expanded, setExpanded] = useState(false);
 
   const handleChange = () => {
-    setExpanded(!show_expanded);
+    setExpanded(!expanded);
   };
   const { title, help } = props;
   const summary = (
@@ -69,7 +67,7 @@ const Collapsible = (props) => {
     <Accordion
       square
       TransitionProps={{ unmountOnExit: true }}
-      expanded={show_expanded}
+      expanded={expanded}
       sx={{
         boxShadow: "none",
         margin: `0px 0px -1px 0px`,


### PR DESCRIPTION
The driving logic behind the auto-close/auto-open behaviour of collapsible sections turned out to be more confusing than useful. Implementing a behaviour that is intuitive and not confusing, is bordering the impossible, so lets not try that.

This patch removes the functionality altogether: collapsible sections will start off being closed, but once opened manually, they will stay open.

Fixes #1159.