### PR TITLE
renderer/config: Fix the paths returned by getStaticPath()

### DIFF
--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -25,9 +25,9 @@ function getStaticPath() {
   // Instead, it includes an unexpected `node_modules` path, specifically:
   // node_modules/electron/dist/Electron.app/Contents/Resources/static
   if (isDevelopment) {
-    return path.join("/static");
+    return path.join("static");
   } else {
-    return path.join("../../../../static");
+    return path.join(__dirname, "..", "..", "..", "..", "static");
   }
 }
 


### PR DESCRIPTION
In development mode, the static path must be a relative path, and in production builds, it needs to be relative to `__dirname`, otherwise static files will not be found.

This fixes - among other things - the ChangeLog screen.