### PR TITLE
api/flash/DFUUtilFlasher: rebootToApplicationMode should be retryable

### DIFF
--- a/src/api/flash.js
+++ b/src/api/flash.js
@@ -132,8 +132,11 @@ export const flash = async (flasher, board, port, filename, options) => {
    ***/
   await flasher.flash(board, port, filename, options);
 
-  // If we were in bootloader mode, and aren't doing a factory reset, we're done here.
+  // If we were in bootloader mode, and aren't doing a factory reset, we're
+  // pretty much done here.
   if (startFromBootloader && !options.factoryReset) {
+    // We do need to reboot back to application mode, however
+    await flasher.rebootToApplicationMode(port, options.device);
     return;
   }
 


### PR DESCRIPTION
Rebooting to Application mode is retryable, we should not be throwing an uncrecoverable exception if it fails, as that will abort the flashing process needlessly.

To make it retryable, this patch changes `runDFUUtil` to throw an exception with either a `HARD_FAIL` or a `SOFT_FAIL` message. Flashing will then stop in either case, because we do not retry flashing. But `rebootToApplicationMode` can catch the exception, and ignore it, because the main flashing loop will double check that the keyboard did end up in app mode.

Additionally, when doing flashing, lets not run `dfu-util` with `--reset`, because we'll do that reset explicitly in `rebootToApplicationMode()`. In turn, do not use `--reset` there, either, because `--detach` is enough, `--reset` just gives us an extra warning and doesn't do anything.

However, if we're starting from bootloader mode, with `--reset` removed from the flash call, we need to do an explicit `rebootToApplicationMode()` before returning. Lets do that, too.

Fixes #1221.