### PR TITLE
Add bépo layout as a host keyboard layout

### DIFF
--- a/data/cldr/keyboards/windows/fr-bépo-t-k0-windows.xml
+++ b/data/cldr/keyboards/windows/fr-bépo-t-k0-windows.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../dtd/ldmlKeyboard.dtd">
+<keyboard locale="fr-t-k0-windows">
+	<version platform="10" number="$Revision$"/>
+	<names>
+		<name value="French bépo"/>
+	</names>
+	<settings fallback="omit" transformPartial="hide"/>
+	<keyMap>
+		<map iso="E00" to="$"/> <!-- ` -->
+		<map iso="E01" to="\u{22}"/> <!-- 1 -->
+		<map iso="E02" to="«"/> <!-- 2 -->
+		<map iso="E03" to="»"/> <!-- 3  to= "  -->
+		<map iso="E04" to="("/> <!-- 4 -->
+		<map iso="E05" to=")"/> <!-- 5 -->
+		<map iso="E06" to="@"/> <!-- 6 -->
+		<map iso="E07" to="+"/> <!-- 7 -->
+		<map iso="E08" to="-"/> <!-- 8 -->
+		<map iso="E09" to="/"/> <!-- 9 -->
+		<map iso="E10" to="*"/> <!-- 0 -->
+		<map iso="E11" to="="/> <!-- - -->
+		<map iso="E12" to="%"/>
+		<map iso="D01" to="b"/> <!-- Q -->
+		<map iso="D02" to="é"/> <!-- W -->
+		<map iso="D03" to="p"/>
+		<map iso="D04" to="o"/>
+		<map iso="D05" to="è"/>
+		<map iso="D06" to="^"/>
+		<map iso="D07" to="v"/>
+		<map iso="D08" to="d"/>
+		<map iso="D09" to="l"/>
+		<map iso="D10" to="j"/>
+		<map iso="D11" to="z"/> <!-- [ -->
+		<map iso="D12" to="w"/> <!-- ] -->
+		<map iso="C01" to="a"/> <!-- A -->
+		<map iso="C02" to="u"/>
+		<map iso="C03" to="i"/>
+		<map iso="C04" to="e"/>
+		<map iso="C05" to=","/>
+		<map iso="C06" to="c"/>
+		<map iso="C07" to="t"/>
+		<map iso="C08" to="s"/>
+		<map iso="C09" to="r"/>
+		<map iso="C10" to="n"/> <!-- ; -->
+		<map iso="C11" to="m"/> <!-- ' -->
+		<map iso="C12" to="ç"/> <!-- (key to right of ') -->
+		<map iso="B00" to="ê"/> <!-- (key to left of Z) -->
+		<map iso="B01" to="à"/> <!-- Z -->
+		<map iso="B02" to="y"/>
+		<map iso="B03" to="x"/>
+		<map iso="B04" to="."/>
+		<map iso="B05" to="k"/>
+		<map iso="B06" to="’"/>
+		<map iso="B07" to="q"/> <!-- M -->
+		<map iso="B08" to="g"/> <!-- , -->
+		<map iso="B09" to="h"/> <!-- . -->
+		<map iso="B10" to="f"/> <!-- / -->
+		<map iso="A03" to=" "/> <!-- space -->
+	</keyMap>
+	<keyMap modifiers="shift">
+		<map iso="E00" to="#"/> <!--   base=& -->
+		<map iso="E01" to="1"/> <!--   base=& -->
+		<map iso="E02" to="2"/> <!--   base=é -->
+		<map iso="E03" to="3"/> <!--   base=" -->
+		<map iso="E04" to="4"/> <!--   base=' -->
+		<map iso="E05" to="5"/> <!--   base=( -->
+		<map iso="E06" to="6"/> <!--   base=- -->
+		<map iso="E07" to="7"/> <!--   base=è -->
+		<map iso="E08" to="8"/> <!--   base=_ -->
+		<map iso="E09" to="9"/> <!--   base=ç -->
+		<map iso="E10" to="0"/> <!--   base=à -->
+		<map iso="E11" to="°"/> <!-- -  base=) -->
+		<map iso="E12" to="`"/> <!-- = -->
+		<map iso="D01" to="B"/> <!-- Q -->
+		<map iso="D02" to="É"/> <!-- W -->
+		<map iso="D03" to="P"/>
+		<map iso="D04" to="O"/>
+		<map iso="D05" to="È"/>
+		<map iso="D06" to="!"/>
+		<map iso="D07" to="V"/>
+		<map iso="D08" to="D"/>
+		<map iso="D09" to="L"/>
+		<map iso="D10" to="J"/>
+		<map iso="D11" to="Z"/> <!-- [  base=^ -->
+		<map iso="D12" to="W"/> <!-- ]  base=$ -->
+		<map iso="C01" to="A"/> <!-- A -->
+		<map iso="C02" to="U"/>
+		<map iso="C03" to="I"/>
+		<map iso="C04" to="E"/>
+		<map iso="C05" to=";"/>
+		<map iso="C06" to="C"/>
+		<map iso="C07" to="T"/>
+		<map iso="C08" to="S"/>
+		<map iso="C09" to="R"/>
+		<map iso="C10" to="N"/> <!-- ; -->
+		<map iso="C11" to="M"/> <!-- '  base=ù -->
+		<map iso="C12" to="Ç"/> <!-- (key to right of ')  base=* -->
+		<map iso="B00" to="Ê"/> <!-- (key to left of Z)  base=< -->
+		<map iso="B01" to="À"/> <!-- Z -->
+		<map iso="B02" to="Y"/>
+		<map iso="B03" to="X"/>
+		<map iso="B04" to=":"/>
+		<map iso="B05" to="K"/>
+		<map iso="B06" to="?"/>
+		<map iso="B07" to="Q"/> <!-- M  base=, -->
+		<map iso="B08" to="G"/> <!-- ,  base=; -->
+		<map iso="B09" to="H"/> <!-- .  base=: -->
+		<map iso="B10" to="F"/> <!-- /  base=! -->
+		<map iso="A03" to=" "/> <!-- space -->
+	</keyMap>
+	<keyMap modifiers="caps">
+		<map iso="E00" to="#"/> <!-- ` -->
+		<map iso="E01" to="1"/> <!--   base=& -->
+		<map iso="E02" to="2"/> <!--   base=é -->
+		<map iso="E03" to="3"/> <!--   base=" -->
+		<map iso="E04" to="4"/> <!--   base=' -->
+		<map iso="E05" to="5"/> <!--   base=( -->
+		<map iso="E06" to="6"/> <!--   base=- -->
+		<map iso="E07" to="7"/> <!--   base=è -->
+		<map iso="E08" to="8"/> <!--   base=_ -->
+		<map iso="E09" to="9"/> <!--   base=ç -->
+		<map iso="E10" to="0"/> <!--   base=à -->
+		<map iso="E11" to="="/> <!-- -  base=) -->
+		<map iso="E12" to="%"/> <!-- = -->
+		<map iso="D01" to="B"/> <!-- Q -->
+		<map iso="D02" to="É"/> <!-- W -->
+		<map iso="D03" to="P"/>
+		<map iso="D04" to="O"/>
+		<map iso="D05" to="È"/>
+		<map iso="D06" to="!"/>
+		<map iso="D07" to="V"/>
+		<map iso="D08" to="D"/>
+		<map iso="D09" to="L"/>
+		<map iso="D10" to="J"/>
+		<map iso="D11" to="Z"/> <!-- [  base=^ -->
+		<map iso="D12" to="W"/> <!-- ]  base=$ -->
+		<map iso="C01" to="A"/> <!-- A -->
+		<map iso="C02" to="U"/>
+		<map iso="C03" to="I"/>
+		<map iso="C04" to="E"/>
+		<map iso="C05" to=";"/>
+		<map iso="C06" to="C"/>
+		<map iso="C07" to="T"/>
+		<map iso="C08" to="S"/>
+		<map iso="C09" to="R"/>
+		<map iso="C10" to="N"/> <!-- ; -->
+		<map iso="C11" to="M"/> <!-- '  base=ù -->
+		<map iso="C12" to="Ç"/> <!-- (key to right of ')  base=* -->
+		<map iso="B00" to="Ê"/> <!-- (key to left of Z) -->
+		<map iso="B01" to="À"/> <!-- Z -->
+		<map iso="B02" to="Y"/>
+		<map iso="B03" to="X"/>
+		<map iso="B04" to=":"/>
+		<map iso="B05" to="K"/>
+		<map iso="B06" to="?"/>
+		<map iso="B07" to="Q"/> <!-- M  base=, -->
+		<map iso="B08" to="G"/> <!-- ,  base=; -->
+		<map iso="B09" to="H"/> <!-- .  base=: -->
+		<map iso="B10" to="F"/> <!-- /  base=! -->
+		<map iso="A03" to=" "/> <!-- space -->
+	</keyMap>
+	<keyMap modifiers="caps+shift">
+		<map iso="E01" to="\u{22}"/> <!-- 1 -->
+		<map iso="E02" to="«"/> <!-- 2 -->
+		<map iso="E03" to="»"/> <!-- 3  to= »  -->
+		<map iso="E04" to="("/> <!-- 4 -->
+		<map iso="E05" to=")"/> <!-- 5 -->
+		<map iso="E06" to="@"/> <!-- 6 -->
+		<map iso="E07" to="+"/> <!-- 7 -->
+		<map iso="E08" to="-"/> <!-- 8 -->
+    <map iso="E09" to="/"/> <!-- 9 -->
+    <map iso="E10" to="*"/> <!-- 0 -->
+		<map iso="E11" to="°"/> <!-- - -->
+		<map iso="E12" to="`"/>
+		<map iso="D01" to="a"/> <!-- Q -->
+		<map iso="D02" to="u"/> <!-- W -->
+		<map iso="D03" to="i"/>
+		<map iso="D04" to="e"/>
+		<map iso="D05" to=";"/>
+		<map iso="D06" to="c"/>
+		<map iso="D07" to="t"/>
+		<map iso="D08" to="s"/>
+		<map iso="D09" to="r"/>
+		<map iso="D10" to="n"/>
+		<map iso="D11" to="m"/> <!-- [ -->
+		<map iso="D12" to="ç"/> <!-- ] -->
+		<map iso="C01" to="a"/> <!-- A -->
+		<map iso="C02" to="u"/>
+		<map iso="C03" to="i"/>
+		<map iso="C04" to="e"/>
+		<map iso="C05" to=";"/>
+		<map iso="C06" to="c"/>
+		<map iso="C07" to="t"/>
+		<map iso="C08" to="s"/>
+		<map iso="C09" to="r"/>
+		<map iso="C10" to="n"/> <!-- ; -->
+		<map iso="C11" to="m"/> <!-- ' -->
+		<map iso="C12" to="ç"/> <!-- (key to right of ') -->
+		<map iso="B00" to="ê"/> <!-- (key to left of Z)  base=< -->
+		<map iso="B01" to="à"/> <!-- Z -->
+		<map iso="B02" to="y"/>
+		<map iso="B03" to="x"/>
+		<map iso="B04" to=":"/>
+		<map iso="B05" to="k"/>
+		<map iso="B06" to="?"/>
+		<map iso="B07" to="q"/> <!-- M -->
+		<map iso="B08" to="g"/> <!-- , -->
+		<map iso="B09" to="h"/> <!-- . -->
+		<map iso="B10" to="f"/> <!-- / -->
+		<map iso="A03" to=" "/> <!-- space -->
+	</keyMap>
+	<keyMap modifiers="altR+caps? ctrl+alt+caps?">
+		<map iso="E00" to="–"/> <!-- 2  base=é -->
+    <map iso="E02" to="—"/> <!-- 2  base=é -->
+    <map iso="E02" to="<"/> <!-- 2  base=é -->
+		<map iso="E03" to=">"/> <!-- 3  base=" -->
+		<map iso="E04" to="["/> <!-- 4  base=' -->
+		<map iso="E05" to="]"/> <!-- 5  base=( -->
+		<map iso="E06" to="^"/> <!-- 6  base=- -->
+		<map iso="E07" to="±"/> <!-- 7  base=è -->
+		<map iso="E08" to="−"/> <!-- 8  base=_ -->
+		<map iso="E09" to="÷" transform="no"/> <!-- 9  base=ç -->
+		<map iso="E10" to="×"/> <!-- 0  base=à -->
+		<map iso="E11" to="≠"/> <!-- -  base=) -->
+		<map iso="E12" to="‰"/> <!-- = -->
+		<map iso="D01" to="|"/> <!-- Q -->
+		<map iso="D03" to="&amp;"/>
+		<map iso="D04" to="œ"/>
+		<map iso="D06" to="¡"/>
+		<map iso="C01" to="æ"/> <!-- A -->
+		<map iso="C02" to="ù"/>
+		<map iso="C04" to="€"/>
+		<map iso="C05" to="'"/>
+		<map iso="B00" to="/"/> <!-- (key to left of Z) -->
+		<map iso="B01" to="\"/> <!-- Z -->
+		<map iso="B02" to="{"/>
+		<map iso="B03" to="}"/>
+		<map iso="B04" to="…"/>
+		<map iso="B05" to="~"/>
+		<map iso="B06" to="¿"/>
+		<map iso="B08" to="µ"/> <!-- , -->
+		<map iso="A03" to="_"/> <!-- space -->
+	</keyMap>
+	<keyMap modifiers="ctrl+caps?">
+		<map iso="A03" to=" "/> <!-- space -->
+	</keyMap>
+	<transforms type="simple">
+		<transform from="` " to="`"/>
+		<transform from="`a" to="à"/>
+		<transform from="`A" to="À"/>
+		<transform from="`e" to="è"/>
+		<transform from="`E" to="È"/>
+		<transform from="`i" to="ì"/>
+		<transform from="`I" to="Ì"/>
+		<transform from="`o" to="ò"/>
+		<transform from="`O" to="Ò"/>
+		<transform from="`u" to="ù"/>
+		<transform from="`U" to="Ù"/>
+		<transform from="^ " to="^"/>
+		<transform from="^a" to="â"/>
+		<transform from="^A" to="Â"/>
+		<transform from="^e" to="ê"/>
+		<transform from="^E" to="Ê"/>
+		<transform from="^i" to="î"/>
+		<transform from="^I" to="Î"/>
+		<transform from="^o" to="ô"/>
+		<transform from="^O" to="Ô"/>
+		<transform from="^u" to="û"/>
+		<transform from="^U" to="Û"/>
+		<transform from="¨ " to="¨"/>
+		<transform from="¨a" to="ä"/>
+		<transform from="¨A" to="Ä"/>
+		<transform from="¨e" to="ë"/>
+		<transform from="¨E" to="Ë"/>
+		<transform from="¨i" to="ï"/>
+		<transform from="¨I" to="Ï"/>
+		<transform from="¨o" to="ö"/>
+		<transform from="¨O" to="Ö"/>
+		<transform from="¨u" to="ü"/>
+		<transform from="¨U" to="Ü"/>
+		<transform from="¨y" to="ÿ"/>
+		<transform from="~ " to="~"/>
+		<transform from="~a" to="ã"/>
+		<transform from="~A" to="Ã"/>
+		<transform from="~n" to="ñ"/>
+		<transform from="~N" to="Ñ"/>
+		<transform from="~o" to="õ"/>
+		<transform from="~O" to="Õ"/>
+	</transforms>
+</keyboard>


### PR DESCRIPTION
This PR offers a solution to https://github.com/keyboardio/Chrysalis/issues/1069. See my comment [here](https://github.com/keyboardio/Chrysalis/issues/1069#issuecomment-1659769672). The idea is to add the bépo layout among the selectable layouts in the Layout editor section of the User Interface preferences:
![image](https://github.com/keyboardio/chrysalis/assets/1062625/b80f9fe1-e9a5-4678-b242-37cde46de6d4)
As said in my comment the result is not perfect (so don’t hesitate to make suggestions) but it is a dramatic improvement for bépo users:
![image](https://github.com/keyboardio/chrysalis/assets/1062625/04a6d76d-ec4a-4816-a8f9-a2c71e948e3a)
I only have a Fedora machine so I couldn’t test this on anything, so don’t hesitate to make more tests. 