### PR TITLE
ci: Only run the publish step for PRs when the source repo is ours

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -78,6 +78,7 @@ jobs:
             !dist/*.blockmap
 
   publish:
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs: build
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
Because the publish step requires secrets that are unavailable for pull requests, we can't - and don't want to, either - run the publish step, because it would fail. As such, skip the step instead.

This does reduce the usefulness of building artifacts for each PR, but they remain useful for PRs originating from the Chrysalis repo, so it is still worth keeping.