### PR TITLE
TopsyTurvy cannot be combined with other mods

### DIFF
--- a/src/api/focus/keymap/db/modifiers.js
+++ b/src/api/focus/keymap/db/modifiers.js
@@ -67,7 +67,7 @@ const setModifiersLabel = (key, mods) => {
 };
 
 const generateModifierCombinations = () => {
-  const modKeys = ["ctrl", "alt", "altgr", "shift", "gui", "topsyturvy"];
+  const modKeys = ["ctrl", "alt", "altgr", "shift", "gui"];
   const combinations = [];
 
   // Nested loops to generate all combinations
@@ -84,18 +84,18 @@ const generateModifierCombinations = () => {
           combinations.push(createModCombination([modKeys[i], modKeys[j], modKeys[k], modKeys[l]]));
 
           for (let m = l + 1; m < modKeys.length; m++) {
-            combinations.push(createModCombination([modKeys[i], modKeys[j], modKeys[k], modKeys[l], modKeys[m]]));
-
-            for (let n = m + 1; n < modKeys.length; n++) {
-              combinations.push(
-                createModCombination([modKeys[i], modKeys[j], modKeys[k], modKeys[l], modKeys[m], modKeys[n]]),
-              );
-            }
+            combinations.push(
+              createModCombination([modKeys[i], modKeys[j], modKeys[k], modKeys[l], modKeys[m]]),
+            );
           }
         }
       }
     }
   }
+
+  // TT can't be combined with other mods because its
+  // keycode range would collide with DynamicMacros or other keys.
+  combinations.push(createModCombination(["topsyturvy"]));
 
   return combinations;
 };

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -192,7 +192,7 @@
         },
         "topsyturvy": {
           "label": "Invert Shift",
-          "tooltip": "Invert the behavior of the Shift key. (For example, send 'A' when unshifted and 'a' when shifted)"
+          "tooltip": "Invert the behavior of the Shift key. (For example, send 'A' when unshifted and 'a' when shifted). This cannot be combined with other modifiers."
         }
       },
       "layer": {

--- a/src/renderer/screens/Editor/Sidebar/Modifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/Modifiers.js
@@ -72,7 +72,7 @@ const Modifiers = (props) => {
           key.baseCode == modifier.code ||
           key.code == modifier.code ||
           db.isInCategory(key.code, "dualuse") ||
-          (db.isInCategory(key.code, "topsyturvy") && mod == "shift")
+          db.isInCategory(key.code, "topsyturvy")
         }
       />
     );

--- a/src/renderer/screens/Editor/Sidebar/SpecialModifiers.js
+++ b/src/renderer/screens/Editor/Sidebar/SpecialModifiers.js
@@ -44,11 +44,9 @@ export const SpecialModifiers = (props) => {
   const { currentKey: key } = props;
 
   const isDualUse = db.isInCategory(key.code, "dualuse");
-  const isShifted = db.isInCategory(key.code, "shift");
-  const isTopsyTurvy = db.isInCategory(key.code, "topsyturvy");
-  const isMod = (key, mod) => key.baseCode == mod || key.code == mod;
+  const regularMods = ["ctrl", "alt", "altgr", "shift", "gui"];
+  const isModified = regularMods.some((mod) => db.isInCategory(key.code, mod));
   const isModifier = db.isInCategory(key.baseCode || key.code, "modifier");
-  const c = db.constants.codes;
   const topsyTurvyAvailable = usePluginAvailable("TopsyTurvy");
 
   return (
@@ -63,7 +61,7 @@ export const SpecialModifiers = (props) => {
             <FormControlLabel
               control={makeSwitch("topsyturvy")}
               label={t("editor.sidebar.keypicker.topsyturvy.label")}
-              disabled={!topsyTurvyAvailable || isMod(key, c.LEFT_SHIFT) || isShifted || isDualUse}
+              disabled={!topsyTurvyAvailable || isModifier || isModified || isDualUse}
             />
           </Tooltip>
         </FormControl>


### PR DESCRIPTION
This PR prevents a collision with DynamicMacros key range.  For example, DM#0 has keycode 53596.  Without this PR, this displays as "C+Ƨ+{" and the macro can't be edited.

This PR:
1. Prevents generating modifier combinations that include `topsyturvy` with other mods.  This avoids the display issue where DynamicMacros \#0-9 decoded to TopsyTurvy+Control.
2. In the Modifiers tab, disables the TopsyTurvy radio button when any other mod is selected, and vice versa.  This prevents the user creating invalid combinations.

This is a quick follow-up to PR #1379, addressing issue #1378.