### PR TITLE
LayoutSharing: Do not offer backups for import for now

### DIFF
--- a/src/renderer/screens/Editor/Sidebar/LayoutSharing.js
+++ b/src/renderer/screens/Editor/Sidebar/LayoutSharing.js
@@ -31,7 +31,6 @@ import { GlobalContext } from "@renderer/components/GlobalContext";
 import { t } from "i18next";
 import React, { useContext } from "react";
 
-import { BackupImport } from "./LayoutSharing/BackupImport";
 import { ExportToFile } from "./LayoutSharing/ExportToFile";
 import { FileImport } from "./LayoutSharing/FileImport";
 import { LibraryImport } from "./LayoutSharing/LibraryImport";
@@ -122,11 +121,6 @@ const LayoutSharing = (props) => {
         >
           <Box sx={{ overflow: "auto", padding: 3 }}>
             <LibraryImport
-              setLayout={setLayout}
-              layoutName={layoutName}
-              {...others}
-            />
-            <BackupImport
               setLayout={setLayout}
               layoutName={layoutName}
               {...others}


### PR DESCRIPTION
Due to an earlier change, importing from backups made during flash are not importable via the "Backup & Restore" mechanism. Since the import was half-broken in this case anyway, lets disable this feature for now, until we develop a proper fix.

Addresses #1201 - but doesn't fix it.