### PR TITLE
Various safety nets for flashing starting from bootloader mode

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -473,6 +473,7 @@
     "permissionErrorSuggestion": "Chrysalis can fix this by installing a udev rules file into /etc/udev/rules.d/."
   },
   "firmwareUpdate": {
+    "bootloaderWarning": "Your keyboard is in bootloader mode, so Chrysalis can't back up the keyboard's settings. If the new firmware is incompatible with your existing settings, key layouts and other settings might be corrupted after the update. For this reason, Chrysalis will default to a factory reset, which will let you start from a clean slate. You can cancel and exit bootloader mode, so Chrysalis can back up your keyboard. Alternatively, you may turn off the factory reset, if you know that the new firmware is compatible.",
     "firmwareChangelog": {
       "title": "Firmware Changelog",
       "view": "What's new in {{version}}?"
@@ -491,6 +492,8 @@
       "error": "Error flashing the firmware",
       "success": "Firmware flashed successfully!",
       "button": "Update",
+      "anywayButton": "Update anyway",
+      "cancelAndDisconnectButton": "Cancel and disconnect",
       "notifications": {
         "title": "Problem encountered while flashing",
         "enter": {

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -38,6 +38,7 @@ import { ipcRenderer } from "electron";
 import path from "path";
 import { useTranslation } from "react-i18next";
 
+import BootloaderWarning from "./FirmwareUpdate/BootloaderWarning";
 import FirmwareVersion from "./FirmwareUpdate/FirmwareVersion";
 import FirmwareSelect from "./FirmwareUpdate/FirmwareSelect";
 import FirmwareUpdateWarning from "./FirmwareUpdate/FirmwareUpdateWarning";
@@ -197,6 +198,11 @@ const FirmwareUpdate = (props) => {
     }
   };
 
+  const uploadVariant = isBootloader ? "outlined" : "contained";
+  const uploadLabel = isBootloader
+    ? t("firmwareUpdate.flashing.anywayButton")
+    : t("firmwareUpdate.flashing.button");
+
   return (
     <>
       <PageTitle title={t("app.menu.firmwareUpdate")} />
@@ -208,7 +214,7 @@ const FirmwareUpdate = (props) => {
         <Paper sx={{ p: 2 }}>
           <UpdateDescription />
           <Divider sx={{ my: 2 }} />
-          <FirmwareVersion />
+          {isBootloader ? <BootloaderWarning /> : <FirmwareVersion />}
           <FirmwareSelect
             selectedFirmware={[selectedFirmwareType, setSelectedFirmwareType]}
             firmwareFilename={[firmwareFilename, setFirmwareFilename]}
@@ -231,7 +237,7 @@ const FirmwareUpdate = (props) => {
               startIcon={
                 progress == "success" ? <CheckIcon /> : <CloudUploadIcon />
               }
-              variant="contained"
+              variant={uploadVariant}
               onClick={onUpdateClick}
               disabled={buttonsDisabled}
               color={
@@ -239,8 +245,19 @@ const FirmwareUpdate = (props) => {
                 "primary"
               }
             >
-              {t("firmwareUpdate.flashing.button")}
+              {uploadLabel}
             </Button>
+            {isBootloader && (
+              <Button
+                onClick={props.onDisconnect}
+                variant="contained"
+                disabled={buttonsDisabled}
+                color="primary"
+                sx={{ ml: 2 }}
+              >
+                {t("firmwareUpdate.flashing.cancelAndDisconnectButton")}
+              </Button>
+            )}
           </Box>
         </Paper>
       </Container>

--- a/src/renderer/screens/FirmwareUpdate/BootloaderWarning.js
+++ b/src/renderer/screens/FirmwareUpdate/BootloaderWarning.js
@@ -1,0 +1,42 @@
+// -*- mode: js-jsx -*-
+/* Chrysalis -- Kaleidoscope Command Center
+ * Copyright (C) 2022  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Alert from "@mui/material/Alert";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import React, { useContext } from "react";
+import { GlobalContext } from "@renderer/components/GlobalContext";
+
+import { useTranslation } from "react-i18next";
+
+const BootloaderWarning = (props) => {
+  const { t } = useTranslation();
+  const globalContext = useContext(GlobalContext);
+
+  return (
+    <>
+      <Alert severity="warning">
+        <Typography component="p">
+          {t("firmwareUpdate.bootloaderWarning")}
+        </Typography>
+      </Alert>
+      <Divider sx={{ my: 2 }} />
+    </>
+  );
+};
+
+export default BootloaderWarning;


### PR DESCRIPTION
![Screenshot from 2022-10-27 23-28-45](https://user-images.githubusercontent.com/17243/198403381-b6bb3390-0bd1-4650-9eea-2f926d63d820.png)

This does a few things in case Chrysalis arrives to the FirmwareUpdate screen while the keyboard is in bootloader mode:
- It will default to enabling factory reset (but can still be toggled off)
- It will display a warning message in place of the firmware version, explaining the dangers of flashing from bootloader mode, and recommending to try normal flashing if possible
- The Upload button will become "Upload anyway", and use the secondary color
- A new "Cancel and disconnect" button will be displayed (in primary color) to provide an easy way out