### PR TITLE
Fix the colormap importing via backup & restore

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -244,6 +244,12 @@ const Editor = (props) => {
     showContextBar();
   };
 
+  const onColormapAndPaletteChange = (newData) => {
+    setModified(true);
+    setColormap(newData);
+    showContextBar();
+  };
+
   const onColormapChange = (newColormap) => {
     const newcolormap = { ...colormap };
     newcolormap.colorMap = newColormap;
@@ -499,6 +505,7 @@ const Editor = (props) => {
         onKeymapChange={onKeymapChange}
         onColormapChange={onColormapChange}
         onPaletteChange={onPaletteChange}
+        onColormapAndPaletteChange={onColormapAndPaletteChange}
         onLedChange={onLedChange}
         setOpenMacroEditor={maybeOpenMacroEditor}
         currentKey={currentKey}

--- a/src/renderer/screens/Editor/Sidebar.js
+++ b/src/renderer/screens/Editor/Sidebar.js
@@ -125,6 +125,7 @@ const Sidebar = (props) => {
           onKeymapChange={props.onKeymapChange}
           onPaletteChange={props.onPaletteChange}
           onColormapChange={props.onColormapChange}
+          onColormapAndPaletteChange={props.onColormapAndPaletteChange}
         />
         {categories}
       </Box>

--- a/src/renderer/screens/Editor/Sidebar/LayoutSharing.js
+++ b/src/renderer/screens/Editor/Sidebar/LayoutSharing.js
@@ -68,10 +68,14 @@ const LayoutSharing = (props) => {
       : colormap.colorMap;
     const newPalette = layout.palette || colormap.palette;
 
+    const newCP = {
+      palette: newPalette,
+      colorMap: newColormap,
+    };
+
     closeImportConfirm();
     props.onKeymapChange(newKeymap);
-    props.onColormapChange(newColormap);
-    props.onPaletteChange(newPalette);
+    props.onColormapAndPaletteChange(newCP);
     props.onClose();
   };
 

--- a/src/renderer/screens/Editor/Sidebar/Overview.js
+++ b/src/renderer/screens/Editor/Sidebar/Overview.js
@@ -232,6 +232,7 @@ const Overview = (props) => {
         onKeymapChange={props.onKeymapChange}
         onPaletteChange={props.onPaletteChange}
         onColormapChange={props.onColormapChange}
+        onColormapAndPaletteChange={props.onColormapAndPaletteChange}
       />
     </Box>
   );


### PR DESCRIPTION
When importing the colormap, we're importing both the palette, and the colormap, but we were importing them in two steps, both of which were asynchronously setting the same state. This resulted in the two async state changes stomping on each others feet, and corrupting the colormap.

To remedy this issue, add a new helper that can set them both at the same time, and thus, we avoid the race condition.

Fixes #1059.