### PR TITLE
Refactor the 104key widget to hang all the layout data off the <Key>

### DIFF
--- a/src/renderer/screens/Editor/Keyboard104.js
+++ b/src/renderer/screens/Editor/Keyboard104.js
@@ -27,43 +27,6 @@ const KeySelector = (props) => {
   const keymap = db.getStandardLayout();
   const theme = useTheme();
   const { currentKeyCode, onKeySelect } = props;
-  const keySpacingX = keycapunit;
-  const keySpacingY = keycapunit;
-  const keyOffsetX = [
-    [0, 1, 0, 0, 0, 0.5, 0, 0, 0, 0.5],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0.5],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0.5, 0, 0, 0, 0.5],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0.5],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.5, 1.5, 0, 0, 0, 0.5],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0.5],
-  ];
-  const keySizeX = [
-    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2],
-    [1.5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.5],
-    [1.75, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2.25],
-    [1.25, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2.75],
-    [1.25, 1.25, 1.25, 6.25, 1.25, 1.25, 1.25, 1.25, 1, 1, 1, 2],
-  ];
-  const keySizeY = [[], [], [], [], []];
-  keySizeY[2][20] = 2;
-  keySizeY[4][17] = 2;
-
-  const getKeySizeX = (row, col) => {
-    if (keySizeX[row]?.[col]) {
-      return keySizeX[row][col];
-    } else {
-      return 1;
-    }
-  };
-
-  const getKeySizeY = (row, col) => {
-    if (keySizeY[row]?.[col]) {
-      return keySizeY[row][col];
-    } else {
-      return 1;
-    }
-  };
 
   const getKey = (row, col) => {
     if (keymap[row]) {
@@ -75,64 +38,20 @@ const KeySelector = (props) => {
     }
   };
 
-  const getX = (row, col) => {
-    let offset = 0;
-
-    for (let i = 0; i < col; i++) {
-      offset += getKeySizeX(row, i) * keySpacingX;
-
-      if (keyOffsetX[row]?.[i]) {
-        offset += keyOffsetX[row][i] * keySpacingX;
-      }
-    }
-
-    if (keyOffsetX[row]?.[col]) {
-      offset += keyOffsetX[row][col] * keySpacingX;
-    }
-
-    return offset;
-  };
-
-  const getY = (row) => {
-    let y = row * keySpacingY;
-    if (row > 0) y += keySpacingY * 0.5;
-    return y;
-  };
-
-  const getKeyWidth = (row, col) => {
-    const size = getKeySizeX(row, col);
-    return keycapunit * size;
-  };
-
-  const getKeyHeight = (row, col) => {
-    return keycapunit * getKeySizeY(row, col);
-  };
-
-  const getKeycapSize = (row, col) => {
-    return getKeySizeX(row, col).toString() + "u";
-  };
-
   const Key = (props) => {
     const { row, col } = props;
-    const x = getX(row, col),
-      y = getY(row, col),
-      key = getKey(row, col),
-      active = key.code == currentKeyCode;
+
+    const key = getKey(row, col);
+
+    const x = props.x * keycapunit;
+    const y = props.y * keycapunit;
+    const active = key.code == currentKeyCode;
     const stroke = theme.palette.divider;
-    const height = getKeyHeight(row, col);
-    const width = getKeyWidth(row, col);
-    const bottom = y + height - 8;
-    const buttonColor = active
-      ? theme.palette.primary.light
-      : theme.palette.background.paper;
+    const height = props.height * keycapunit;
+    const width = props.width * keycapunit;
 
-    const textColor = theme.palette.getContrastText(buttonColor);
+    const label = db.format(key, { keycapSize: props.width + "u" });
 
-    const onClick = (event) => {
-      return onKeySelect(event.currentTarget.getAttribute("data-key-code"));
-    };
-
-    const label = db.format(key, { keycapSize: getKeycapSize(row, col) });
     let fontSize =
       label.main.length == 1
         ? Math.round(keycapunit / 2.5)
@@ -143,6 +62,16 @@ const KeySelector = (props) => {
       fontSize -= 3;
       mainLegendY += fontSize / 2 + 2;
     }
+
+    const buttonColor = active
+      ? theme.palette.primary.light
+      : theme.palette.background.paper;
+
+    const textColor = theme.palette.getContrastText(buttonColor);
+
+    const onClick = (event) => {
+      return onKeySelect(event.currentTarget.getAttribute("data-key-code"));
+    };
 
     return (
       <g onClick={onClick} className="key" data-key-code={key.code}>
@@ -182,11 +111,6 @@ const KeySelector = (props) => {
     );
   };
 
-  const viewBoxSize =
-    "0 0 " +
-    Math.round(23 * keycapunit).toString() +
-    " " +
-    Math.round(6.5 * keycapunit).toString();
   return (
     <Box
       sx={{
@@ -194,7 +118,12 @@ const KeySelector = (props) => {
       }}
     >
       <svg
-        viewBox={viewBoxSize}
+        viewBox={
+          "0 0 " +
+          Math.round(23 * keycapunit).toString() +
+          " " +
+          Math.round(6.5 * keycapunit).toString()
+        }
         xmlns="http://www.w3.org/2000/svg"
         preserveAspectRatio="xMidYMin meet"
         width="100%"
@@ -208,141 +137,141 @@ const KeySelector = (props) => {
       >
         <g transform="">
           <g>
-            <Key row={0} col={0} />
+            <Key row={0} col={0} width={1} height={1} x={0} y={0} />
 
-            <Key row={0} col={1} />
-            <Key row={0} col={2} />
-            <Key row={0} col={3} />
-            <Key row={0} col={4} />
+            <Key row={0} col={1} width={1} height={1} x={2} y={0} />
+            <Key row={0} col={2} width={1} height={1} x={3} y={0} />
+            <Key row={0} col={3} width={1} height={1} x={4} y={0} />
+            <Key row={0} col={4} width={1} height={1} x={5} y={0} />
 
-            <Key row={0} col={5} />
-            <Key row={0} col={6} />
-            <Key row={0} col={7} />
-            <Key row={0} col={8} />
+            <Key row={0} col={5} width={1} height={1} x={6.5} y={0} />
+            <Key row={0} col={6} width={1} height={1} x={7.5} y={0} />
+            <Key row={0} col={7} width={1} height={1} x={8.5} y={0} />
+            <Key row={0} col={8} width={1} height={1} x={9.5} y={0} />
 
-            <Key row={0} col={9} />
-            <Key row={0} col={10} />
-            <Key row={0} col={11} />
-            <Key row={0} col={12} />
+            <Key row={0} col={9} width={1} height={1} x={11} y={0} />
+            <Key row={0} col={10} width={1} height={1} x={12} y={0} />
+            <Key row={0} col={11} width={1} height={1} x={13} y={0} />
+            <Key row={0} col={12} width={1} height={1} x={14} y={0} />
           </g>
 
           <g>
-            <Key row={1} col={0} />
-            <Key row={1} col={1} />
-            <Key row={1} col={2} />
-            <Key row={1} col={3} />
-            <Key row={1} col={4} />
-            <Key row={1} col={5} />
-            <Key row={1} col={6} />
-            <Key row={1} col={7} />
-            <Key row={1} col={8} />
-            <Key row={1} col={9} />
-            <Key row={1} col={10} />
-            <Key row={1} col={11} />
-            <Key row={1} col={12} />
-            <Key row={1} col={13} />
+            <Key row={1} col={0} width={1} height={1} x={0} y={1.5} />
+            <Key row={1} col={1} width={1} height={1} x={1} y={1.5} />
+            <Key row={1} col={2} width={1} height={1} x={2} y={1.5} />
+            <Key row={1} col={3} width={1} height={1} x={3} y={1.5} />
+            <Key row={1} col={4} width={1} height={1} x={4} y={1.5} />
+            <Key row={1} col={5} width={1} height={1} x={5} y={1.5} />
+            <Key row={1} col={6} width={1} height={1} x={6} y={1.5} />
+            <Key row={1} col={7} width={1} height={1} x={7} y={1.5} />
+            <Key row={1} col={8} width={1} height={1} x={8} y={1.5} />
+            <Key row={1} col={9} width={1} height={1} x={9} y={1.5} />
+            <Key row={1} col={10} width={1} height={1} x={10} y={1.5} />
+            <Key row={1} col={11} width={1} height={1} x={11} y={1.5} />
+            <Key row={1} col={12} width={1} height={1} x={12} y={1.5} />
+            <Key row={1} col={13} width={2} height={1} x={13} y={1.5} />
 
-            <Key row={1} col={14} />
-            <Key row={1} col={15} />
-            <Key row={1} col={16} />
+            <Key row={1} col={14} width={1} height={1} x={15.5} y={1.5} />
+            <Key row={1} col={15} width={1} height={1} x={16.5} y={1.5} />
+            <Key row={1} col={16} width={1} height={1} x={17.5} y={1.5} />
 
-            <Key row={1} col={17} />
-            <Key row={1} col={18} />
-            <Key row={1} col={19} />
-            <Key row={1} col={20} />
+            <Key row={1} col={17} width={1} height={1} x={19} y={1.5} />
+            <Key row={1} col={18} width={1} height={1} x={20} y={1.5} />
+            <Key row={1} col={19} width={1} height={1} x={21} y={1.5} />
+            <Key row={1} col={20} width={1} height={1} x={22} y={1.5} />
           </g>
 
           <g>
-            <Key row={2} col={0} />
-            <Key row={2} col={1} />
-            <Key row={2} col={2} />
-            <Key row={2} col={3} />
-            <Key row={2} col={4} />
-            <Key row={2} col={5} />
-            <Key row={2} col={6} />
-            <Key row={2} col={7} />
-            <Key row={2} col={8} />
-            <Key row={2} col={9} />
-            <Key row={2} col={10} />
-            <Key row={2} col={11} />
-            <Key row={2} col={12} />
-            <Key row={2} col={13} />
+            <Key row={2} col={0} width={1.5} height={1} x={0} y={2.5} />
+            <Key row={2} col={1} width={1} height={1} x={1.5} y={2.5} />
+            <Key row={2} col={2} width={1} height={1} x={2.5} y={2.5} />
+            <Key row={2} col={3} width={1} height={1} x={3.5} y={2.5} />
+            <Key row={2} col={4} width={1} height={1} x={4.5} y={2.5} />
+            <Key row={2} col={5} width={1} height={1} x={5.5} y={2.5} />
+            <Key row={2} col={6} width={1} height={1} x={6.5} y={2.5} />
+            <Key row={2} col={7} width={1} height={1} x={7.5} y={2.5} />
+            <Key row={2} col={8} width={1} height={1} x={8.5} y={2.5} />
+            <Key row={2} col={9} width={1} height={1} x={9.5} y={2.5} />
+            <Key row={2} col={10} width={1} height={1} x={10.5} y={2.5} />
+            <Key row={2} col={11} width={1} height={1} x={11.5} y={2.5} />
+            <Key row={2} col={12} width={1} height={1} x={12.5} y={2.5} />
+            <Key row={2} col={13} width={1.5} height={1} x={13.5} y={2.5} />
 
-            <Key row={2} col={14} />
-            <Key row={2} col={15} />
-            <Key row={2} col={16} />
+            <Key row={2} col={14} width={1} height={1} x={15.5} y={2.5} />
+            <Key row={2} col={15} width={1} height={1} x={16.5} y={2.5} />
+            <Key row={2} col={16} width={1} height={1} x={17.5} y={2.5} />
 
-            <Key row={2} col={17} />
-            <Key row={2} col={18} />
-            <Key row={2} col={19} />
-            <Key row={2} col={20} />
+            <Key row={2} col={17} width={1} height={1} x={19} y={2.5} />
+            <Key row={2} col={18} width={1} height={1} x={20} y={2.5} />
+            <Key row={2} col={19} width={1} height={1} x={21} y={2.5} />
+            <Key row={2} col={20} width={1} height={2} x={22} y={2.5} />
           </g>
 
           <g>
-            <Key row={3} col={0} />
-            <Key row={3} col={1} />
-            <Key row={3} col={2} />
-            <Key row={3} col={3} />
-            <Key row={3} col={4} />
-            <Key row={3} col={5} />
-            <Key row={3} col={6} />
-            <Key row={3} col={7} />
-            <Key row={3} col={8} />
-            <Key row={3} col={9} />
-            <Key row={3} col={10} />
-            <Key row={3} col={11} />
-            <Key row={3} col={12} />
+            <Key row={3} col={0} width={1.75} height={1} x={0} y={3.5} />
+            <Key row={3} col={1} width={1} height={1} x={1.75} y={3.5} />
+            <Key row={3} col={2} width={1} height={1} x={2.75} y={3.5} />
+            <Key row={3} col={3} width={1} height={1} x={3.75} y={3.5} />
+            <Key row={3} col={4} width={1} height={1} x={4.75} y={3.5} />
+            <Key row={3} col={5} width={1} height={1} x={5.75} y={3.5} />
+            <Key row={3} col={6} width={1} height={1} x={6.75} y={3.5} />
+            <Key row={3} col={7} width={1} height={1} x={7.75} y={3.5} />
+            <Key row={3} col={8} width={1} height={1} x={8.75} y={3.5} />
+            <Key row={3} col={9} width={1} height={1} x={9.75} y={3.5} />
+            <Key row={3} col={10} width={1} height={1} x={10.75} y={3.5} />
+            <Key row={3} col={11} width={1} height={1} x={11.75} y={3.5} />
+            <Key row={3} col={12} width={2.25} height={1} x={12.75} y={3.5} />
 
-            <Key row={3} col={13} />
-            <Key row={3} col={14} />
-            <Key row={3} col={15} />
+            <Key row={3} col={13} width={1} height={1} x={15.5} y={3.5} />
+            <Key row={3} col={14} width={1} height={1} x={16.5} y={3.5} />
+            <Key row={3} col={15} width={1} height={1} x={17.5} y={3.5} />
 
-            <Key row={3} col={16} />
-            <Key row={3} col={17} />
-            <Key row={3} col={18} />
+            <Key row={3} col={16} width={1} height={1} x={19} y={3.5} />
+            <Key row={3} col={17} width={1} height={1} x={20} y={3.5} />
+            <Key row={3} col={18} width={1} height={1} x={21} y={3.5} />
           </g>
 
           <g>
-            <Key row={4} col={0} />
-            <Key row={4} col={1} />
-            <Key row={4} col={2} />
-            <Key row={4} col={3} />
-            <Key row={4} col={4} />
-            <Key row={4} col={5} />
-            <Key row={4} col={6} />
-            <Key row={4} col={7} />
-            <Key row={4} col={8} />
-            <Key row={4} col={9} />
-            <Key row={4} col={10} />
-            <Key row={4} col={11} />
-            <Key row={4} col={12} />
+            <Key row={4} col={0} width={1.25} height={1} x={0} y={4.5} />
+            <Key row={4} col={1} width={1} height={1} x={1.25} y={4.5} />
+            <Key row={4} col={2} width={1} height={1} x={2.25} y={4.5} />
+            <Key row={4} col={3} width={1} height={1} x={3.25} y={4.5} />
+            <Key row={4} col={4} width={1} height={1} x={4.25} y={4.5} />
+            <Key row={4} col={5} width={1} height={1} x={5.25} y={4.5} />
+            <Key row={4} col={6} width={1} height={1} x={6.25} y={4.5} />
+            <Key row={4} col={7} width={1} height={1} x={7.25} y={4.5} />
+            <Key row={4} col={8} width={1} height={1} x={8.25} y={4.5} />
+            <Key row={4} col={9} width={1} height={1} x={9.25} y={4.5} />
+            <Key row={4} col={10} width={1} height={1} x={10.25} y={4.5} />
+            <Key row={4} col={11} width={1} height={1} x={11.25} y={4.5} />
+            <Key row={4} col={12} width={2.75} height={1} x={12.25} y={4.5} />
 
-            <Key row={4} col={13} />
+            <Key row={4} col={13} width={1} height={1} x={16.5} y={4.5} />
 
-            <Key row={4} col={14} />
-            <Key row={4} col={15} />
-            <Key row={4} col={16} />
-            <Key row={4} col={17} />
+            <Key row={4} col={14} width={1} height={1} x={19} y={4.5} />
+            <Key row={4} col={15} width={1} height={1} x={20} y={4.5} />
+            <Key row={4} col={16} width={1} height={1} x={21} y={4.5} />
+            <Key row={4} col={17} width={1} height={2} x={22} y={4.5} />
           </g>
 
           <g>
-            <Key row={5} col={0} />
-            <Key row={5} col={1} />
-            <Key row={5} col={2} />
+            <Key row={5} col={0} width={1.25} height={1} x={0} y={5.5} />
+            <Key row={5} col={1} width={1.25} height={1} x={1.25} y={5.5} />
+            <Key row={5} col={2} width={1.25} height={1} x={2.5} y={5.5} />
 
-            <Key row={5} col={3} />
+            <Key row={5} col={3} width={6.25} height={1} x={3.75} y={5.5} />
 
-            <Key row={5} col={4} />
-            <Key row={5} col={5} />
-            <Key row={5} col={6} />
-            <Key row={5} col={7} />
+            <Key row={5} col={4} width={1.25} height={1} x={10} y={5.5} />
+            <Key row={5} col={5} width={1.25} height={1} x={11.25} y={5.5} />
+            <Key row={5} col={6} width={1.25} height={1} x={12.5} y={5.5} />
+            <Key row={5} col={7} width={1.25} height={1} x={13.75} y={5.5} />
 
-            <Key row={5} col={8} />
-            <Key row={5} col={9} />
-            <Key row={5} col={10} />
+            <Key row={5} col={8} width={1} height={1} x={15.5} y={5.5} />
+            <Key row={5} col={9} width={1} height={1} x={16.5} y={5.5} />
+            <Key row={5} col={10} width={1} height={1} x={17.5} y={5.5} />
 
-            <Key row={5} col={11} />
-            <Key row={5} col={12} />
+            <Key row={5} col={11} width={2} height={1} x={19} y={5.5} />
+            <Key row={5} col={12} width={1} height={1} x={21} y={5.5} />
           </g>
         </g>
       </svg>


### PR DESCRIPTION
elements of the datastructure, rather than spreading it across a bunch of different data structures.

Original:

![image](https://user-images.githubusercontent.com/45416/197662024-fc77b06d-365a-4605-b4ac-c3fc16a714a1.png)

New:

![image](https://user-images.githubusercontent.com/45416/197662097-806718c1-7688-4a17-b4e8-b06b5e917ad1.png)

(Note that these may have been manually resized, but the actual layout should be identical)